### PR TITLE
installs python deps on ctfd start

### DIFF
--- a/conf/ctfd/start.sh
+++ b/conf/ctfd/start.sh
@@ -10,10 +10,10 @@ SECRET_KEY=${SECRET_KEY:-}
 SKIP_DB_PING=${SKIP_DB_PING:-false}
 
 ## Install plugins deps on load
-for d in CTFd/plugins/*; do \
-    if [ -f "$d/requirements.txt" ]; then \
+for d in CTFd/plugins/*; do
+    if [ -f "$d/requirements.txt" ]; then
         pip install --no-cache-dir -r "$d/requirements.txt";\
-    fi; \
+    fi;
 done;
 
 # Check that a .ctfd_secret_key file or SECRET_KEY envvar is set


### PR DESCRIPTION
The virtual env in install.sh is only accessible from the host. The container in compose needs to install the deps on container start or else our plugin will not load because it cannot access the deps.