### PR TITLE
version tag generation and fix to when build action excutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,13 @@ on:
       - development
       - staging
       - production
+    types: [closed]
 
 jobs:
   build-and-deploy:
     name: Build and Deploy Vite App
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,14 +1,14 @@
 name: semver
 on:
   pull_request:
-    # types: [closed]
+    types: [closed]
     branches:
-      # - staging
+      - staging
 
 jobs:
   tag:
     runs-on: ubuntu-latest
-    # if: github.event.pull_request.merged
+    if: github.event.pull_request.merged
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -27,8 +27,12 @@ jobs:
         run: |
           git config --global user.email "zcoughlan@cyberskyline.com"
           git config --global user.name "Zoe Coughlan"
-          git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
-          git push origin "${{ steps.tag.outputs.version_tag }}"
+          if git rev-parse "${{ steps.tag.outputs.version_tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.tag.outputs.version_tag }} already exists. Skipping."
+          else
+            git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
+            git push origin "${{ steps.tag.outputs.version_tag }}"
+          fi
       - name: View PR author
         run: echo "This PR is opened by ${{ github.event.pull_request.assignee.name }} with email ${{ github.event.pull_request.assignee.email }}."
 

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -27,14 +27,10 @@ jobs:
         run: |
           git config --global user.email "zcoughlan@cyberskyline.com"
           git config --global user.name "Zoe Coughlan"
-          if git rev-parse "${{ steps.tag.outputs.version_tag }}" >/dev/null 2>&1; then
-            echo "Tag ${{ steps.tag.outputs.version_tag }} already exists. Skipping."
-          else
-            git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
-            git push origin "${{ steps.tag.outputs.version_tag }}"
-          fi
+          git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
+          git push origin "${{ steps.tag.outputs.version_tag }}"
       - name: View PR author
-        run: echo "This PR is opened by ${{ github.event.pull_request.user.name }} with email ${{ github.event.pull_request.user.email }}."
+        run: echo "This PR is opened by ${{ github.event.pull_request.assignee.name }} with email ${{ github.event.pull_request.assignee.email }}."
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -30,7 +30,7 @@ jobs:
           git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
           git push origin "${{ steps.tag.outputs.version_tag }}"
       - name: View PR author
-        run: echo "This PR is opened by ${{ github.event.pull_request.user.login }} with email ${{ github.event.pull_request.user.email }}."
+        run: echo "This PR is opened by ${{ github.event.pull_request.user.name }} with email ${{ github.event.pull_request.user.email }}."
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,14 +1,14 @@
 name: semver
 on:
   pull_request:
-    types: [closed]
+    # types: [closed]
     branches:
-      - staging
+      # - staging
 
 jobs:
   tag:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged
+    # if: github.event.pull_request.merged
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -29,6 +29,8 @@ jobs:
           git config --global user.name "Zoe Coughlan"
           git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
           git push origin "${{ steps.tag.outputs.version_tag }}"
+      - name: View PR author
+        run: echo "This PR is opened by ${{ github.event.pull_request.user.login }} with email ${{ github.event.pull_request.user.email }}."
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -27,8 +27,12 @@ jobs:
         run: |
           git config --global user.email "zcoughlan@cyberskyline.com"
           git config --global user.name "Zoe Coughlan"
-          git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
-          git push origin "${{ steps.tag.outputs.version_tag }}"
+          if git rev-parse "${{ steps.tag.outputs.version_tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.tag.outputs.version_tag }} already exists. Skipping."
+          else
+            git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
+            git push origin "${{ steps.tag.outputs.version_tag }}"
+          fi
       - name: View PR author
         run: echo "This PR is opened by ${{ github.event.pull_request.user.name }} with email ${{ github.event.pull_request.user.email }}."
 

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -2,18 +2,33 @@ name: semver
 on:
   pull_request:
     types: [closed]
+    branches:
+      - staging
 
 jobs:
-  build:
+  tag:
     runs-on: ubuntu-latest
-
     if: github.event.pull_request.merged
-
     steps:
-      - name: Tag
-        uses: K-Phoen/semver-release-action@master
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
-          release_branch: development
-          release_strategy: tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Tag
+        id: tag
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          bump_each_commit: true
+          bump_each_commit_patch_pattern: "(PATCH)"
+
+      - name: Create tag
+        run: |
+          git config --global user.email "zcoughlan@cyberskyline.com"
+          git config --global user.name "Zoe Coughlan"
+          git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
+          git push origin "${{ steps.tag.outputs.version_tag }}"
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -33,8 +33,6 @@ jobs:
             git tag -a "${{ steps.tag.outputs.version_tag }}" -m "version ${{ steps.tag.outputs.version_tag }}"
             git push origin "${{ steps.tag.outputs.version_tag }}"
           fi
-      - name: View PR author
-        run: echo "This PR is opened by ${{ github.event.pull_request.assignee.name }} with email ${{ github.event.pull_request.assignee.email }}."
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
switched to this for tag versioning
https://github.com/marketplace/actions/git-semantic-version
it uses commit history and commit messages labeled with `(PATCH)`, `(MINOR)`, and `(MAJOR)` (doesn't look in description, just message/title. i can change this if we need to)

will update documentation to reflect this to ensure it gets used. since it only executes on successful merge from PR, devs would still need to do a PR with an empty commit to sync the version number if they forget to increment it, but it makes it easy to make sure different changes on the same branch get counted together i.e. two different things happening simultaneously on the dev branch

maintains keeping track of progress because it looks thru history (thats why it does a checkout action)

Currently signing the tags as myself since I wasn't sure who else to sign them as and the runner needed some author info. I can obviously change this as needed