### PR TITLE
Add radix-based markdown component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,10 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
+    "react-markdown": "^10.1.0",
     "react-router": "^7.6.3",
+    "remark-breaks": "^4.0.0",
+    "remark-gfm": "^4.0.1",
     "swr": "^2.3.3"
   },
   "devDependencies": {

--- a/frontend/src/components/RadixMarkdown.tsx
+++ b/frontend/src/components/RadixMarkdown.tsx
@@ -1,0 +1,68 @@
+import ReactMarkdown, { type Components } from 'react-markdown';
+import {
+  Text, Heading, Link, Table, Code, Em, Strong, Blockquote,
+} from '@radix-ui/themes';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+
+/**
+ * Mapping of html elements to their themed Radix UI counterparts to use when rendering markdown.
+ */
+const Components: Components = {
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  p : ({ children }) => <Text as="p" color="gray" mb="2">{children}</Text>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  em : ({ children }) => <Em>{children}</Em>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  strong : ({ children }) => <Strong>{children}</Strong>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  code : ({ children }) => <Code color="lime">{children}</Code>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  blockquote : ({ children }) => <Blockquote>{children}</Blockquote>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  a : ({ href, children }) => <Link href={href} color="lime" target="_blank" rel="noopener noreferrer">{children}</Link>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  h1 : ({ children }) => <Heading size="6" as="h1">{children}</Heading>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  h2 : ({ children }) => <Heading size="5" as="h2">{children}</Heading>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  h3 : ({ children }) => <Heading size="4" as="h3">{children}</Heading>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  h4 : ({ children }) => <Heading size="3" as="h4">{children}</Heading>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  h5 : ({ children }) => <Heading size="2" as="h5">{children}</Heading>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  h6 : ({ children }) => <Heading size="1" as="h6">{children}</Heading>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  ul : ({ children }) => <ul className="list-disc list-inside mb-2">{children}</ul>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  ol : ({ children }) => <ol className="list-decimal list-inside mb-2">{children}</ol>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  li : ({ children }) => <Text asChild color="gray" mb="1"><li>{children}</li></Text>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  table : ({ children }) => <Table.Root className="w-fit max-w-full mb-2">{children}</Table.Root>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  thead : ({ children }) => <Table.Header>{children}</Table.Header>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  tbody : ({ children }) => <Table.Body>{children}</Table.Body>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  tr : ({ children }) => <Table.Row>{children}</Table.Row>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  th : ({ children }) => <Table.ColumnHeaderCell>{children}</Table.ColumnHeaderCell>,
+  // @ts-expect-error - ReactMarkdown types broken under React 19
+  td : ({ children }) => <Table.Cell>{children}</Table.Cell>,
+};
+
+/**
+ * Renders the given string as markdown using Radix UI components.
+ */
+export default function RadixMarkdown({ children }: {
+  children: string;
+}) {
+  return (
+    /* @ts-expect-error - ReactMarkdown types broken under React 19 */
+    <ReactMarkdown components={Components} remarkPlugins={[ remarkGfm, remarkBreaks ]}>
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,45 +27,45 @@ __metadata:
   linkType: hard
 
 "@babel/compat-data@npm:^7.27.2":
-  version: 7.27.7
-  resolution: "@babel/compat-data@npm:7.27.7"
-  checksum: 10/e71bf453a478875e8eb11bee84229f17185eb05ccf109e6c81eea3b931eaab531f7eb8fdd45fb7dfbcba26e88de5bc3ea7f36cbd14c5f15231c2fec81503609d
+  version: 7.28.0
+  resolution: "@babel/compat-data@npm:7.28.0"
+  checksum: 10/1a56a5e48c7259f72cc4329adeca38e72fd650ea09de267ea4aa070e3da91e5c265313b6656823fff77d64a8bab9554f276c66dade9355fdc0d8604deea015aa
   languageName: node
   linkType: hard
 
 "@babel/core@npm:^7.27.4":
-  version: 7.27.7
-  resolution: "@babel/core@npm:7.27.7"
+  version: 7.28.0
+  resolution: "@babel/core@npm:7.28.0"
   dependencies:
     "@ampproject/remapping": "npm:^2.2.0"
     "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.27.5"
+    "@babel/generator": "npm:^7.28.0"
     "@babel/helper-compilation-targets": "npm:^7.27.2"
     "@babel/helper-module-transforms": "npm:^7.27.3"
     "@babel/helpers": "npm:^7.27.6"
-    "@babel/parser": "npm:^7.27.7"
+    "@babel/parser": "npm:^7.28.0"
     "@babel/template": "npm:^7.27.2"
-    "@babel/traverse": "npm:^7.27.7"
-    "@babel/types": "npm:^7.27.7"
+    "@babel/traverse": "npm:^7.28.0"
+    "@babel/types": "npm:^7.28.0"
     convert-source-map: "npm:^2.0.0"
     debug: "npm:^4.1.0"
     gensync: "npm:^1.0.0-beta.2"
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
-  checksum: 10/3503d575ebbf6e66d43d17bbf14c7f93466e8f44ba6f566722747ae887d6c3890ecf64447a3bae8e431ea96907180ac8618b5452d85d9951f571116122b7f66d
+  checksum: 10/1c86eec8d76053f7b1c5f65296d51d7b8ac00f80d169ff76d3cd2e7d85ab222eb100d40cc3314f41b96c8cc06e9abab21c63d246161f0f3f70ef14c958419c33
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.27.5":
-  version: 7.27.5
-  resolution: "@babel/generator@npm:7.27.5"
+"@babel/generator@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/generator@npm:7.28.0"
   dependencies:
-    "@babel/parser": "npm:^7.27.5"
-    "@babel/types": "npm:^7.27.3"
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
+    "@babel/parser": "npm:^7.28.0"
+    "@babel/types": "npm:^7.28.0"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
-  checksum: 10/f5e6942670cb32156b3ac2d75ce09b373558823387f15dd1413c27fe9eb5756a7c6011fc7f956c7acc53efb530bfb28afffa24364d46c4e9ffccc4e5c8b3b094
+  checksum: 10/064c5ba4c07ecd7600377bd0022d5f6bdb3b35e9ff78d9378f6bd1e656467ca902c091647222ab2f0d2967f6d6c0ca33157d37dd9b1c51926c9b0e1527ab9b92
   languageName: node
   linkType: hard
 
@@ -79,6 +79,13 @@ __metadata:
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
   checksum: 10/bd53c30a7477049db04b655d11f4c3500aea3bcbc2497cf02161de2ecf994fec7c098aabbcebe210ffabc2ecbdb1e3ffad23fb4d3f18723b814f423ea1749fe8
+  languageName: node
+  linkType: hard
+
+"@babel/helper-globals@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/helper-globals@npm:7.28.0"
+  checksum: 10/91445f7edfde9b65dcac47f4f858f68dc1661bf73332060ab67ad7cc7b313421099a2bfc4bda30c3db3842cfa1e86fffbb0d7b2c5205a177d91b22c8d7d9cb47
   languageName: node
   linkType: hard
 
@@ -143,14 +150,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.27.5, @babel/parser@npm:^7.27.7":
-  version: 7.27.7
-  resolution: "@babel/parser@npm:7.27.7"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.27.5, @babel/parser@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/parser@npm:7.28.0"
   dependencies:
-    "@babel/types": "npm:^7.27.7"
+    "@babel/types": "npm:^7.28.0"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10/ed25ccfc709e77b94afebfa8377cca2ee5d0750162a6b4e7eb7b679ccdf307d1a015dee58d94afe726ed6d278a83aa348cb3a47717222ac4c3650d077f6ca4fd
+  checksum: 10/2c14a0d2600bae9ab81924df0a85bbd34e427caa099c260743f7c6c12b2042e743e776043a0d1a2573229ae648f7e66a80cfb26fc27e2a9eb59b55932d44c817
   languageName: node
   linkType: hard
 
@@ -187,28 +194,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3, @babel/traverse@npm:^7.27.7":
-  version: 7.27.7
-  resolution: "@babel/traverse@npm:7.27.7"
+"@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3, @babel/traverse@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/traverse@npm:7.28.0"
   dependencies:
     "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.27.5"
-    "@babel/parser": "npm:^7.27.7"
+    "@babel/generator": "npm:^7.28.0"
+    "@babel/helper-globals": "npm:^7.28.0"
+    "@babel/parser": "npm:^7.28.0"
     "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.27.7"
+    "@babel/types": "npm:^7.28.0"
     debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10/10b83c362b5c2758dbbf308c3144fa0fdcc98c8f107c2b7637e2c3c975f8b4e77a18e4b5854200f5ca3749ec3bcabd57bb9831ae8455f0701cabc6366983f379
+  checksum: 10/c1c24b12b6cb46241ec5d11ddbd2989d6955c282715cbd8ee91a09fe156b3bdb0b88353ac33329c2992113e3dfb5198f616c834f8805bb3fa85da1f864bec5f3
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.27.6, @babel/types@npm:^7.27.7":
-  version: 7.27.7
-  resolution: "@babel/types@npm:7.27.7"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.6, @babel/types@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/types@npm:7.28.0"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
-  checksum: 10/39e9f05527ef0771dfb6220213a9ef2ca35c2b6d531e3310c8ffafb53aa50362e809f75af8feb28bd6abb874a00c02b05ac00e3063ee239db5c6f1653eab19c5
+  checksum: 10/2f28b84efb5005d1e85fc3944219c284400c42aeefc1f6e10500a74fed43b3dfb4f9e349a5d6e0e3fc24f5d241c513b30ef00ede2885535ce7a0a4e111c2098e
   languageName: node
   linkType: hard
 
@@ -939,13 +946,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.5":
-  version: 0.3.10
-  resolution: "@jridgewell/gen-mapping@npm:0.3.10"
+"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.5":
+  version: 0.3.12
+  resolution: "@jridgewell/gen-mapping@npm:0.3.12"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.0"
     "@jridgewell/trace-mapping": "npm:^0.3.24"
-  checksum: 10/f64728f0c4056f4c78e7e9b93dcef0e2e1782ef857728a9512abe62fd321d3d219125f015a6da6082412ab30526a6e117144c69fd7643127e5e27e657940e6b8
+  checksum: 10/151667531566417a940d4dd0a319724979f7a90b9deb9f1617344e1183887d78c835bc1a9209c1ee10fc8a669cdd7ac8120a43a2b6bc8d0d5dd18a173059ff4b
   languageName: node
   linkType: hard
 
@@ -957,19 +964,19 @@ __metadata:
   linkType: hard
 
 "@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0":
-  version: 1.5.2
-  resolution: "@jridgewell/sourcemap-codec@npm:1.5.2"
-  checksum: 10/13e77f2011e3b931079501b17a859ed932888175f1b48f19d9062506bb9b5bd306e5396d43113538b1132d421688ff41f45f0707523a15f54f2ffaa8f9dbc4b2
+  version: 1.5.4
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.4"
+  checksum: 10/f677787f52224c6c971a7a41b7a074243240a6917fa75eceb9f7a442866f374fb0522b505e0496ee10a650c5936727e76d11bf36a6d0ae9e6c3b726c9e284cc7
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
-  version: 0.3.27
-  resolution: "@jridgewell/trace-mapping@npm:0.3.27"
+"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.28":
+  version: 0.3.29
+  resolution: "@jridgewell/trace-mapping@npm:0.3.29"
   dependencies:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 10/5eb38fe4b395b695fdd9bb751915dd299fcd96740063362573cb0188e69c3de1ff38bb5b6629995c8d65acb9fd2b1bf2e47285a60aea8d6bc354aef5328d6550
+  checksum: 10/64e1ce0dc3a9e56b0118eaf1b2f50746fd59a36de37516cc6855b5370d5f367aa8229e1237536d738262e252c70ee229619cb04e3f3b822146ee3eb1b7ab297f
   languageName: node
   linkType: hard
 
@@ -1158,20 +1165,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@milkdown/components@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/components@npm:7.15.0"
+"@milkdown/components@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/components@npm:7.15.1"
   dependencies:
     "@floating-ui/dom": "npm:^1.5.1"
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/plugin-tooltip": "npm:7.15.0"
-    "@milkdown/preset-commonmark": "npm:7.15.0"
-    "@milkdown/preset-gfm": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/transformer": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/plugin-tooltip": "npm:7.15.1"
+    "@milkdown/preset-commonmark": "npm:7.15.1"
+    "@milkdown/preset-gfm": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/transformer": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     "@types/lodash.debounce": "npm:^4.0.7"
     "@types/lodash.throttle": "npm:^4.1.9"
     clsx: "npm:^2.0.0"
@@ -1186,29 +1193,29 @@ __metadata:
     "@codemirror/language": ^6
     "@codemirror/state": ^6
     "@codemirror/view": ^6
-  checksum: 10/3f34764630b44f09d159f8dcc0dd1f555e1087531d5d665d21d4a5c495c816d9235329c7ae7d42698c29958fc594864461d543185c4f37b5cfae38a465c985c3
+  checksum: 10/1643de26fdca03005307c580dcb0230eeb489236f57da002ff2e937151e3f02f4c5b8c97a48a2e17b384cf690d40015227c3499b1867de347f50d8dc667f6bce
   languageName: node
   linkType: hard
 
-"@milkdown/core@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/core@npm:7.15.0"
+"@milkdown/core@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/core@npm:7.15.1"
   dependencies:
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/transformer": "npm:7.15.0"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/transformer": "npm:7.15.1"
     remark-parse: "npm:^11.0.0"
     remark-stringify: "npm:^11.0.0"
     tslib: "npm:^2.8.1"
     unified: "npm:^11.0.3"
-  checksum: 10/81d68328fec790be04caa4d681746110da3a4de28b3efe94742e988168fadbb507884c4736aacf48b9455d8e52ac7b9b1b37bafae288112fd17f10e3e0d5e570
+  checksum: 10/33d135e0416541c49660ff0bbafb0ec5b88f2c294fee9c9980a0795af7852aafac0fb5e6ee879f580072ebb933d0dd4b70a1578d1396af507a58530e968aabd7
   languageName: node
   linkType: hard
 
-"@milkdown/crepe@npm:7.15.0, @milkdown/crepe@npm:^7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/crepe@npm:7.15.0"
+"@milkdown/crepe@npm:7.15.1, @milkdown/crepe@npm:^7.15.0":
+  version: 7.15.1
+  resolution: "@milkdown/crepe@npm:7.15.1"
   dependencies:
     "@codemirror/commands": "npm:^6.2.4"
     "@codemirror/language": "npm:^6.10.1"
@@ -1217,7 +1224,7 @@ __metadata:
     "@codemirror/theme-one-dark": "npm:^6.1.2"
     "@codemirror/view": "npm:^6.16.0"
     "@floating-ui/dom": "npm:^1.5.1"
-    "@milkdown/kit": "npm:7.15.0"
+    "@milkdown/kit": "npm:7.15.1"
     "@types/lodash-es": "npm:^4.17.12"
     clsx: "npm:^2.0.0"
     codemirror: "npm:^6.0.1"
@@ -1229,256 +1236,256 @@ __metadata:
     tslib: "npm:^2.8.1"
     unist-util-visit: "npm:^5.0.0"
     vue: "npm:^3.5.13"
-  checksum: 10/8f0f862baaa0032ecd66c429ef35286eb2ea7843c3a51c647d06bf3033359f80b0f57018834bc43ed567174d1c9fc55996a2c261a01679a0a8623342215c8fe7
+  checksum: 10/be866c22730403496665ba91be99cbebe2dfb45edcffef58e6f8e1bf497bae939de2606ac7dfcf62b433dc565c18b72b019275a857c41d11f3ee668b697246ea
   languageName: node
   linkType: hard
 
-"@milkdown/ctx@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/ctx@npm:7.15.0"
+"@milkdown/ctx@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/ctx@npm:7.15.1"
   dependencies:
-    "@milkdown/exception": "npm:7.15.0"
+    "@milkdown/exception": "npm:7.15.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/213072ac9260977b23c052ebb69159875b03d41003e34a28ced17c9e9bffbc9e37fc8dd7580c4b26e524577b308adeb6405e6765b7a7fa35fdf9efa54036043c
+  checksum: 10/d3e8e0429a8a0ba110c23fd91f107bf36215c9ea3baa0f3e9144e5e305a047f462b78e2920769c7e24df74d054d7f27f8ced7cbb0dd02ce26b6ca5baa11231e4
   languageName: node
   linkType: hard
 
-"@milkdown/exception@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/exception@npm:7.15.0"
+"@milkdown/exception@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/exception@npm:7.15.1"
   dependencies:
     tslib: "npm:^2.8.1"
-  checksum: 10/d60af16313a466d0022a337b3115c95b72d976e49b3f47ab235af49587580f9c3d323b69ca6a54158a7a61b7d039e878a80807d3caaf3655602d3878d1913924
+  checksum: 10/c1a2186e71dcfb40064c8feb99790490abbbc77c45927f68535bf4cdc2f11f4663af52b00ff66da48f477f32fe330455afb56594c72963b3246edbc1def4e342
   languageName: node
   linkType: hard
 
-"@milkdown/kit@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/kit@npm:7.15.0"
+"@milkdown/kit@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/kit@npm:7.15.1"
   dependencies:
-    "@milkdown/components": "npm:7.15.0"
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/plugin-block": "npm:7.15.0"
-    "@milkdown/plugin-clipboard": "npm:7.15.0"
-    "@milkdown/plugin-cursor": "npm:7.15.0"
-    "@milkdown/plugin-history": "npm:7.15.0"
-    "@milkdown/plugin-indent": "npm:7.15.0"
-    "@milkdown/plugin-listener": "npm:7.15.0"
-    "@milkdown/plugin-slash": "npm:7.15.0"
-    "@milkdown/plugin-tooltip": "npm:7.15.0"
-    "@milkdown/plugin-trailing": "npm:7.15.0"
-    "@milkdown/plugin-upload": "npm:7.15.0"
-    "@milkdown/preset-commonmark": "npm:7.15.0"
-    "@milkdown/preset-gfm": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/transformer": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/components": "npm:7.15.1"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/plugin-block": "npm:7.15.1"
+    "@milkdown/plugin-clipboard": "npm:7.15.1"
+    "@milkdown/plugin-cursor": "npm:7.15.1"
+    "@milkdown/plugin-history": "npm:7.15.1"
+    "@milkdown/plugin-indent": "npm:7.15.1"
+    "@milkdown/plugin-listener": "npm:7.15.1"
+    "@milkdown/plugin-slash": "npm:7.15.1"
+    "@milkdown/plugin-tooltip": "npm:7.15.1"
+    "@milkdown/plugin-trailing": "npm:7.15.1"
+    "@milkdown/plugin-upload": "npm:7.15.1"
+    "@milkdown/preset-commonmark": "npm:7.15.1"
+    "@milkdown/preset-gfm": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/transformer": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/b30083dd7ad3cada7c0ef528a76cc9d35374b496326a54cfd58118d77ad48eecaf957590386a37db07a6fbaf7c26aab257e25a99352cc26197abad300615572f
+  checksum: 10/46d45720beec14c18b3156b4252e6a4a0f67ce05a2eaaddddfbcfb19b95884284991cd9b6ced96329f49e55072bc8afb4c534887c0195ab690026fcfcbcd1deb
   languageName: node
   linkType: hard
 
 "@milkdown/plugin-automd@npm:^7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-automd@npm:7.15.0"
+  version: 7.15.1
+  resolution: "@milkdown/plugin-automd@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/38fd931618152dce3d547408601bf5c44d49aca330fda333451d386474d536531f84d8bcd0a011b9471ddedcc26041b2c8b8329b5287bc2b6cbae4a7e5f07e55
+  checksum: 10/73a180519e8043140d887ea74ea0b5810880559769440d782992de52b67b4a578623467bdfd681be6b6988f859198e5636253a44bed77ea38b0218d8e877b659
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-block@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-block@npm:7.15.0"
+"@milkdown/plugin-block@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-block@npm:7.15.1"
   dependencies:
     "@floating-ui/dom": "npm:^1.5.1"
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     "@types/lodash.throttle": "npm:^4.1.9"
     lodash.throttle: "npm:^4.1.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/c43558c1214bbf92b8755a15935ec420dc6a3d67792b792b1f5ead03ae054b8bfd074ca8e67d49635cd1529c29c145818554d7be2e864ec695a62ab91150735b
+  checksum: 10/668e9f349e06b50556b6993c4a232c9d79407a416506039cedf2cfd5169133d589e3740e1fc5077ae9d2c1576cf7a52c6375dac393f16cede35915a981676260
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-clipboard@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-clipboard@npm:7.15.0"
+"@milkdown/plugin-clipboard@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-clipboard@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/6a3b66745b9c0419c6deb2b48288c6e586567195116f17c5267abdbfc19931f40185be366145c24e196bf816537ba8f9cda9837b7764ce4e25c0f4dcfaf194fa
+  checksum: 10/d5f1337c5c9da7ef25fbc95edbe7ddbe074d78b52018bc05e0120cf748262853a90f769bfd74f8adfd8b5ba67169e5283003d7b8986053e7e5f5cbb627362d69
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-cursor@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-cursor@npm:7.15.0"
+"@milkdown/plugin-cursor@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-cursor@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/c04ccb0775a18a9bb7e45f9a01cd1971b6e32b32ed43aadc8d192964f91942507babf970d9282bcef0d56824d43a523ad30f05ada0ad897df1c1479094dcd0f5
+  checksum: 10/558bde821364c2a97c07424ee5abb8d66203bc6075cadf9bca83a57a696944fc64e649a54561d38a8a2384c70ff23ee3d8d18fedd090e65330f0081908edf229
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-history@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-history@npm:7.15.0"
+"@milkdown/plugin-history@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-history@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/c1527c3783499e1f7c21f591b48815663341f3d07eb5497cd451f444a9bc0bfb19ea8d29257b225a1c4aaa72d13f0d30f064cf441122b3a4c16c543f922e4e0d
+  checksum: 10/61038578e79f55b5a760bf30539fee01599ea87f74bf962e75f933a84d9f8e3a4766708975d3d3f88d2dea382f8cd9c2595957ff8aa42a613fe0a4186682b9e8
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-indent@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-indent@npm:7.15.0"
+"@milkdown/plugin-indent@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-indent@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/afd1f2fb019ba267dfb5b2fbafd008a6d480dabbdfd4b20b8b3809464d5fc0f3c0bfa789ba741dace4a347a7490397e5d7ea2679d62cd4f98b58928271fd2e6f
+  checksum: 10/36845cdd8a306d2c45e3d03f0b3dfeb7b4e51956f0247c596d93de4074e7505985309cada84c2a250160513b461a588494de4591d6679635db02928345802f58
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-listener@npm:7.15.0, @milkdown/plugin-listener@npm:^7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-listener@npm:7.15.0"
+"@milkdown/plugin-listener@npm:7.15.1, @milkdown/plugin-listener@npm:^7.15.0":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-listener@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     "@types/lodash.debounce": "npm:^4.0.7"
     lodash.debounce: "npm:^4.0.8"
     tslib: "npm:^2.8.1"
-  checksum: 10/cccf505ea6f196cb8056e86c4ef078cc32e9c60b6e01cb517b2269b4aec503d694fd44d0735c111b0609ba6d7d308a779f89dbeefd3bedb3539db4df4ba0b698
+  checksum: 10/af49eccbea7ed1da35411eedbe02409e068a40676c9e037329393132bcf379c217a8845802cb4384c62af16970d3e2a7985701d29f2323daf4d66841bb877f19
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-slash@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-slash@npm:7.15.0"
+"@milkdown/plugin-slash@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-slash@npm:7.15.1"
   dependencies:
     "@floating-ui/dom": "npm:^1.5.1"
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     "@types/lodash.debounce": "npm:^4.0.7"
     lodash.debounce: "npm:^4.0.8"
     tslib: "npm:^2.8.1"
-  checksum: 10/260be6736cf130e172f8b8c2ff23de0b8c9badcf5a2bef85871bd442faa5306d20d8bbbc49cd7c652d923f4ad7157fc775603ceb5ac58b1e2bee8baf6b05b80f
+  checksum: 10/58e0300cfd06b66f9c60f886f350dcad9ee9f74f395559f60fab301a4e5abda6ee12c6a5f9cd2b63e432e116787b32e2590f3313b98b25fe3b6ac8b951dcd5c4
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-tooltip@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-tooltip@npm:7.15.0"
+"@milkdown/plugin-tooltip@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-tooltip@npm:7.15.1"
   dependencies:
     "@floating-ui/dom": "npm:^1.5.1"
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     "@types/lodash.throttle": "npm:^4.1.9"
     lodash.throttle: "npm:^4.1.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/22f802f47826d8b74e2230129c3552ba320117beab175d981c3621bd15daecac62760bd32f2c7072c25e3abaaddf0b3f846e979ac3255730ad2758042c932da1
+  checksum: 10/b1f525c1d6eb946594e8519a8d883273a693b5e8e4e85bd2fa4c8ac56c46e7ddef06b812d9f329b2e74d187999c76ee75eee29d541956a701fef28dea163de0e
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-trailing@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-trailing@npm:7.15.0"
+"@milkdown/plugin-trailing@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-trailing@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/c97f96f77baebc8316c2f813f050ad91bc19eb4a6f9f898066ce761bf6e8ddf53bfd652f57575cc0a0b04e190bdb5791e5a37cb78945337c485c5e24c8146114
+  checksum: 10/224fb053c61cf6dd49e6d3ded24653667ce28929600b263bfc40dc66c23d87ed05d40685fa8af9a60a3a994051516566a4ecb5872f9c7a211850f01899f74ec5
   languageName: node
   linkType: hard
 
-"@milkdown/plugin-upload@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/plugin-upload@npm:7.15.0"
+"@milkdown/plugin-upload@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/plugin-upload@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/092d63db8f0b1d1b161991a91057b0d6b807cc194a1a31c7293da52e6277a1125ca79565d91c8518fbcd8755dc23c471e706574da23606802bd3ebd1eedee703
+  checksum: 10/08825fed7cc41d0b0df64402b1a1b35ce9116f9c90204c7e2dda4f3cd3c224e306686feb4fb9d2646f7318f7e779712c04be01d8d28c5c4a8564413d150e0020
   languageName: node
   linkType: hard
 
-"@milkdown/preset-commonmark@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/preset-commonmark@npm:7.15.0"
+"@milkdown/preset-commonmark@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/preset-commonmark@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/transformer": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/transformer": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     remark-inline-links: "npm:^7.0.0"
     tslib: "npm:^2.8.1"
     unist-util-visit: "npm:^5.0.0"
     unist-util-visit-parents: "npm:^6.0.1"
-  checksum: 10/c386d4d8d4eb7e7f956c08fb11dec81cdf9c4dfcd597e3809e49a0944be2157e1669a6f588f783fd1b23365f614dc70f442f18bb7ad6701f6d1b137ea8bc6f12
+  checksum: 10/bcce02c1581923128944daa1682e16934e702bc3743b85a750a976828ab751ec5733e8caf1a2df06b0c64a1144b20762432a3df422bc2a3e5c6187bb32a9f8f3
   languageName: node
   linkType: hard
 
-"@milkdown/preset-gfm@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/preset-gfm@npm:7.15.0"
+"@milkdown/preset-gfm@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/preset-gfm@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/preset-commonmark": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/transformer": "npm:7.15.0"
-    "@milkdown/utils": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/preset-commonmark": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/transformer": "npm:7.15.1"
+    "@milkdown/utils": "npm:7.15.1"
     prosemirror-safari-ime-span: "npm:^1.0.1"
     remark-gfm: "npm:^4.0.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/212ff348dc8e6e47ab53d8eed4ba99f29596d1d8e390849cf99bf07ba45aa424d444590bc2e8701ad44342cdddd32b37106948b31a9dbc4c59974d4ceee25d34
+  checksum: 10/efed64176de2b71a9f431739a6664d33bdbfe8cbd3277f3baa76c990c7a7d039be0b27056d350fe0f662addf9aae003c4676dddbe9bea62204236f4e80664aa3
   languageName: node
   linkType: hard
 
-"@milkdown/prose@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/prose@npm:7.15.0"
+"@milkdown/prose@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/prose@npm:7.15.1"
   dependencies:
-    "@milkdown/exception": "npm:7.15.0"
+    "@milkdown/exception": "npm:7.15.1"
     prosemirror-changeset: "npm:^2.2.1"
     prosemirror-commands: "npm:^1.6.2"
     prosemirror-dropcursor: "npm:^1.8.1"
@@ -1493,64 +1500,64 @@ __metadata:
     prosemirror-transform: "npm:^1.10.2"
     prosemirror-view: "npm:^1.37.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/f9a82c5b35b2c2f334fc9fc5316036fee25ee2727d63246407c1134d8a9c6789bccc9517439fa4cc5260c6ffc23e7c7df061f908f878bff59bf368476027a952
+  checksum: 10/309712017386edce1d605c0831b158e3a9afe3fed4089c385fc1e4d5d7a16668419a52fb21a75ad3dedd987bad650c101e9160ebb20c7afd2c865e09b5d76c34
   languageName: node
   linkType: hard
 
 "@milkdown/react@npm:^7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/react@npm:7.15.0"
+  version: 7.15.1
+  resolution: "@milkdown/react@npm:7.15.1"
   dependencies:
-    "@milkdown/crepe": "npm:7.15.0"
-    "@milkdown/kit": "npm:7.15.0"
+    "@milkdown/crepe": "npm:7.15.1"
+    "@milkdown/kit": "npm:7.15.1"
     tslib: "npm:^2.8.1"
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 10/197ada943b32c98d5e68e30968cd270060c9996378aa52a7894a00ac8ddeedfd0e7a66a1eabd9974422d512fef343fbdf42786d0651f333fc8264a57b4164934
+  checksum: 10/bbce8eb24225910b66f8c198743d4934bb2850b9e1fdbd7b608e60d177da93cee2a7b4f33c5314d27cb078d4375ba2a779ec48c0c64a7f7cfe275dd7f67634a7
   languageName: node
   linkType: hard
 
 "@milkdown/theme-nord@npm:^7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/theme-nord@npm:7.15.0"
+  version: 7.15.1
+  resolution: "@milkdown/theme-nord@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
     clsx: "npm:^2.0.0"
     tslib: "npm:^2.8.1"
-  checksum: 10/4271b4080aab3b65ce7f5898cb972ceb264470803e962f48d2fc6227a7adf35c8068d377e2808eba9b28abcc927dcb74490d4a17296ab6584ea1840f85b8b97c
+  checksum: 10/434c3beb7110aa3f4b706ec848f68e63f8ed55963b59eb3d57162b654f0a3d57984b3ae68cc7758c6608adeb8ee02788796023cc2fa18754de4ceb41ad93d71c
   languageName: node
   linkType: hard
 
-"@milkdown/transformer@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/transformer@npm:7.15.0"
+"@milkdown/transformer@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/transformer@npm:7.15.1"
   dependencies:
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
     remark: "npm:^15.0.1"
     remark-parse: "npm:^11.0.0"
     remark-stringify: "npm:^11.0.0"
     tslib: "npm:^2.8.1"
     unified: "npm:^11.0.3"
-  checksum: 10/4d75220e0bff37734506654cd3b9b4d6856405a0445143251f3b06c05f0a2c0c573f370f49640f48fb05066b775825c0a3adbd08039d5152a7374d4e41d341e8
+  checksum: 10/62ada7454c3a2866649bcb3062771cb25963e356307a994d6b4fa564e2890ce965ca2fb101247d011947459055df396ed484314e8effefdec1c82abd9949dddb
   languageName: node
   linkType: hard
 
-"@milkdown/utils@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@milkdown/utils@npm:7.15.0"
+"@milkdown/utils@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@milkdown/utils@npm:7.15.1"
   dependencies:
-    "@milkdown/core": "npm:7.15.0"
-    "@milkdown/ctx": "npm:7.15.0"
-    "@milkdown/exception": "npm:7.15.0"
-    "@milkdown/prose": "npm:7.15.0"
-    "@milkdown/transformer": "npm:7.15.0"
+    "@milkdown/core": "npm:7.15.1"
+    "@milkdown/ctx": "npm:7.15.1"
+    "@milkdown/exception": "npm:7.15.1"
+    "@milkdown/prose": "npm:7.15.1"
+    "@milkdown/transformer": "npm:7.15.1"
     nanoid: "npm:^5.0.9"
     tslib: "npm:^2.8.1"
-  checksum: 10/16fbc1733dc794250d0f072848f98d3bfbc51f167fe9ba62a01a9d75ac54633c76854b4a6c3643848773895b6b7ed75e97d81e082467e341e3ced72c895c5d38
+  checksum: 10/aa4a652e3c9bbceeecafb6fec7197f24cb8714ca8380194411803b889a29ff98742b4a8c4e175fcbb75c7125f02fd8e72cbb367b8b4c9451ebeb995d4debc7af
   languageName: node
   linkType: hard
 
@@ -3324,7 +3331,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.8":
+"@types/estree-jsx@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "@types/estree-jsx@npm:1.0.5"
+  dependencies:
+    "@types/estree": "npm:*"
+  checksum: 10/a028ab0cd7b2950168a05c6a86026eb3a36a54a4adfae57f13911d7b49dffe573d9c2b28421b2d029b49b3d02fcd686611be2622dc3dad6d9791166c083f6008
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10/25a4c16a6752538ffde2826c2cc0c6491d90e69cd6187bef4a006dd2c3c45469f049e643d7e516c515f21484dc3d48fd5c870be158a5beb72f5baf3dc43e4099
@@ -3382,9 +3398,9 @@ __metadata:
   linkType: hard
 
 "@types/lodash@npm:*":
-  version: 4.17.19
-  resolution: "@types/lodash@npm:4.17.19"
-  checksum: 10/555e53da60dd9904ef4b6f4e663abb965cf45582079f2ea231a18b0b48df4808b60f36c978548fcf5e307bf12ccd563bd4551963039028ea120b1695c7146f7c
+  version: 4.17.20
+  resolution: "@types/lodash@npm:4.17.20"
+  checksum: 10/8cd8ad3bd78d2e06a93ae8d6c9907981d5673655fec7cb274a4d9a59549aab5bb5b3017361280773b8990ddfccf363e14d1b37c97af8a9fe363de677f9a61524
   languageName: node
   linkType: hard
 
@@ -3405,11 +3421,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^24.0.7":
-  version: 24.0.7
-  resolution: "@types/node@npm:24.0.7"
+  version: 24.0.10
+  resolution: "@types/node@npm:24.0.10"
   dependencies:
     undici-types: "npm:~7.8.0"
-  checksum: 10/1df93467fcd5cf178cc381babe58f8f8a504a097fd64297241bd63fd9dbe2b750b1b4ab2bd8b8f6a2dd431d0703da7a74dee8cca5113ae2421f9a4a1ec43d9c0
+  checksum: 10/ff8921c515d72fbc0a11ff282096e2d2e11ac04a2e9c7f765bcec5cb69cd367a88ab5dd556dc162ac98b9212957939b7ae80f12f3fc90db10c82135affd6d120
   languageName: node
   linkType: hard
 
@@ -3445,105 +3461,112 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.35.0, @typescript-eslint/eslint-plugin@npm:^8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.35.0"
+"@types/unist@npm:^2.0.0":
+  version: 2.0.11
+  resolution: "@types/unist@npm:2.0.11"
+  checksum: 10/6d436e832bc35c6dde9f056ac515ebf2b3384a1d7f63679d12358766f9b313368077402e9c1126a14d827f10370a5485e628bf61aa91117cf4fc882423191a4e
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/eslint-plugin@npm:8.35.1, @typescript-eslint/eslint-plugin@npm:^8.35.0":
+  version: 8.35.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.35.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.35.0"
-    "@typescript-eslint/type-utils": "npm:8.35.0"
-    "@typescript-eslint/utils": "npm:8.35.0"
-    "@typescript-eslint/visitor-keys": "npm:8.35.0"
+    "@typescript-eslint/scope-manager": "npm:8.35.1"
+    "@typescript-eslint/type-utils": "npm:8.35.1"
+    "@typescript-eslint/utils": "npm:8.35.1"
+    "@typescript-eslint/visitor-keys": "npm:8.35.1"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^7.0.0"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.35.0
+    "@typescript-eslint/parser": ^8.35.1
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/a87ef0ed958bfb1d2fd38f41d1628d5411136c201e1361ba2ea136a3e9ec01516abf3d4e963eee1bba60132a630814a8af06f4cc014fafd578d8b45f62771eb0
+  checksum: 10/22c4ff7503e4919449b996453ff29ba46e5c0024fac883ac41a313482454f13d55937789f499395dc2a7dba25b1ad47ac5295d60b118f2fa54ca768228514662
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.35.0, @typescript-eslint/parser@npm:^8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/parser@npm:8.35.0"
+"@typescript-eslint/parser@npm:8.35.1, @typescript-eslint/parser@npm:^8.35.0":
+  version: 8.35.1
+  resolution: "@typescript-eslint/parser@npm:8.35.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.35.0"
-    "@typescript-eslint/types": "npm:8.35.0"
-    "@typescript-eslint/typescript-estree": "npm:8.35.0"
-    "@typescript-eslint/visitor-keys": "npm:8.35.0"
+    "@typescript-eslint/scope-manager": "npm:8.35.1"
+    "@typescript-eslint/types": "npm:8.35.1"
+    "@typescript-eslint/typescript-estree": "npm:8.35.1"
+    "@typescript-eslint/visitor-keys": "npm:8.35.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/bd0e406938a4b305bb409611c29bcdc01e3a63c1c47fcbf527a7e2033ae71f6de7c7f95aa4f8973dcd38f5ec26f8e2857e01f160ebc538453161735c17b644da
+  checksum: 10/d5e0ecdb945c90fc1fea3f7dd375e424f1a6d49a97627ad24330499d573d45f85348e05a97e3a4643aec5ad9d210073487687872bd573abd79923a12fc46e716
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/project-service@npm:8.35.0"
+"@typescript-eslint/project-service@npm:8.35.1":
+  version: 8.35.1
+  resolution: "@typescript-eslint/project-service@npm:8.35.1"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.35.0"
-    "@typescript-eslint/types": "npm:^8.35.0"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.35.1"
+    "@typescript-eslint/types": "npm:^8.35.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/a9419da92231aa27f75078fcffab1d02398b50fdb7d5399775a414ba02570682b4b60cdfafb544a021b0dc2372f029c4195f5ae17c50deb11c25661b2ac18a74
+  checksum: 10/f8ceb1c6ab7cdf2c7bc334e74d0d1cd86b5e563319c5477987a05f47af433543b281912ae0cdd875561dc2cc4d3ba4ed3bdd8d5bb6dba68bcde4f68a7d0967e7
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.35.0"
+"@typescript-eslint/scope-manager@npm:8.35.1":
+  version: 8.35.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.35.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.35.0"
-    "@typescript-eslint/visitor-keys": "npm:8.35.0"
-  checksum: 10/36082fe476cf744c016a554e5ce77e6beb7d4d9992b513382bdf7e8f7d044ffd780fefc3f698e53780ead677d0afaf93e82bade10f08933e2757750bfd273d13
+    "@typescript-eslint/types": "npm:8.35.1"
+    "@typescript-eslint/visitor-keys": "npm:8.35.1"
+  checksum: 10/9124302c969126a50c70f9ccbefec0e5a771563b5518318d56fc6242c5cff61da74e7885832370ccd406a048edc300476b1723ad1845d41bd205879d95fbc6b6
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.35.0, @typescript-eslint/tsconfig-utils@npm:^8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.35.0"
+"@typescript-eslint/tsconfig-utils@npm:8.35.1, @typescript-eslint/tsconfig-utils@npm:^8.35.1":
+  version: 8.35.1
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.35.1"
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/4160928313ccbe8b169a009b9c1220826c7df7aab427f960c31f3b838931bc7a121ebee8040118481e4528e2e3cf1b26da047c6ac1d802ecff2ef7206026ea6b
+  checksum: 10/6b6176ec7dbfbe53539bce3e7554f062ff4d220aa5cb5793d52067fe6c196d749e77557dca66f5bf1ee23972e948d5c59461fa3e11da9e34a0a27d9fb7585f5a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/type-utils@npm:8.35.0"
+"@typescript-eslint/type-utils@npm:8.35.1":
+  version: 8.35.1
+  resolution: "@typescript-eslint/type-utils@npm:8.35.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.35.0"
-    "@typescript-eslint/utils": "npm:8.35.0"
+    "@typescript-eslint/typescript-estree": "npm:8.35.1"
+    "@typescript-eslint/utils": "npm:8.35.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/796210b0f099a9382ab8a437556e2710fa481f5288e098d7c45e3c26827df762968241d8ac9542d805274e3755785b3afd1ad2018c79efce72a33515f2e5613d
+  checksum: 10/728df75bac6960192c18436a8340ed7a0f78b472486279f673e4018d493569f2278b7fcac78c5e0f7ccdb873ead227de6d94bc7aebf5cf046c4d8e53c5569bfd
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.35.0, @typescript-eslint/types@npm:^8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/types@npm:8.35.0"
-  checksum: 10/34b5e6da2c59ea84cd528608fff0cc14b102fd23f5517dfee4ef38c9372861d80b5bf92445c9679674f0a4f8dc4ded5066c1bca2bc5569c47515f94568984f35
+"@typescript-eslint/types@npm:8.35.1, @typescript-eslint/types@npm:^8.35.1":
+  version: 8.35.1
+  resolution: "@typescript-eslint/types@npm:8.35.1"
+  checksum: 10/2d5b8f40b2ef0b7d439ee119d2ed12372097c4372aea7ff6d46f92fa743fc60619f8619192fbc0df3833d941be5d9bcb5129b8f6d029716ca86ba42514fbeff9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.35.0"
+"@typescript-eslint/typescript-estree@npm:8.35.1":
+  version: 8.35.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.35.1"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.35.0"
-    "@typescript-eslint/tsconfig-utils": "npm:8.35.0"
-    "@typescript-eslint/types": "npm:8.35.0"
-    "@typescript-eslint/visitor-keys": "npm:8.35.0"
+    "@typescript-eslint/project-service": "npm:8.35.1"
+    "@typescript-eslint/tsconfig-utils": "npm:8.35.1"
+    "@typescript-eslint/types": "npm:8.35.1"
+    "@typescript-eslint/visitor-keys": "npm:8.35.1"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -3552,173 +3575,173 @@ __metadata:
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/4dff7c5a8853c8f4e30d35565c62d3ad5bf8445309bd465d94e9bca725853012bb9f58896a04207c30e10b6669511caac8c0f080ed781c93a3db81d5808195aa
+  checksum: 10/b38a891a37e1c8d76bdb3e8039482b723df590bf9d192a5480ec6777a316914542f610a1d9070bc53e0642c511ddc4ee1c3c03ac0e04a5510feefa95307f51b7
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/utils@npm:8.35.0"
+"@typescript-eslint/utils@npm:8.35.1":
+  version: 8.35.1
+  resolution: "@typescript-eslint/utils@npm:8.35.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/scope-manager": "npm:8.35.0"
-    "@typescript-eslint/types": "npm:8.35.0"
-    "@typescript-eslint/typescript-estree": "npm:8.35.0"
+    "@typescript-eslint/scope-manager": "npm:8.35.1"
+    "@typescript-eslint/types": "npm:8.35.1"
+    "@typescript-eslint/typescript-estree": "npm:8.35.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/24b4af650a8f4d21515498c1c38624717f210d68aedc6cee6958f4e8c36504d871176800020764500f64e078dda1ce23c19bbe19f8f5f7efbe995eb1afca42f2
+  checksum: 10/68388898dc095d7813a18049e782d90ed6500496bb68e3ea5efd7e1de24f37732b133bf88faca835b6219383f406693fdf846e16d3c48e9418388121c89dcf48
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.35.0":
-  version: 8.35.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.35.0"
+"@typescript-eslint/visitor-keys@npm:8.35.1":
+  version: 8.35.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.35.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.35.0"
+    "@typescript-eslint/types": "npm:8.35.1"
     eslint-visitor-keys: "npm:^4.2.1"
-  checksum: 10/c0acb13aac3a2be5e82844f7d2e86137347efdd04661dbf9fa69ef04a19dd2f1eb2f1eb6bfbfbaada78a46884308d2c0e0b5d0d1a094c84f2dfb670b67ac2b3b
+  checksum: 10/0add7a9c00e7b336797bb7378bd02b3ef31368a8e928afb2dbeec0cc4ab9f6413519e477f5c504d62b38d1dae3791f7ffda36d41b403411608628bff8dd123bd
   languageName: node
   linkType: hard
 
-"@ungap/structured-clone@npm:^1.2.0":
+"@ungap/structured-clone@npm:^1.0.0, @ungap/structured-clone@npm:^1.2.0":
   version: 1.3.0
   resolution: "@ungap/structured-clone@npm:1.3.0"
   checksum: 10/80d6910946f2b1552a2406650051c91bbd1f24a6bf854354203d84fe2714b3e8ce4618f49cc3410494173a1c1e8e9777372fe68dce74bd45faf0a7a1a6ccf448
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-android-arm-eabi@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-android-arm-eabi@npm:1.9.2"
+"@unrs/resolver-binding-android-arm-eabi@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-android-arm-eabi@npm:1.10.1"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-android-arm64@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-android-arm64@npm:1.9.2"
+"@unrs/resolver-binding-android-arm64@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-android-arm64@npm:1.10.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-darwin-arm64@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-darwin-arm64@npm:1.9.2"
+"@unrs/resolver-binding-darwin-arm64@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-darwin-arm64@npm:1.10.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-darwin-x64@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-darwin-x64@npm:1.9.2"
+"@unrs/resolver-binding-darwin-x64@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-darwin-x64@npm:1.10.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-freebsd-x64@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-freebsd-x64@npm:1.9.2"
+"@unrs/resolver-binding-freebsd-x64@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-freebsd-x64@npm:1.10.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.9.2"
+"@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.10.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-arm-musleabihf@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-arm-musleabihf@npm:1.9.2"
+"@unrs/resolver-binding-linux-arm-musleabihf@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-arm-musleabihf@npm:1.10.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-arm64-gnu@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-arm64-gnu@npm:1.9.2"
+"@unrs/resolver-binding-linux-arm64-gnu@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-arm64-gnu@npm:1.10.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-arm64-musl@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-arm64-musl@npm:1.9.2"
+"@unrs/resolver-binding-linux-arm64-musl@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-arm64-musl@npm:1.10.1"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-ppc64-gnu@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-ppc64-gnu@npm:1.9.2"
+"@unrs/resolver-binding-linux-ppc64-gnu@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-ppc64-gnu@npm:1.10.1"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-riscv64-gnu@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-riscv64-gnu@npm:1.9.2"
+"@unrs/resolver-binding-linux-riscv64-gnu@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-riscv64-gnu@npm:1.10.1"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-riscv64-musl@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-riscv64-musl@npm:1.9.2"
+"@unrs/resolver-binding-linux-riscv64-musl@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-riscv64-musl@npm:1.10.1"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-s390x-gnu@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-s390x-gnu@npm:1.9.2"
+"@unrs/resolver-binding-linux-s390x-gnu@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-s390x-gnu@npm:1.10.1"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-x64-gnu@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-x64-gnu@npm:1.9.2"
+"@unrs/resolver-binding-linux-x64-gnu@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-x64-gnu@npm:1.10.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-x64-musl@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-linux-x64-musl@npm:1.9.2"
+"@unrs/resolver-binding-linux-x64-musl@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-linux-x64-musl@npm:1.10.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-wasm32-wasi@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-wasm32-wasi@npm:1.9.2"
+"@unrs/resolver-binding-wasm32-wasi@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-wasm32-wasi@npm:1.10.1"
   dependencies:
     "@napi-rs/wasm-runtime": "npm:^0.2.11"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-win32-arm64-msvc@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-win32-arm64-msvc@npm:1.9.2"
+"@unrs/resolver-binding-win32-arm64-msvc@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-win32-arm64-msvc@npm:1.10.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-win32-ia32-msvc@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-win32-ia32-msvc@npm:1.9.2"
+"@unrs/resolver-binding-win32-ia32-msvc@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-win32-ia32-msvc@npm:1.10.1"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-win32-x64-msvc@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.9.2"
+"@unrs/resolver-binding-win32-x64-msvc@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.10.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4254,10 +4277,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"character-entities-html4@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "character-entities-html4@npm:2.1.0"
+  checksum: 10/7034aa7c7fa90309667f6dd50499c8a760c3d3a6fb159adb4e0bada0107d194551cdbad0714302f62d06ce4ed68565c8c2e15fdef2e8f8764eb63fa92b34b11d
+  languageName: node
+  linkType: hard
+
+"character-entities-legacy@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "character-entities-legacy@npm:3.0.0"
+  checksum: 10/7582af055cb488b626d364b7d7a4e46b06abd526fb63c0e4eb35bcb9c9799cc4f76b39f34fdccef2d1174ac95e53e9ab355aae83227c1a2505877893fce77731
+  languageName: node
+  linkType: hard
+
 "character-entities@npm:^2.0.0":
   version: 2.0.2
   resolution: "character-entities@npm:2.0.2"
   checksum: 10/c8dd1f4bf1a92fccf7d2fad9673660a88b37854557d30f6076c32fedfb92d1420208298829ff1d3b6b4fa1c7012e8326c45e7f5c3ed1e9a09ec177593c521b2f
+  languageName: node
+  linkType: hard
+
+"character-reference-invalid@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "character-reference-invalid@npm:2.0.1"
+  checksum: 10/98d3b1a52ae510b7329e6ee7f6210df14f1e318c5415975d4c9e7ee0ef4c07875d47c6e74230c64551f12f556b4a8ccc24d9f3691a2aa197019e72a95e9297ee
   languageName: node
   linkType: hard
 
@@ -4310,6 +4354,13 @@ __metadata:
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10/b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"comma-separated-tokens@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "comma-separated-tokens@npm:2.0.3"
+  checksum: 10/e3bf9e0332a5c45f49b90e79bcdb4a7a85f28d6a6f0876a94f1bb9b2bfbdbbb9292aac50e1e742d8c0db1e62a0229a106f57917e2d067fca951d81737651700d
   languageName: node
   linkType: hard
 
@@ -4557,9 +4608,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.173":
-  version: 1.5.177
-  resolution: "electron-to-chromium@npm:1.5.177"
-  checksum: 10/86f740f3d0fc10cbc056496f8673ced2aea8db54cc122a87d90ed81127eebb4e9618a032bbf5edabab4ef897bc4d6a09a54512448c671308f239a946751ee421
+  version: 1.5.179
+  resolution: "electron-to-chromium@npm:1.5.179"
+  checksum: 10/4d0463947288c66e0a6f733aae001508de798692eb7f92fc05c16a4b86771a79f3c6c8ec5e76fbdf219276cc4ae72ef1e1ccb609c8121bac26a5f7c260d03191
   languageName: node
   linkType: hard
 
@@ -5171,6 +5222,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-util-is-identifier-name@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "estree-util-is-identifier-name@npm:3.0.0"
+  checksum: 10/cdc9187614fdb269d714eddfdf72c270a79daa9ed51e259bb78527983be6dcc68da6a914ccc41175b662194c67fbd2a1cd262f85fac1eef7111cfddfaf6f77f8
+  languageName: node
+  linkType: hard
+
 "estree-walker@npm:^2.0.2":
   version: 2.0.2
   resolution: "estree-walker@npm:2.0.2"
@@ -5352,7 +5410,10 @@ __metadata:
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     react-icons: "npm:^5.5.0"
+    react-markdown: "npm:^10.1.0"
     react-router: "npm:^7.6.3"
+    remark-breaks: "npm:^4.0.0"
+    remark-gfm: "npm:^4.0.1"
     swr: "npm:^2.3.3"
     tailwindcss: "npm:^4.1.11"
     typescript: "npm:~5.8.3"
@@ -5534,13 +5595,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^11.1.0":
-  version: 11.12.0
-  resolution: "globals@npm:11.12.0"
-  checksum: 10/9f054fa38ff8de8fa356502eb9d2dae0c928217b8b5c8de1f09f5c9b6c8a96d8b9bd3afc49acbcd384a98a81fea713c859e1b09e214c60509517bb8fc2bc13c2
-  languageName: node
-  linkType: hard
-
 "globals@npm:^13.19.0":
   version: 13.24.0
   resolution: "globals@npm:13.24.0"
@@ -5551,9 +5605,9 @@ __metadata:
   linkType: hard
 
 "globals@npm:^16.2.0":
-  version: 16.2.0
-  resolution: "globals@npm:16.2.0"
-  checksum: 10/37fc33502973ebbee5a44b58939aa8574abc00ca1fc4c1d4ec0571a2c6620843ae647eff8bd082adf6bb5975ad221a887522b9a7961125764f0cb6dfab0b7483
+  version: 16.3.0
+  resolution: "globals@npm:16.3.0"
+  checksum: 10/accb0939d993a1c461df8d961ce9911a9a96120929e0a61057ae8e75b7df0a8bf8089da0f4e3a476db0211156416fbd26e222a56f74b389a140b34481c0a72b0
   languageName: node
   linkType: hard
 
@@ -5645,6 +5699,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-to-jsx-runtime@npm:^2.0.0":
+  version: 2.3.6
+  resolution: "hast-util-to-jsx-runtime@npm:2.3.6"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    estree-util-is-identifier-name: "npm:^3.0.0"
+    hast-util-whitespace: "npm:^3.0.0"
+    mdast-util-mdx-expression: "npm:^2.0.0"
+    mdast-util-mdx-jsx: "npm:^3.0.0"
+    mdast-util-mdxjs-esm: "npm:^2.0.0"
+    property-information: "npm:^7.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+    style-to-js: "npm:^1.0.0"
+    unist-util-position: "npm:^5.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10/111bd69f482952c7591cb4e1d3face25f1c18849b310a4d6cacc91e2d2cbc965d455fad35c059b8f0cfd762e933b826a7090b6f3098dece08307a6569de8f1d8
+  languageName: node
+  linkType: hard
+
+"hast-util-whitespace@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "hast-util-whitespace@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: 10/8c7e9eeb8131fc18702f3a42623eb6b0b09d470347aa8badacac70e6d91f79657ab8c6b57c4c6fee3658cff405fac30e816d1cdfb3ed1fbf6045d0a4555cf4d4
+  languageName: node
+  linkType: hard
+
+"html-url-attributes@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "html-url-attributes@npm:3.0.1"
+  checksum: 10/494074c2f730c5c0e517aa1b10111fb36732534a2d2b70427582c4a615472b47da472cf3a17562cc653826d378d20960f2783e0400f4f7cf0c3c2d91c6188d13
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.2.0
   resolution: "http-cache-semantics@npm:4.2.0"
@@ -5729,6 +5822,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inline-style-parser@npm:0.2.4":
+  version: 0.2.4
+  resolution: "inline-style-parser@npm:0.2.4"
+  checksum: 10/80814479d1f3c9cbd102f9de4cd6558cf43cc2e48640e81c4371c3634f1e8b6dfeb2f21063cfa31d46cc83e834c20cd59ed9eeed9bfd45ef5bc02187ad941faf
+  languageName: node
+  linkType: hard
+
 "internal-slot@npm:^1.1.0":
   version: 1.1.0
   resolution: "internal-slot@npm:1.1.0"
@@ -5747,6 +5847,23 @@ __metadata:
     jsbn: "npm:1.1.0"
     sprintf-js: "npm:^1.1.3"
   checksum: 10/1ed81e06721af012306329b31f532b5e24e00cb537be18ddc905a84f19fe8f83a09a1699862bf3a1ec4b9dea93c55a3fa5faf8b5ea380431469df540f38b092c
+  languageName: node
+  linkType: hard
+
+"is-alphabetical@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-alphabetical@npm:2.0.1"
+  checksum: 10/56207db8d9de0850f0cd30f4966bf731eb82cedfe496cbc2e97e7c3bacaf66fc54a972d2d08c0d93bb679cb84976a05d24c5ad63de56fabbfc60aadae312edaa
+  languageName: node
+  linkType: hard
+
+"is-alphanumerical@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-alphanumerical@npm:2.0.1"
+  dependencies:
+    is-alphabetical: "npm:^2.0.0"
+    is-decimal: "npm:^2.0.0"
+  checksum: 10/87acc068008d4c9c4e9f5bd5e251041d42e7a50995c77b1499cf6ed248f971aadeddb11f239cabf09f7975ee58cac7a48ffc170b7890076d8d227b24a68663c9
   languageName: node
   linkType: hard
 
@@ -5839,6 +5956,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-decimal@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-decimal@npm:2.0.1"
+  checksum: 10/97132de7acdce77caa7b797632970a2ecd649a88e715db0e4dbc00ab0708b5e7574ba5903962c860cd4894a14fd12b100c0c4ac8aed445cf6f55c6cf747a4158
+  languageName: node
+  linkType: hard
+
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -5880,6 +6004,13 @@ __metadata:
   dependencies:
     is-extglob: "npm:^2.1.1"
   checksum: 10/3ed74f2b0cdf4f401f38edb0442ddfde3092d79d7d35c9919c86641efdbcbb32e45aa3c0f70ce5eecc946896cd5a0f26e4188b9f2b881876f7cb6c505b82da11
+  languageName: node
+  linkType: hard
+
+"is-hexadecimal@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-hexadecimal@npm:2.0.1"
+  checksum: 10/66a2ea85994c622858f063f23eda506db29d92b52580709eb6f4c19550552d4dcf3fb81952e52f7cf972097237959e00adc7bb8c9400cd12886e15bf06145321
   languageName: node
   linkType: hard
 
@@ -6560,6 +6691,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-mdx-expression@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-mdx-expression@npm:2.0.1"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10/70e860f8ee22c4f478449942750055d649d4380bf43b235d0710af510189d285fb057e401d20b59596d9789f4e270fce08ca892dc849676f9e3383b991d52485
+  languageName: node
+  linkType: hard
+
+"mdast-util-mdx-jsx@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "mdast-util-mdx-jsx@npm:3.2.0"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    ccount: "npm:^2.0.0"
+    devlop: "npm:^1.1.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    parse-entities: "npm:^4.0.0"
+    stringify-entities: "npm:^4.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10/62cd650a522e5d72ea6afd6d4a557fc86525b802d097a29a2fbe17d22e7b97c502a580611873e4d685777fe77c6ff8d39fb6e37d026b3acbc86c3b24927f4ad9
+  languageName: node
+  linkType: hard
+
+"mdast-util-mdxjs-esm@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-mdxjs-esm@npm:2.0.1"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10/05474226e163a3f407fccb5780b0d8585a95e548e5da4a85227df43f281b940c7941a9a9d4af1be4f885fe554731647addb057a728e87aa1f503ff9cc72c9163
+  languageName: node
+  linkType: hard
+
+"mdast-util-newline-to-break@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-newline-to-break@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-find-and-replace: "npm:^3.0.0"
+  checksum: 10/2300312c02501458854129e776cbbf6daafa6b7675a54a634f9a3c76055b0466081ad9eebde6bc655030e868fd7c183352acd856bcd265b3ea96f214c4f7fd7b
+  languageName: node
+  linkType: hard
+
 "mdast-util-phrasing@npm:^4.0.0":
   version: 4.1.0
   resolution: "mdast-util-phrasing@npm:4.1.0"
@@ -6567,6 +6756,23 @@ __metadata:
     "@types/mdast": "npm:^4.0.0"
     unist-util-is: "npm:^6.0.0"
   checksum: 10/3a97533e8ad104a422f8bebb34b3dde4f17167b8ed3a721cf9263c7416bd3447d2364e6d012a594aada40cac9e949db28a060bb71a982231693609034ed5324e
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-hast@npm:^13.0.0":
+  version: 13.2.0
+  resolution: "mdast-util-to-hast@npm:13.2.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    "@ungap/structured-clone": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    trim-lines: "npm:^3.0.0"
+    unist-util-position: "npm:^5.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10/b17ee338f843af31a1c7a2ebf0df6f0b41c9380b7119a63ab521d271df665456578e1234bb7617883e8d860fe878038dcf2b76ab2f21e0f7451215a096d26cce
   languageName: node
   linkType: hard
 
@@ -7092,12 +7298,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"napi-postinstall@npm:^0.2.4":
-  version: 0.2.5
-  resolution: "napi-postinstall@npm:0.2.5"
+"napi-postinstall@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "napi-postinstall@npm:0.3.0"
   bin:
     napi-postinstall: lib/cli.js
-  checksum: 10/3c2887c6f8dd896fb92bda3d5ed7e6904384abf35088e1b943e68c07e4ac6edfbeb63d200a9e939e7d942966805349c9e04ca67342a7f7ef4675e78755e4144d
+  checksum: 10/4cddb80320a895015fd7e566b7c5866197f7bbb808fb37c6f99c4d68138a19d8d801b1025c9fb38f78ff266734fe3a0b4717cf792a4a8f062cfbde5ed7144114
   languageName: node
   linkType: hard
 
@@ -7317,6 +7523,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-entities@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "parse-entities@npm:4.0.2"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    character-entities-legacy: "npm:^3.0.0"
+    character-reference-invalid: "npm:^2.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    is-alphanumerical: "npm:^2.0.0"
+    is-decimal: "npm:^2.0.0"
+    is-hexadecimal: "npm:^2.0.0"
+  checksum: 10/b0ce693d0b3d7ed1cea6fe814e6e077c71532695f01178e846269e9a2bc2f7ff34ca4bb8db80b48af0451100f25bb010df6591c9bb6306e4680ccb423d1e4038
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
@@ -7426,6 +7647,13 @@ __metadata:
     object-assign: "npm:^4.1.1"
     react-is: "npm:^16.13.1"
   checksum: 10/7d959caec002bc964c86cdc461ec93108b27337dabe6192fb97d69e16a0c799a03462713868b40749bfc1caf5f57ef80ac3e4ffad3effa636ee667582a75e2c0
+  languageName: node
+  linkType: hard
+
+"property-information@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "property-information@npm:7.1.0"
+  checksum: 10/896d38a52ad7170de73f832d277c69e76a9605d941ebb3f0d6e56271414a7fdf95ff6d2819e68036b8a0c7d2d4d88bf1d4a5765c032cb19c2343567ee3a14b15
   languageName: node
   linkType: hard
 
@@ -7710,6 +7938,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-markdown@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "react-markdown@npm:10.1.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    hast-util-to-jsx-runtime: "npm:^2.0.0"
+    html-url-attributes: "npm:^3.0.0"
+    mdast-util-to-hast: "npm:^13.0.0"
+    remark-parse: "npm:^11.0.0"
+    remark-rehype: "npm:^11.0.0"
+    unified: "npm:^11.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+  peerDependencies:
+    "@types/react": ">=18"
+    react: ">=18"
+  checksum: 10/886c037d18266e94750abbc00c6096435bccd4da5f2d1727984bcbdf83e9f2a5cc9a6b0eecfe6c30456dc26546fee41c7f6aecbf176e6d7453963df4abefd7df
+  languageName: node
+  linkType: hard
+
 "react-refresh@npm:^0.17.0":
   version: 0.17.0
   resolution: "react-refresh@npm:0.17.0"
@@ -7821,6 +8071,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-breaks@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "remark-breaks@npm:4.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-newline-to-break: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10/6841b88ea4995ec9d469bb10f8272ce264466ffd706a85a931fd6d451dc81440916bd62118d62f10b7c61704b740e7eda4c0c8bee62dc27e8a02ee2766af1bf2
+  languageName: node
+  linkType: hard
+
 "remark-gfm@npm:^4.0.1":
   version: 4.0.1
   resolution: "remark-gfm@npm:4.0.1"
@@ -7867,6 +8128,19 @@ __metadata:
     micromark-util-types: "npm:^2.0.0"
     unified: "npm:^11.0.0"
   checksum: 10/59d584be56ebc7c05524989c4ed86eb8a7b6e361942b705ca13a37349f60740a6073aedf7783af46ce920d09dd156148942d5e33e8be3dbcd47f818cb4bc410c
+  languageName: node
+  linkType: hard
+
+"remark-rehype@npm:^11.0.0":
+  version: 11.1.2
+  resolution: "remark-rehype@npm:11.1.2"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-to-hast: "npm:^13.0.0"
+    unified: "npm:^11.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10/b5374a0bf08398431c92740d0cd9b20aea9df44cee12326820ddcc1b7ee642706604006461ea9799554c347e7caf31e7432132a03b97c508e1f77d29c423bd86
   languageName: node
   linkType: hard
 
@@ -8291,6 +8565,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"space-separated-tokens@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "space-separated-tokens@npm:2.0.2"
+  checksum: 10/202e97d7ca1ba0758a0aa4fe226ff98142073bcceeff2da3aad037968878552c3bbce3b3231970025375bbba5aee00c5b8206eda408da837ab2dc9c0f26be990
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:^1.1.3":
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
@@ -8426,6 +8707,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stringify-entities@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "stringify-entities@npm:4.0.4"
+  dependencies:
+    character-entities-html4: "npm:^2.0.0"
+    character-entities-legacy: "npm:^3.0.0"
+  checksum: 10/42bd2f37528795a7b4386bd39dc4699515fb0f0b8c418a6bb29ae205ce66eaff9e8801a2bee65b8049c918c9475a71c7e5911f6a88c19f1d84ebdcba3d881a2d
+  languageName: node
+  linkType: hard
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
@@ -8465,6 +8756,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"style-to-js@npm:^1.0.0":
+  version: 1.1.17
+  resolution: "style-to-js@npm:1.1.17"
+  dependencies:
+    style-to-object: "npm:1.0.9"
+  checksum: 10/431f2fca8a55a61939a83ff0f58638e2996621ad93a97cf93f2be5115f411330d4e506ccf18621bd45607ec161546b763bb6961ad08238ad939b6261ff377230
+  languageName: node
+  linkType: hard
+
+"style-to-object@npm:1.0.9":
+  version: 1.0.9
+  resolution: "style-to-object@npm:1.0.9"
+  dependencies:
+    inline-style-parser: "npm:0.2.4"
+  checksum: 10/fd0c131a83103fe4025afd8e0fd90c605054d485ad80f2ab402e7afa79f482f4b05fff40b6aa661cb1b835e5c56bb0644dc38cbf9b3d2982fc552435db3dae50
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
@@ -8482,14 +8791,14 @@ __metadata:
   linkType: hard
 
 "swr@npm:^2.3.3":
-  version: 2.3.3
-  resolution: "swr@npm:2.3.3"
+  version: 2.3.4
+  resolution: "swr@npm:2.3.4"
   dependencies:
     dequal: "npm:^2.0.3"
     use-sync-external-store: "npm:^1.4.0"
   peerDependencies:
     react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/11cd5d1acbc62cf0e092e0d19f1d67b2e6ecb542602250f3277eb235750cd3285291bae9a8264c1f5b3973890f75234c104a0baf1ac6059aadc700ecba100fcc
+  checksum: 10/a0898f2d8471c03d7e983e0362f88d08ed4d8579ee45e26a4c9bc9e71b342abd821d7b2f2247f96c41534bd7e56ced4d15150c1b21e38a256548e831aa3cdfa6
   languageName: node
   linkType: hard
 
@@ -8544,6 +8853,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10/10dda13571e1f5ad37546827e9b6d4252d2e0bc176c24a101252153ef435d83696e2557fe128c4678e4e78f5f01e83711c703eef9814eb12dab028580d45980a
+  languageName: node
+  linkType: hard
+
+"trim-lines@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "trim-lines@npm:3.0.1"
+  checksum: 10/7a1325e4ce8ff7e9e52007600e9c9862a166d0db1f1cf0c9357e359e410acab1278fcd91cc279dfa5123fc37b69f080de02f471e91dbbc61b155b9ca92597929
   languageName: node
   linkType: hard
 
@@ -8652,16 +8968,16 @@ __metadata:
   linkType: hard
 
 "typescript-eslint@npm:^8.35.0":
-  version: 8.35.0
-  resolution: "typescript-eslint@npm:8.35.0"
+  version: 8.35.1
+  resolution: "typescript-eslint@npm:8.35.1"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.35.0"
-    "@typescript-eslint/parser": "npm:8.35.0"
-    "@typescript-eslint/utils": "npm:8.35.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.35.1"
+    "@typescript-eslint/parser": "npm:8.35.1"
+    "@typescript-eslint/utils": "npm:8.35.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/350f584dfe2de1863954d65e27f8a02849569970ee4e0c108d881180d044ffeb4cc112a447ea835f347357219219afefed35084bd0bfd27496eb882f221eb5de
+  checksum: 10/56080cf28068e074cf6fa9f0a4002b54fe2c9ba319a7b0eccc5d0a4a76fecb8023fe83f209b983da2f0c782fbbd1c6a5fd680f9dd71e4a1f0e964fb6df4dd89e
   languageName: node
   linkType: hard
 
@@ -8746,6 +9062,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-util-position@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-position@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10/89d4da00e74618d7562ac7ac288961df9bcd4ccca6df3b5a90650f018eceb6b95de6e771e88bdbef46cc9d96861d456abe57b7ad1108921e0feb67c6292aa29d
+  languageName: node
+  linkType: hard
+
 "unist-util-remove-position@npm:^5.0.0":
   version: 5.0.0
   resolution: "unist-util-remove-position@npm:5.0.0"
@@ -8787,29 +9112,29 @@ __metadata:
   linkType: hard
 
 "unrs-resolver@npm:^1.7.11":
-  version: 1.9.2
-  resolution: "unrs-resolver@npm:1.9.2"
+  version: 1.10.1
+  resolution: "unrs-resolver@npm:1.10.1"
   dependencies:
-    "@unrs/resolver-binding-android-arm-eabi": "npm:1.9.2"
-    "@unrs/resolver-binding-android-arm64": "npm:1.9.2"
-    "@unrs/resolver-binding-darwin-arm64": "npm:1.9.2"
-    "@unrs/resolver-binding-darwin-x64": "npm:1.9.2"
-    "@unrs/resolver-binding-freebsd-x64": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-arm-gnueabihf": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-arm-musleabihf": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-arm64-gnu": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-arm64-musl": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-ppc64-gnu": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-riscv64-gnu": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-riscv64-musl": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-s390x-gnu": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-x64-gnu": "npm:1.9.2"
-    "@unrs/resolver-binding-linux-x64-musl": "npm:1.9.2"
-    "@unrs/resolver-binding-wasm32-wasi": "npm:1.9.2"
-    "@unrs/resolver-binding-win32-arm64-msvc": "npm:1.9.2"
-    "@unrs/resolver-binding-win32-ia32-msvc": "npm:1.9.2"
-    "@unrs/resolver-binding-win32-x64-msvc": "npm:1.9.2"
-    napi-postinstall: "npm:^0.2.4"
+    "@unrs/resolver-binding-android-arm-eabi": "npm:1.10.1"
+    "@unrs/resolver-binding-android-arm64": "npm:1.10.1"
+    "@unrs/resolver-binding-darwin-arm64": "npm:1.10.1"
+    "@unrs/resolver-binding-darwin-x64": "npm:1.10.1"
+    "@unrs/resolver-binding-freebsd-x64": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-arm-gnueabihf": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-arm-musleabihf": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-arm64-gnu": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-arm64-musl": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-ppc64-gnu": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-riscv64-gnu": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-riscv64-musl": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-s390x-gnu": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-x64-gnu": "npm:1.10.1"
+    "@unrs/resolver-binding-linux-x64-musl": "npm:1.10.1"
+    "@unrs/resolver-binding-wasm32-wasi": "npm:1.10.1"
+    "@unrs/resolver-binding-win32-arm64-msvc": "npm:1.10.1"
+    "@unrs/resolver-binding-win32-ia32-msvc": "npm:1.10.1"
+    "@unrs/resolver-binding-win32-x64-msvc": "npm:1.10.1"
+    napi-postinstall: "npm:^0.3.0"
   dependenciesMeta:
     "@unrs/resolver-binding-android-arm-eabi":
       optional: true
@@ -8849,7 +9174,7 @@ __metadata:
       optional: true
     "@unrs/resolver-binding-win32-x64-msvc":
       optional: true
-  checksum: 10/b299c0ccf1c71f7e0607ed57ae35d887732cd60f2b5fc33dbb4ec80ea8afe707dfb0615882e27265d1d722042bef6134736caaa3a3e000155ccac712f888e110
+  checksum: 10/ee09b8eb16880bbd6c10f8776706afe68fc7567d512beecb41d1e6d478397ed9a7c0b1aa61ee1063a5dd3bb57f24e6d3f93b206c57d5e0e63cad73ebf77f8255
   languageName: node
   linkType: hard
 
@@ -8937,8 +9262,8 @@ __metadata:
   linkType: hard
 
 "vite@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "vite@npm:7.0.0"
+  version: 7.0.1
+  resolution: "vite@npm:7.0.1"
   dependencies:
     esbuild: "npm:^0.25.0"
     fdir: "npm:^6.4.6"
@@ -8987,7 +9312,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10/2501b706dc481529efb16c6241794a66d68ea7a074d49f22e45b701769fbeeccc721c58272c9fce743d3b1472a3de497f85ca18cb059b1b8b906b2b295e524dc
+  checksum: 10/c4f5be940e5794cae0a62528c7e4b636334eaa2a3dac41ba199cdb51c4048ffe6760ee85e7f20e141bb10338f8dd35d6e5154071db4f62ae4814a8f1b9af0393
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Renders github-flavored markdown using Radix components.

react-markdown, TypeScript, and React 19 don't interact well currently (even though they're supposed to), so I've had to `@ts-expect-error` a lot of lines - TypeScript raises a lot of errors when using the library claiming that types are incompatible, even though everything still works as expected.