### PR TITLE
Backend fixes for admin work

### DIFF
--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -10,7 +10,7 @@ from CTFd.utils.user import get_current_user, is_admin as is_admin_ctfd
 from CTFd.utils.decorators import admins_only, authed_only
 from ..exceptions import PermissionError, ValidationError
 from .error_handler import handle_exceptions
-
+from ...user.models.User import User
 
 def api_endpoint(auth_required=True, admin_required=False, json_required=False, validation_func=None):
     """
@@ -67,7 +67,7 @@ def _auth_handler(f, auth_required, json_required, validation_func):
                 raise PermissionError("Authentication is required to access this resource.")
             g.user = current_user
             if "current_user" in sig.parameters:
-                kwargs["current_user"] = current_user
+                kwargs["current_user"] = User.find_or_create_by_ctfd_id(current_user.id)
         if json_required:
             if not request.is_json:
                 raise ValidationError("Request must have a JSON body.")

--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -31,10 +31,10 @@ def api_endpoint(auth_required=True, admin_required=False, json_required=False, 
     Usage:
         @api_endpoint(auth_required=True, json_required=True, validation_func=validate_team_creation)
         @load_event()  # Loads event from route params
-        def create_team(self, event_id):
-            data = g.validated_data  # Already parsed and validated
-            event = g.event  # Already loaded
-            eligibility = g.user_eligibility  # Already checked
+        def create_team(self, event_id, event, validated_data, current_user):
+            validated_data  # Already parsed and validated
+            event # Already loaded
+            current_user # Already loaded
             # ... business logic
     """
 
@@ -65,7 +65,6 @@ def _auth_handler(f, auth_required, json_required, validation_func):
             current_user = get_current_user()
             if not current_user:
                 raise PermissionError("Authentication is required to access this resource.")
-            g.user = current_user
             if "current_user" in sig.parameters:
                 kwargs["current_user"] = User.find_or_create_by_ctfd_id(current_user.id)
         if json_required:
@@ -79,7 +78,7 @@ def _auth_handler(f, auth_required, json_required, validation_func):
             g.json_data = data
             if validation_func:
                 try:
-                    g.validated_data = validation_func(data)
+                    kwargs["validated_data"] = validation_func(data)
                 except Exception as e:
                     raise ValidationError(str(e))
         return f(*args, **kwargs)
@@ -134,7 +133,7 @@ def admin_view(f):
             raise PermissionError("You must be logged in to view this page.")
         if not is_admin_ctfd():
             raise PermissionError("You must be an administrator to view this page.")
-        g.user = user
+        kwargs["current_user"] = User.find_or_create_by_ctfd_id(user.id)
         return f(*args, **kwargs)
 
     return decorated_function

--- a/backend/ng/core/utils/validator.py
+++ b/backend/ng/core/utils/validator.py
@@ -3,7 +3,7 @@ Base validation framework - reusable across domains.
 """
 
 from typing import Any
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from . import utc_now
 
@@ -17,6 +17,7 @@ class ValidationErrorMessages:
     FIELD_MUST_BE_BOOLEAN = "{field} must be true or false"
     FIELD_MUST_BE_POSITIVE = "{field} must be a positive number"
     FIELD_MUST_BE_DATETIME = "{field} must be a valid datetime in ISO format (YYYY-MM-DDTHH:MM:SS)"
+    FIELD_DATETIME_MUST_BE_UTC = "{field} must be specified in UTC (Z or +00:00)"
     FIELD_DATETIME_PAST = "{field} cannot be in the past"
     FIELD_DATETIME_ORDER = "Start time must be before end time"
     FIELD_OUT_OF_RANGE = "{field} must be between {min_val} and {max_val}"
@@ -197,7 +198,16 @@ class BaseValidator:
             return None
 
         try:
-            dt_value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            dt_value = datetime.fromisoformat(value)
+            
+            # require that tzinfo is set and is UTC
+            if dt_value.tzinfo is not timezone.utc:
+                self.errors[field] = ValidationErrorMessages.FIELD_DATETIME_MUST_BE_UTC.format(field=name)
+                return None
+            
+            # strip tzinfo to allow using this value with naive datetimes from utc_now/db
+            dt_value = dt_value.replace(tzinfo=None)
+            
             if not allow_past and dt_value < utc_now():
                 self.errors[field] = ValidationErrorMessages.FIELD_DATETIME_PAST.format(field=name)
                 return None

--- a/backend/ng/event/models/Event.py
+++ b/backend/ng/event/models/Event.py
@@ -69,13 +69,13 @@ class Event(db.Model):
             "name": self.name,
             "description": self.description,
             "max_team_size": self.max_team_size,
-            "start_time": self.start_time,
-            "end_time": self.end_time,
+            "start_time": self.start_time.isoformat() + "Z" if self.start_time else None,
+            "end_time": self.end_time.isoformat() + "Z" if self.end_time else None,
             "locked": self.locked,
             "public": self.public,
             "registration_open": self.registration_open,
-            "registration_start_date": self.registration_start_date,
-            "registration_end_date": self.registration_end_date,
+            "registration_start_date": self.registration_start_date.isoformat() + "Z" if self.registration_start_date else None,
+            "registration_end_date": self.registration_end_date.isoformat() + "Z" if self.registration_end_date else None,
         }
 
         return data

--- a/backend/ng/event/routes/user_routes.py
+++ b/backend/ng/event/routes/user_routes.py
@@ -28,7 +28,6 @@ class EventList(Resource):
     def get(self):
         """Get all public events"""
         results = Event.get_all_events(public_only=True)
-        print(results)
         return success_response(results)
     
 @events_user_namespace.route("/<int:event_id>")
@@ -37,7 +36,6 @@ class EventDetail(Resource):
     @load_event(source=LoaderType.PARAM)
     def get(self, event_id, event):
         """Get event details"""
-        print(event.serialize())
         return success_response(event)
     
 @events_user_namespace.route("/<int:event_id>/me/eligibility")

--- a/backend/ng/support/models/Ticket.py
+++ b/backend/ng/support/models/Ticket.py
@@ -80,8 +80,8 @@ class Ticket(db.Model):
             "subject": self.subject,
             "author_id": self.author_id,
             "status": self.status,
-            "opened_timestamp": self.opened_timestamp.isoformat() if self.opened_timestamp else None,
-            "last_updated": self.last_updated.isoformat() if self.last_updated else None,
+            "opened_timestamp": self.opened_timestamp.isoformat() + "Z" if self.opened_timestamp else None,
+            "last_updated": self.last_updated.isoformat() + "Z" if self.last_updated else None,
             "event_id": self.event_id,
             "team_id": self.team_id,
             "challenge_id": self.challenge_id,
@@ -91,12 +91,12 @@ class Ticket(db.Model):
 
         if include_admin_fields:
             first_admin_response_timestamp = (
-                self.first_admin_response_timestamp.isoformat() if self.first_admin_response_timestamp else None
+                self.first_admin_response_timestamp.isoformat() + "Z" if self.first_admin_response_timestamp else None
             )
             data.update(
                 {
                     "assigned_to": self.assigned_to,
-                    "closed_timestamp": self.closed_timestamp.isoformat() if self.closed_timestamp else None,
+                    "closed_timestamp": self.closed_timestamp.isoformat() + "Z" if self.closed_timestamp else None,
                     "muted": self.muted,
                     "first_admin_response_timestamp": first_admin_response_timestamp,
                 }

--- a/backend/ng/support/models/TicketMessage.py
+++ b/backend/ng/support/models/TicketMessage.py
@@ -47,7 +47,7 @@ class TicketMessage(db.Model):
             "author_id": self.author_id,
             "author_name": author_name,
             "author_type": author_type,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "created_at": self.created_at.isoformat() + "Z" if self.created_at else None,
             "ticket_id": self.ticket_id,
         }
 

--- a/backend/ng/support/routes/admin_tickets.py
+++ b/backend/ng/support/routes/admin_tickets.py
@@ -82,25 +82,24 @@ class AdminTicketDetail(Resource):
     @admin_endpoint()
     @load_ticket(LoaderType.PARAM)
     @admin_tickets_namespace.doc(**ADMIN_GET_TICKET_DETAILS_DOC)
-    def get(self, ticket_id):
+    def get(self, ticket_id, current_user):
         """Get any ticket"""
-        result = get_ticket(ticket_id, g.user.id, is_admin=True)
+        result = get_ticket(ticket_id, current_user.id, is_admin=True)
         return success_response(result)
 
     @admin_endpoint(json_required=True, validation_func=validate_ticket_update)
     @load_ticket(LoaderType.PARAM)
     @admin_tickets_namespace.doc(**ADMIN_UPDATE_TICKET_DOC)
-    def patch(self, ticket_id):
+    def patch(self, ticket_id, validated_data, current_user):
         """Update any ticket"""
-        data = g.validated_data
         result = update_ticket(
             ticket_id,
-            g.user.id,
+            current_user.id,
             is_admin=True,
-            subject=data.get("subject"),
-            event_id=data.get("event_id"),
-            team_id=data.get("team_id"),
-            challenge_id=data.get("challenge_id"),
+            subject=validated_data.get("subject"),
+            event_id=validated_data.get("event_id"),
+            team_id=validated_data.get("team_id"),
+            challenge_id=validated_data.get("challenge_id"),
         )
         return success_response(result)
 
@@ -110,10 +109,9 @@ class AdminTicketAssign(Resource):
     @admin_endpoint(json_required=True, validation_func=validate_ticket_assignment)
     @load_ticket(LoaderType.PARAM)
     @admin_tickets_namespace.doc(**ADMIN_ASSIGN_TICKET_DOC)
-    def post(self, ticket_id):
+    def post(self, ticket_id, validated_data, current_user):
         """Assign ticket"""
-        data = g.validated_data
-        result = assign_ticket(ticket_id, data["user_id"], g.user.id)
+        result = assign_ticket(ticket_id, validated_data["user_id"], current_user.id)
         return success_response(result)
 
 
@@ -122,9 +120,9 @@ class AdminTicketUnassign(Resource):
     @admin_endpoint()
     @load_ticket(LoaderType.PARAM)
     @admin_tickets_namespace.doc(**ADMIN_UNASSIGN_TICKET_DOC)
-    def post(self, ticket_id):
+    def post(self, ticket_id, current_user):
         """Unassign ticket"""
-        result = unassign_ticket(ticket_id, g.user.id)
+        result = unassign_ticket(ticket_id, current_user.id)
         return success_response(result)
 
 
@@ -133,9 +131,9 @@ class AdminTicketClose(Resource):
     @admin_endpoint()
     @load_ticket(LoaderType.PARAM)
     @admin_tickets_namespace.doc(**ADMIN_CLOSE_TICKET_DOC)
-    def post(self, ticket_id):
+    def post(self, ticket_id, current_user):
         """Close ticket"""
-        result = close_ticket(ticket_id, g.user.id)
+        result = close_ticket(ticket_id, current_user.id)
         return success_response(result)
 
 
@@ -144,9 +142,9 @@ class AdminTicketReopen(Resource):
     @admin_endpoint()
     @load_ticket(LoaderType.PARAM)
     @admin_tickets_namespace.doc(**ADMIN_REOPEN_TICKET_DOC)
-    def post(self, ticket_id):
+    def post(self, ticket_id, current_user):
         """Reopen ticket"""
-        result = reopen_ticket(ticket_id, g.user.id)
+        result = reopen_ticket(ticket_id, current_user.id)
         return success_response(result)
 
 
@@ -161,10 +159,9 @@ class AdminTagList(Resource):
 
     @admin_endpoint(json_required=True, validation_func=validate_tag_creation)
     @admin_tickets_namespace.doc(**ADMIN_CREATE_TAG_DOC)
-    def post(self):
+    def post(self, validated_data):
         """Create tag"""
-        data = g.validated_data
-        result = create_tag(data["name"], data.get("color"), data.get("description"))
+        result = create_tag(validated_data["name"], validated_data.get("color"), validated_data.get("description"))
         return success_response(result, status_code=201)
 
 
@@ -196,10 +193,9 @@ class AdminTagDetail(Resource):
     @admin_endpoint(json_required=True, validation_func=validate_tag_update)
     @load_ticket_tag(LoaderType.PARAM)
     @admin_tickets_namespace.doc(**ADMIN_UPDATE_TAG_DOC)
-    def patch(self, tag_id):
+    def patch(self, tag_id, validated_data):
         """Update tag"""
-        data = g.validated_data
-        result = update_tag(tag_id, data.get("name"), data.get("color"), data.get("description"))
+        result = update_tag(tag_id, validated_data.get("name"), validated_data.get("color"), validated_data.get("description"))
         return success_response(result)
 
     @admin_endpoint()

--- a/backend/ng/support/routes/user_tickets.py
+++ b/backend/ng/support/routes/user_tickets.py
@@ -46,24 +46,23 @@ user_tickets_namespace = Namespace("tickets", description="support ticket operat
 class TicketList(Resource):
     @user_endpoint()
     @user_tickets_namespace.doc(**GET_MY_TICKETS_DOC)
-    def get(self):
+    def get(self, current_user):
         """Get user tickets"""
         filters = validate_ticket_filters(request.args.to_dict())
-        result = list_tickets(g.user.id, filters.get("status", "all"), is_admin=False)
+        result = list_tickets(current_user.id, filters.get("status", "all"), is_admin=False)
         return success_response(result)
 
     @user_endpoint(json_required=True, validation_func=validate_ticket_creation)
     @user_tickets_namespace.doc(**CREATE_NEW_TICKET_DOC)
-    def post(self):
+    def post(self, validated_data, current_user):
         """Create ticket"""
-        data = g.validated_data
         result = create_ticket(
-            data["subject"],
-            g.user.id,
-            data.get("event_id"),
-            data.get("team_id"),
-            data.get("challenge_id"),
-            data.get("tag_ids"),
+            validated_data["subject"],
+            current_user.id,
+            validated_data.get("event_id"),
+            validated_data.get("team_id"),
+            validated_data.get("challenge_id"),
+            validated_data.get("tag_ids"),
         )
         return success_response(result, status_code=201)
 
@@ -72,18 +71,17 @@ class TicketDetail(Resource):
     @user_endpoint()
     @load_ticket(LoaderType.PARAM)
     @user_tickets_namespace.doc(**GET_MY_TICKET_DETAILS_DOC)
-    def get(self, ticket_id):
+    def get(self, ticket_id, current_user):
         """Get ticket details"""
-        result = get_ticket(ticket_id, g.user.id, is_admin=False)
+        result = get_ticket(ticket_id, current_user.id, is_admin=False)
         return success_response(result)
 
     @user_endpoint(json_required=True, validation_func=validate_ticket_update)
     @load_ticket(LoaderType.PARAM)
     @user_tickets_namespace.doc(**UPDATE_MY_TICKET_DOC)
-    def patch(self, ticket_id):
+    def patch(self, ticket_id, validated_data, current_user):
         """Update ticket"""
-        data = g.validated_data
-        result = update_ticket(ticket_id, g.user.id, is_admin=False, subject=data.get("subject"))
+        result = update_ticket(ticket_id, current_user.id, is_admin=False, subject=validated_data.get("subject"))
         return success_response(result)
 
 
@@ -92,8 +90,7 @@ class TicketMessages(Resource):
     @user_endpoint(json_required=True, validation_func=validate_ticket_message)
     @load_ticket(LoaderType.PARAM)
     @user_tickets_namespace.doc(**CREATE_TICKET_REPLY_DOC)
-    def post(self, ticket_id):
+    def post(self, ticket_id, validated_data, current_user):
         """Reply to ticket"""
-        data = g.validated_data
-        result = create_ticket_message(ticket_id, data["text"], g.user.id, is_admin=False)
+        result = create_ticket_message(ticket_id, validated_data["text"], current_user.id, is_admin=False)
         return success_response(result, status_code=201)

--- a/backend/ng/team/models/TeamMember.py
+++ b/backend/ng/team/models/TeamMember.py
@@ -65,7 +65,7 @@ class TeamMember(db.Model):
             "user_name": user_name,
             "team_id": self.team_id,
             "event_id": self.event_id,
-            "joined_at": self.joined_at.isoformat() if self.joined_at else None,
+            "joined_at": self.joined_at.isoformat() + "Z" if self.joined_at else None,
             "role": self.role.value,
         }
 

--- a/backend/ng/team/routes/admin_routes.py
+++ b/backend/ng/team/routes/admin_routes.py
@@ -30,3 +30,11 @@ class TeamDetail(Resource):
     def get(self, team_id, team):
         """Get a team"""
         return success_response(team)
+
+@teams_admin_namespace.route("/<int:team_id>/members")
+class TeamMembers(Resource):
+    @admin_endpoint()
+    @load_team(source=LoaderType.PARAM)
+    def get(self, team_id, team):
+        """Get all members of a team"""
+        return success_response(team.members)

--- a/backend/ng/user/models/User.py
+++ b/backend/ng/user/models/User.py
@@ -71,6 +71,23 @@ class User(db.Model):
             db.session.commit()
         return user
 
+    def get_events(self):
+        """Get all events the user is registered in.
+
+        Returns:
+            list: List of events the user is registered in
+        """
+        from ...team.models.TeamMember import TeamMember
+        from ...event.models.Event import Event
+
+        # Get all teams the user is a member of
+        team_members = TeamMember.query.filter_by(user_id=self.id).all()
+        event_ids = [tm.event_id for tm in team_members]
+
+        # Get all events for those teams
+        events = Event.query.filter(Event.id.in_(event_ids)).all()
+        return events
+
     @classmethod
     def find_by_id(cls, user_id: int):
         """Find a user by ID.
@@ -82,6 +99,22 @@ class User(db.Model):
             User or None: The user instance if found, None otherwise
         """
         return cls.query.get(user_id)
+    
+    @classmethod
+    def find_or_create_by_ctfd_id(cls, ctfd_user_id: int, commit: bool = True) -> User:
+        """Find or create a user by CTFd user ID.
+
+        Args:
+            ctfd_user_id (int): The CTFd user ID to find or create
+            commit (bool, optional): Whether to commit immediately
+
+        Returns:
+            User: The found or created user instance
+        """
+        user = cls.query.get(ctfd_user_id)
+        if not user:
+            user = cls.create_user(ctfd_user_id, commit=commit)
+        return user
 
     @classmethod
     def get_all_users(cls):

--- a/backend/ng/user/models/User.py
+++ b/backend/ng/user/models/User.py
@@ -87,6 +87,16 @@ class User(db.Model):
         # Get all events for those teams
         events = Event.query.filter(Event.id.in_(event_ids)).all()
         return events
+    
+    def get_teams(self):
+        """Get all teams the user is a member of.
+
+        Returns:
+            list: List of teams the user is a member of
+        """
+
+        # Get all team members for this user
+        return [tm.team for tm in self.team_members]
 
     @classmethod
     def find_by_id(cls, user_id: int):

--- a/backend/ng/user/models/User.py
+++ b/backend/ng/user/models/User.py
@@ -121,7 +121,7 @@ class User(db.Model):
         """Gets all users with their basic details.
         """
 
-        return cls.query().all()
+        return cls.query.all()
 
     @classmethod
     def delete_all(cls) -> None:

--- a/backend/ng/user/routes/admin_routes.py
+++ b/backend/ng/user/routes/admin_routes.py
@@ -14,7 +14,7 @@ from ..models.User import User
 
 users_admin_namespace = Namespace("/admin/users", description="user endpoints for admins")
 
-@users_admin_namespace.route("/users")
+@users_admin_namespace.route("")
 class UsersAdminResource(Resource):
     @admin_endpoint()
     def get(self):

--- a/backend/ng/user/routes/admin_routes.py
+++ b/backend/ng/user/routes/admin_routes.py
@@ -31,13 +31,13 @@ class UsersAdminResource(Resource):
 class UserAdminResource(Resource):
     @admin_endpoint()
     @load_user(source=LoaderType.PARAM, output_key="target_user")
-    def get(self, target_user):
+    def get(self, user_id, target_user):
         """Get a specific user by ID"""
         return success_response(target_user)
 
     @admin_endpoint(json_required=True, validation_func=User.validate)
     @load_user(source=LoaderType.PARAM, output_key="target_user")
-    def put(self, target_user, validated_data):
+    def put(self, user_id, target_user, validated_data):
         """Update a specific user"""
         target_user.update(**validated_data)
         return success_response()
@@ -47,3 +47,21 @@ class UserAdminResource(Resource):
     # def delete(self, target_user):
     #     # TODO implement
     #     return success_response()
+
+@users_admin_namespace.route("/<int:user_id>/events")
+class UserEventsAdminResource(Resource):
+    @admin_endpoint()
+    @load_user(source=LoaderType.PARAM, output_key="target_user")
+    def get(self, user_id, target_user):
+        """Get events for a specific user"""
+        events = target_user.get_events()
+        return success_response(events)
+    
+@users_admin_namespace.route("/<int:user_id>/teams")
+class UserTeamsAdminResource(Resource):
+    @admin_endpoint()
+    @load_user(source=LoaderType.PARAM, output_key="target_user")
+    def get(self, user_id, target_user):
+        """Get teams for a specific user"""
+        teams = target_user.get_teams()
+        return success_response(teams)

--- a/backend/ng/user/routes/user_routes.py
+++ b/backend/ng/user/routes/user_routes.py
@@ -10,17 +10,17 @@ users_user_namespace = Namespace("/users", description="user endpoints for users
 @users_user_namespace.route("/me")
 class UserProfile(Resource):
     @user_endpoint()
-    def get(self, user):
+    def get(self, current_user):
         """Get my user information"""
-        return success_response(user)
+        return success_response(current_user)
 
 @users_user_namespace.route("/me/events")
 class UserEvents(Resource):
     @user_endpoint()
-    def get(self, user):
+    def get(self, current_user):
         """Get my events"""
-        # TODO - implement
-        return success_response([ ])
+        events = current_user.get_events()
+        return success_response(events)
     
 # @users_user_namespace.route("/me/teams")
 # class UserTeams(Resource):

--- a/backend/ng/user/routes/user_routes.py
+++ b/backend/ng/user/routes/user_routes.py
@@ -22,10 +22,10 @@ class UserEvents(Resource):
         events = current_user.get_events()
         return success_response(events)
     
-# @users_user_namespace.route("/me/teams")
-# class UserTeams(Resource):
-#     @user_endpoint()
-#     def get(self, user):
-#         """Get my teams"""
-#         # TODO - implement
-#         return success_response([ ])
+@users_user_namespace.route("/me/teams")
+class UserTeams(Resource):
+    @user_endpoint()
+    def get(self, current_user):
+        """Get my teams"""
+        teams = current_user.get_teams()
+        return success_response(teams)

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -9,41 +9,35 @@ import { APIPREFIX } from './constants';
 async function parseResponseData(res: Response) {
   const data = await res.text();
 
-  let parsedData: {
-    success: false;
-    errors: Record<string, string>;
-  } | {
-    success: true;
-    data: unknown;
-  };
+  let parsedData: unknown;
 
   try {
     // Attempt to parse the response as JSON
-    parsedData = JSON.parse(data);
+    parsedData = JSON.parse(data, (_key, value) => {
+      // if the value is an ISO date, parse it into a Date object
+      if (
+        typeof value === 'string'
+        && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value)
+      ) {
+        return new Date(value);
+      }
+
+      // otherwise, return the value as is
+      return value;
+    });
   } catch {
-    let message = `Failed to parse API response. (${res.status})`;
-
-    // If parsing fails, we likely got an HTML error page from flask.
-    // If we're in debug mode, the plaintext stack trace is included in this page after the closing </html> tag.
-    const stackTrace = data.split('</html>')[1].replace(/<!--/g, '').replace(/-->/g, '').trim();
-
-    // If we got a stack trace, append it to the error message.
-    if (stackTrace) {
-      message += `\n\n${stackTrace}`;
-    }
-
-    throw new Error(message);
+    throw new Error(`Failed to parse API response. (${res.status})`);
   }
 
   // At this point, we should have a success/failure JSON response from the API.
-  if (!parsedData.success) {
-    // If the response indicates failure, throw an error with all errors included in the response.
-    throw new Error(Object.values(parsedData.errors).join(', '));
-  } else {
-    // If the response indicates success, return the data object.
-    // This will end up in the data property when SWR hooks are used.
-    return parsedData.data;
+  if (!res.ok) {
+    // If the response indicates failure, throw it as an error.
+    throw new Error((parsedData as { message: string }).message);
   }
+
+  // If the response indicates success, return the data.
+  // This will end up in the data property when SWR hooks are used.
+  return (parsedData as { data: unknown }).data;
 }
 
 /**

--- a/frontend/src/hooks/events.ts
+++ b/frontend/src/hooks/events.ts
@@ -3,10 +3,18 @@ import { apiMutation } from '@/fetchers';
 import type { Event } from '../types';
 
 /**
- * Retrieves a list of all events.
+ * Retrieves a list of all public and registerable events.
  */
 export function useEvents() {
-  return useSWR<{events: Event[], total_events: number}, Error>('/events');
+  return useSWR<Event[], Error>('/events');
+}
+
+/**
+ * Retrieves a list of *all* events.
+ * This is an admin-only endpoint.
+ */
+export function useAllEvents() {
+  return useSWR<Event[], Error>('/admin/events');
 }
 
 /**
@@ -14,7 +22,37 @@ export function useEvents() {
  * @param eventId The ID of the event to fetch
  */
 export function useEvent(eventId: number | null) {
-  return useSWR<{event: Event}, Error>(eventId ? `/events/${eventId}` : null);
+  return useSWR<Event, Error>(eventId ? `/events/${eventId}` : null);
+}
+
+/**
+ * Retrieves a specific event by its ID for admin purposes.
+ * This is an admin-only endpoint.
+ * @param eventId The ID of the event to fetch
+ */
+export function useAdminEvent(eventId: number | null) {
+  return useSWR<Event, Error>(eventId ? `/admin/events/${eventId}` : null);
+}
+
+/**
+ * Gets the events a user is registered for.
+ * This is an admin-only endpoint.
+ * @param userId The ID of the user to fetch events for, or null if this should not be fetched.
+ * @returns
+ */
+export function useUserEvents(userId: number | null) {
+  return useSWR<Event[], Error>(
+    userId ? `/admin/users/${userId}/events` : null,
+  );
+}
+
+/**
+ * Gets the events the currently signed in user is registered for.
+ */
+export function useMyEvents() {
+  return useSWR<Event[], Error>(
+    '/users/me/events',
+  );
 }
 
 /**
@@ -22,23 +60,23 @@ export function useEvent(eventId: number | null) {
  * @param event The event object to create
  */
 export function createEvent(event: Omit<Event, 'id'>) {
-  apiMutation('/events', event, {
+  apiMutation('/admin/events', event, {
     method : 'POST',
   }).then(() => {
-    mutate('/events');
+    mutate('/admin/events');
   });
 }
 
 /**
  * Updates an existing event.
  * @param eventId ID of the event to update
- * @param updates Patches to apply to the event data
+ * @param updates New event data to apply
  */
-export function updateEvent(eventId: number, updates: Partial<Omit<Event, 'id'>>) {
-  apiMutation(`/events/${eventId}`, updates, {
-    method : 'PATCH',
+export function updateEvent(eventId: number, updated: Omit<Event, 'id'>) {
+  return apiMutation(`/admin/events/${eventId}`, updated, {
+    method : 'PUT',
   }).then(() => {
-    mutate(`/events/${eventId}`);
-    mutate('/events');
+    mutate(`/admin/events/${eventId}`);
+    mutate('/admin/events');
   });
 }

--- a/frontend/src/hooks/team.ts
+++ b/frontend/src/hooks/team.ts
@@ -1,38 +1,54 @@
 import type { Team, TeamMember } from '@/types';
 import useSWR from 'swr';
 
-export function useTeams() {
-  return useSWR<{
-    teams: Team[],
-    total_teams: number
-  }, Error>(
-    '/teams/all',
+/**
+ * Get a list of all teams across the system.
+ * This is an admin-only endpoint.
+ */
+export function useAllTeams() {
+  return useSWR<Team[], Error>(
+    '/admin/teams',
   );
 }
 
-export function useEventTeams(eventId: number | null) {
-  return useSWR<{
-    teams: Team[],
-    total_teams: number,
-    event_name: string
-  }, Error>(
-    eventId ? `/events/${eventId}/teams` : null,
-  );
-}
-
+/**
+ * Get a list of teams the given user is part of.
+ * This is an admin-only endpoint.
+ * @param userId The ID of the user to fetch teams for, or null if this should not be fetched.
+ */
 export function useUserTeams(userId: number | null) {
-  return useSWR<{
-    teams: Team[]
-  }, Error>(
-    userId ? `/users/${userId}/teams` : null,
+  return useSWR<Team[], Error>(
+    userId ? `/admin/users/${userId}/teams` : null,
   );
 }
 
+/**
+ * Get a list of teams the currently signed in user is part of.
+ */
+export function useMyTeams() {
+  return useSWR<Team[], Error>(
+    '/users/me/teams',
+  );
+}
+
+/**
+ * Get information about a specific team by ID.
+ * This is an admin-only endpoint.
+ * @param teamId The ID of the team to fetch, or null if this should not be fetched.
+ */
 export function useTeam(teamId: number | null) {
-  return useSWR<{
-    team: Team,
-    team_members: TeamMember[]
-  }, Error>(
-    teamId ? `/teams/${teamId}` : null,
+  return useSWR<Team, Error>(
+    teamId ? `/admin/teams/${teamId}` : null,
+  );
+}
+
+/**
+ * Get a list of members for a specific team.
+ * This is an admin-only endpoint.
+ * @param teamId The ID of the team to fetch members for, or null if this should not be fetched.
+ */
+export function useTeamMembers(teamId: number | null) {
+  return useSWR<TeamMember[], Error>(
+    teamId ? `/admin/teams/${teamId}/members` : null,
   );
 }

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -1,14 +1,30 @@
 import type { User } from '@/types';
 import useSWR from 'swr';
 
-export function useUsers() {
-  return useSWR<{ users: Array<User>, total: number }, Error>(
-    '/users/all',
+/**
+ * Get a list of all users.
+ * This is an admin-only endpoint.
+ */
+export function useAllUsers() {
+  return useSWR<User[], Error>(
+    '/admin/users',
   );
 }
 
+/**
+ * Get information about a specific user.
+ * This is an admin-only endpoint.
+ * @param userId The ID of the user to fetch, or null if this should not be fetched.
+ */
 export function useUser(userId: number | null) {
-  return useSWR<{ user: User }, Error>(
-    userId ? `/users/${userId}` : null,
+  return useSWR<User, Error>(
+    userId ? `/admin/users/${userId}` : null,
   );
+}
+
+/**
+ * Get the currently signed in user.
+ */
+export function useCurrentUser() {
+  return useSWR<User>('/users/me');
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,38 +1,41 @@
-export type Event = {
+export interface Event {
   id: number;
   name: string;
   description?: string | null;
   max_team_size: number;
-  start_time?: string;
-  end_time?: string;
+  start_time?: Date;
+  end_time?: Date;
   locked: boolean;
-  team_count: number;
-  total_members: number;
-};
+  public: boolean;
+  registration_open: boolean;
+  registration_start_date?: Date;
+  registration_end_date?: Date;
+}
 
-export type User = {
+export interface User {
   id: number;
   name: string;
   email: string;
-  role: 'admin' | 'user';
-  registered_at: string;
-  team_count: number;
+  role: string;
+  registered_at: Date;
 }
 
-export type Team = {
+export interface Team {
   id: number;
   name: string;
   event_id: number;
-  event_name: string;
   member_count: number;
-  max_team_size: number;
-  is_full: boolean;
-  invite_code: string;
   ranked: boolean;
+  locked: boolean;
+  invite_code?: string;
 }
 
-export type TeamMember = {
+export interface TeamMember {
+  id: number;
   user_id: number;
-  joined_at: string;
+  user_name: string;
+  team_id: number;
+  event_id: number;
+  joined_at: Date;
   role: 'member' | 'captain';
 }


### PR DESCRIPTION
Applies the following changes to backend code:
- Use `kwargs` consistently for passing data into route handlers. `g.` is now only used for giving validators access to the incoming JSON data. Some things were previously not working due to this inconsistency.
- Sets up endpoint for getting teams for the current user, and equivalent admin endpoints for getting events/teams of any user
- Adds a route for admins to get the TeamMembers on a given team
- Fixes double `/users` in path for all users endpoint
- Validators now enforce that incoming ISO timestamps are in UTC
- ISO timestamps are explicitly specified as UTC in model `serialize` methods (`Z` is appended onto the naive datetimes)

Additionally, frontend data fetching code has been updated to account for recent backend changes. The frontend will also now automatically parse ISO dates into JS Date objects as part of SWR logic, so that components don't need to do that conversion themselves.

Admin frontend still needs a bit more cleanup before it's ready to merge, but it is now working with these changes applied - don't want these fixes to be blocked by that.

Backend tests that involve timestamp validation will likely need adjustment for the new logic, as the output of  `utc_now` -> `isoformat()` does _not_ explicitly specify UTC. We'll either want to append `Z` or attach tzinfo to the produced datetime.