### PR TITLE
Initial admin pages for events, teams, users

### DIFF
--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -4,7 +4,6 @@ import NotFound from 'components/NotFound';
 import Dashboard from 'routes/dashboard';
 import Notifications from 'routes/notifications';
 import Profile from 'routes/profile';
-import Scoreboard from 'routes/scoreboard';
 
 // Support tickets
 import Support from 'routes/support';
@@ -27,6 +26,7 @@ import AdminTeams from 'routes/admin/teams';
 import AdminEvents from 'routes/admin/events';
 import AdminReports from 'routes/admin/reports';
 import AdminSettings from 'routes/admin/settings';
+import AdminApiTest from 'routes/admin/api-test';
 
 function Routes() {
   const routes = useRoutes([
@@ -45,7 +45,6 @@ function Routes() {
     },
     { path : '/notifications/:idNotif', element : <Notifications /> },
     { path : '/profile', element : <Profile /> },
-    { path : '/scoreboard/:idEvent', element : <Scoreboard /> },
     {
       path : '/support',
       children : [
@@ -69,6 +68,7 @@ function Routes() {
         { path : 'notifications', element : <AdminNotifications /> },
         { path : 'tickets', element : <AdminTickets /> },
         { path : 'settings', element : <AdminSettings /> },
+        { path : 'api-test', element : <AdminApiTest /> },
       ],
     },
 

--- a/frontend/src/components/AdminDataList.tsx
+++ b/frontend/src/components/AdminDataList.tsx
@@ -1,4 +1,5 @@
 import { DataList } from '@radix-ui/themes';
+import RoleBadge from './RoleBadge';
 
 /**
  * Presents key-value pairs of the given object in a formatted list.
@@ -7,11 +8,21 @@ import { DataList } from '@radix-ui/themes';
 export default function AdminDataList({ data }: {data: Record<string, unknown>}) {
   return (
     <DataList.Root>
-      {Object.entries(data).map(([key, value]) => (
+      {Object.entries(data).map(([ key, value ]) => (
         <DataList.Item key={key}>
-          <DataList.Label>{key}</DataList.Label>
+          <DataList.Label>
+            {key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, ' ')}
+          </DataList.Label>
           <DataList.Value className="whitespace-pre-wrap">
-            {value?.toString()}
+            {(() => {
+              if (value instanceof Date) {
+                return value.toLocaleString();
+              }
+              if (key === 'role') {
+                return <RoleBadge value={value!.toString()} />;
+              }
+              return value?.toString();
+            })()}
           </DataList.Value>
         </DataList.Item>
       ))}

--- a/frontend/src/components/AdminDataList.tsx
+++ b/frontend/src/components/AdminDataList.tsx
@@ -1,0 +1,20 @@
+import { DataList } from '@radix-ui/themes';
+
+/**
+ * Presents key-value pairs of the given object in a formatted list.
+ * Useful for displaying/debugging admin data or configuration settings.
+ */
+export default function AdminDataList({ data }: {data: Record<string, unknown>}) {
+  return (
+    <DataList.Root>
+      {Object.entries(data).map(([key, value]) => (
+        <DataList.Item key={key}>
+          <DataList.Label>{key}</DataList.Label>
+          <DataList.Value className="whitespace-pre-wrap">
+            {value?.toString()}
+          </DataList.Value>
+        </DataList.Item>
+      ))}
+    </DataList.Root>
+  );
+}

--- a/frontend/src/components/AdminGrid.tsx
+++ b/frontend/src/components/AdminGrid.tsx
@@ -1,7 +1,8 @@
 import { radixTheme } from '@/grid';
-import { Spinner } from '@radix-ui/themes';
-import type { ColDef } from 'ag-grid-community';
+import { Flex, Spinner } from '@radix-ui/themes';
+import type { ColDef, GridState } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
+import { useState } from 'react';
 import { useSearchParams } from 'react-router';
 
 /**
@@ -10,53 +11,67 @@ import { useSearchParams } from 'react-router';
 export default function AdminGrid<T>({
   rowData,
   columnDefs,
+  initialState,
   loading = false,
+  sidebarComponent : Sidebar,
   getRowId,
 }: {
     rowData: T[];
     columnDefs: ColDef<T>[];
+    initialState?: GridState;
     loading?: boolean;
+    sidebarComponent?: React.ComponentType<{entity: T}>;
     getRowId: (params: { data: T }) => string;
 }) {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [ searchParams, setSearchParams ] = useSearchParams();
   const selectedId = searchParams.get('id');
 
+  const [ selectedData, setSelectedData ] = useState<T | null>(null);
+
   return (
-    <AgGridReact
-      key="admin-grid"
-      theme={radixTheme}
-      rowData={rowData}
-      columnDefs={columnDefs}
-      rowSelection={{
-        mode : 'singleRow',
-        checkboxes : true,
-        enableClickSelection : true,
-      }}
-      loading={loading}
-      loadingOverlayComponent={Spinner}
-      getRowId={getRowId}
-      onRowSelected={(event) => {
-        if (event.node.isSelected() && event.node.id && event.node.id !== selectedId) {
-          setSearchParams((prev) => {
-            prev.set('id', event.node.id!);
-            return prev;
-          });
-        }
-        if (event.api.getSelectedNodes().length === 0) {
-          setSearchParams((prev) => {
-            prev.delete('id');
-            return prev;
-          });
-        }
-      }}
-      onRowDataUpdated={(params) => {
-        // Sync the grid selection with what should be selected as new data is loaded
-        // to ensure that the selected row is selected once it loads in.
-        if (selectedId) {
-          params.api.getRowNode(selectedId)?.setSelected(true);
-        }
-      }}
-      className="w-full h-full grow"
-    />
+    <Flex direction="row" gap="4" className="w-full h-full">
+      <AgGridReact
+        key="admin-grid"
+        theme={radixTheme}
+        rowData={rowData}
+        columnDefs={columnDefs}
+        rowSelection={{
+          mode : 'singleRow',
+          checkboxes : true,
+          enableClickSelection : true,
+        }}
+        loading={loading}
+        loadingOverlayComponent={Spinner}
+        getRowId={getRowId}
+        onRowSelected={(event) => {
+          if (event.node.isSelected() && event.node.id && event.node.id !== selectedId) {
+            setSearchParams((prev) => {
+              prev.set('id', event.node.id!);
+              return prev;
+            });
+            setSelectedData(event.data ?? null);
+          }
+          if (event.api.getSelectedNodes().length === 0) {
+            setSearchParams((prev) => {
+              prev.delete('id');
+              return prev;
+            });
+            setSelectedData(null);
+          }
+        }}
+        onRowDataUpdated={(params) => {
+          if (selectedId) {
+            const node = params.api.getRowNode(selectedId);
+            node?.setSelected(true);
+            setSelectedData(node?.data ?? null);
+          }
+        }}
+        initialState={initialState}
+        className="w-full h-full grow"
+      />
+      {Sidebar && selectedData && (
+        <Sidebar entity={selectedData} key={selectedId} />
+      )}
+    </Flex>
   );
 }

--- a/frontend/src/components/AdminGrid.tsx
+++ b/frontend/src/components/AdminGrid.tsx
@@ -1,0 +1,62 @@
+import { radixTheme } from '@/grid';
+import { Spinner } from '@radix-ui/themes';
+import type { ColDef } from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+import { useSearchParams } from 'react-router';
+
+/**
+ * Wrapper around AgGridReact with common functionality for all admin grids.
+ */
+export default function AdminGrid<T>({
+  rowData,
+  columnDefs,
+  loading = false,
+  getRowId,
+}: {
+    rowData: T[];
+    columnDefs: ColDef<T>[];
+    loading?: boolean;
+    getRowId: (params: { data: T }) => string;
+}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedId = searchParams.get('id');
+
+  return (
+    <AgGridReact
+      key="admin-grid"
+      theme={radixTheme}
+      rowData={rowData}
+      columnDefs={columnDefs}
+      rowSelection={{
+        mode : 'singleRow',
+        checkboxes : true,
+        enableClickSelection : true,
+      }}
+      loading={loading}
+      loadingOverlayComponent={Spinner}
+      getRowId={getRowId}
+      onRowSelected={(event) => {
+        if (event.node.isSelected() && event.node.id && event.node.id !== selectedId) {
+          setSearchParams((prev) => {
+            prev.set('id', event.node.id!);
+            return prev;
+          });
+        }
+        if (event.api.getSelectedNodes().length === 0) {
+          setSearchParams((prev) => {
+            prev.delete('id');
+            return prev;
+          });
+        }
+      }}
+      onRowDataUpdated={(params) => {
+        // Sync the grid selection with what should be selected as new data is loaded
+        // to ensure that the selected row is selected once it loads in.
+        if (selectedId) {
+          params.api.getRowNode(selectedId)?.setSelected(true);
+        }
+      }}
+      className="w-full h-full grow"
+    />
+  );
+}

--- a/frontend/src/components/AdminSidebar.tsx
+++ b/frontend/src/components/AdminSidebar.tsx
@@ -1,7 +1,7 @@
 import { Flex, Heading } from '@radix-ui/themes';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 
-export default function AdminSidebar({ children, title }: {children: React.ReactNode, title: string}) {
+export default function AdminSidebar({ children, title }: {children: ReactNode, title: string}) {
   const headerRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {

--- a/frontend/src/components/AdminSidebar.tsx
+++ b/frontend/src/components/AdminSidebar.tsx
@@ -1,0 +1,19 @@
+import { Flex, Heading } from '@radix-ui/themes';
+import { useEffect, useRef } from 'react';
+
+export default function AdminSidebar({ children, title }: {children: React.ReactNode, title: string}) {
+  const headerRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    // Steal focus when the sidebar is mounted
+    // Allows keyboard navigation without having to tab through the entire table
+    headerRef.current?.focus();
+  }, []);
+
+  return (
+    <Flex direction="column" gap="4" className="basis-1/2 min-w-128 grow-0 shrink-0 overflow-y-auto">
+      <Heading ref={headerRef} tabIndex={-1}>{title}</Heading>
+      {children}
+    </Flex>
+  );
+}

--- a/frontend/src/components/Callouts.tsx
+++ b/frontend/src/components/Callouts.tsx
@@ -1,0 +1,40 @@
+import { Callout } from '@radix-ui/themes';
+import { TbAlertTriangle, TbCancel, TbInfoCircle } from 'react-icons/tb';
+
+export function ErrorCallout({ children }: {children: React.ReactNode}) {
+  return (
+    <Callout.Root variant="surface" color="red">
+      <Callout.Icon>
+        <TbCancel aria-label="Error" />
+      </Callout.Icon>
+      <Callout.Text className="whitespace-pre-wrap">
+        {children}
+      </Callout.Text>
+    </Callout.Root>
+  );
+}
+
+export function WarningCallout({ children }: {children: React.ReactNode}) {
+  return (
+    <Callout.Root variant="surface" color="amber">
+      <Callout.Icon>
+        <TbAlertTriangle aria-label="Warning" />
+      </Callout.Icon>
+      <Callout.Text className="whitespace-pre-wrap">
+        {children}
+      </Callout.Text>
+    </Callout.Root>
+  );
+}
+export function InfoCallout({ children }: {children: React.ReactNode}) {
+  return (
+    <Callout.Root variant="surface" color="jade">
+      <Callout.Icon>
+        <TbInfoCircle aria-label="Info" />
+      </Callout.Icon>
+      <Callout.Text className="whitespace-pre-wrap">
+        {children}
+      </Callout.Text>
+    </Callout.Root>
+  );
+}

--- a/frontend/src/components/Callouts.tsx
+++ b/frontend/src/components/Callouts.tsx
@@ -1,7 +1,8 @@
 import { Callout } from '@radix-ui/themes';
+import type { ReactNode } from 'react';
 import { TbAlertTriangle, TbCancel, TbInfoCircle } from 'react-icons/tb';
 
-export function ErrorCallout({ children }: {children: React.ReactNode}) {
+export function ErrorCallout({ children }: {children: ReactNode}) {
   return (
     <Callout.Root variant="surface" color="red">
       <Callout.Icon>
@@ -14,7 +15,7 @@ export function ErrorCallout({ children }: {children: React.ReactNode}) {
   );
 }
 
-export function WarningCallout({ children }: {children: React.ReactNode}) {
+export function WarningCallout({ children }: {children: ReactNode}) {
   return (
     <Callout.Root variant="surface" color="amber">
       <Callout.Icon>
@@ -26,7 +27,7 @@ export function WarningCallout({ children }: {children: React.ReactNode}) {
     </Callout.Root>
   );
 }
-export function InfoCallout({ children }: {children: React.ReactNode}) {
+export function InfoCallout({ children }: {children: ReactNode}) {
   return (
     <Callout.Root variant="surface" color="jade">
       <Callout.Icon>

--- a/frontend/src/components/Entity.tsx
+++ b/frontend/src/components/Entity.tsx
@@ -1,0 +1,27 @@
+import { Flex, Link as RadixLink } from '@radix-ui/themes';
+import type { IconType } from 'react-icons';
+import { Link } from 'react-router';
+
+/**
+ * Link to an entity (e.g., user, team, event) with an icon and label.
+ */
+export default function Entity({
+  label,
+  to,
+  icon : Icon,
+}: {
+    label: string;
+    to: string;
+    icon: IconType;
+}) {
+  return (
+    <RadixLink asChild>
+      <Link to={to}>
+        <Flex direction="row" align="center" gap="1" className="h-full">
+          <Icon />
+          <span>{label}</span>
+        </Flex>
+      </Link>
+    </RadixLink>
+  );
+}

--- a/frontend/src/components/EventHeader.tsx
+++ b/frontend/src/components/EventHeader.tsx
@@ -1,6 +1,7 @@
 import {
   Heading, Flex, Box, AspectRatio,
 } from '@radix-ui/themes';
+import type { ReactNode } from 'react';
 import EventBadge from './EventBadge';
 import RadixMarkdown from './RadixMarkdown';
 
@@ -13,7 +14,7 @@ export default function EventHeader({
     name: string;
     description: string;
     state: 'upcoming' | 'waiting' | 'live' | 'ended';
-    children?: React.ReactNode;
+    children?: ReactNode;
 }) {
   return (
     <Flex direction="row" gap="6" align="start">

--- a/frontend/src/components/EventHeader.tsx
+++ b/frontend/src/components/EventHeader.tsx
@@ -1,7 +1,8 @@
 import {
-  Heading, Text, Flex, Box, AspectRatio,
+  Heading, Flex, Box, AspectRatio,
 } from '@radix-ui/themes';
 import EventBadge from './EventBadge';
+import RadixMarkdown from './RadixMarkdown';
 
 export default function EventHeader({
   name,
@@ -28,7 +29,9 @@ export default function EventHeader({
         )}
         <Box>
           <Heading size="9">{name}</Heading>
-          <Text as="p" color="gray">{description}</Text>
+          <RadixMarkdown>
+            {description}
+          </RadixMarkdown>
         </Box>
         {children}
       </Flex>

--- a/frontend/src/components/HeaderContainer.tsx
+++ b/frontend/src/components/HeaderContainer.tsx
@@ -1,7 +1,8 @@
 import { Container } from '@radix-ui/themes';
+import type { ReactNode } from 'react';
 
 export default function HeaderContainer({ children = undefined }: {
-  children?: React.ReactNode
+  children?: ReactNode
 }) {
   return (
     children && (

--- a/frontend/src/components/MemberCountBadge.tsx
+++ b/frontend/src/components/MemberCountBadge.tsx
@@ -1,0 +1,38 @@
+import { useEvent } from '@/hooks/events';
+import type { Team } from '@/types';
+import { Badge } from '@radix-ui/themes';
+import type { accentColors } from '@radix-ui/themes/props';
+
+function getBadgeColor(memberCount: number, maxTeamSize: number): (typeof accentColors)[number] {
+  if (memberCount === 0 || memberCount > maxTeamSize) {
+    return 'red'; // Team is empty or is over-filled
+  }
+
+  if (maxTeamSize > 1 && memberCount === 1) {
+    return 'red'; // Single-member team where 2+ members are required
+  }
+
+  if (maxTeamSize > 1 && memberCount === maxTeamSize) {
+    return 'amber'; // Full team
+  }
+
+  return (maxTeamSize === 1) ? 'jade' : 'lime'; // Valid, individual teams get a distinct color
+}
+
+export default function MemberCountBadge({ team }: { team: Team }) {
+  const { data : event, error } = useEvent(team.event_id);
+
+  if (error) {
+    return <Badge variant="soft" color="red">ERR</Badge>;
+  }
+
+  return (
+    event && (
+    <Badge variant="soft" color={getBadgeColor(team.member_count, event.max_team_size)} size="2">
+      {team.member_count}
+      /
+      {event.max_team_size}
+    </Badge>
+    )
+  );
+}

--- a/frontend/src/components/RoleBadge.tsx
+++ b/frontend/src/components/RoleBadge.tsx
@@ -1,0 +1,15 @@
+import { ROLES } from '@/constants';
+import { Badge } from '@radix-ui/themes';
+
+export default function RoleBadge({ value }: { value: string }) {
+  const color = ROLES[value]?.color || 'gray';
+  const Icon = ROLES[value]?.icon;
+
+  return (
+    <Badge color={color} variant="soft">
+      {Icon && <Icon />}
+      {' '}
+      {value.charAt(0).toUpperCase() + value.slice(1)}
+    </Badge>
+  );
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,7 +1,10 @@
+import type { IconType } from 'react-icons';
 import {
-  TbCalendarEvent,
-  TbCube, TbUser, TbUsersGroup,
+  TbCalendarEvent, TbCube,
+  TbLifebuoy, TbStarFilled, TbTools,
+  TbUser, TbUsersGroup,
 } from 'react-icons/tb';
+import type { accentColors } from '@radix-ui/themes/props';
 
 export const ROUTEPREFIX: string = '/hello';
 export const APIPREFIX: string = '/ng';
@@ -11,3 +14,24 @@ export const EventIcon = TbCalendarEvent;
 export const UserIcon = TbUser;
 export const TeamIcon = TbUsersGroup;
 export const ChallengeIcon = TbCube;
+
+// Colors/icons used for displaying User and TeamMember roles.
+// Will fall back to generic gray badges if a role is not specified here.
+export const ROLES: Record<string, { color: (typeof accentColors)[number]; icon: IconType }> = {
+  admin : {
+    color : 'red',
+    icon : TbTools,
+  },
+  support : {
+    color : 'jade',
+    icon : TbLifebuoy,
+  },
+  captain : {
+    color : 'amber',
+    icon : TbStarFilled,
+  },
+  member : {
+    color : 'gray',
+    icon : UserIcon,
+  },
+};

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,2 +1,13 @@
+import {
+  TbCalendarEvent,
+  TbCube, TbUser, TbUsersGroup,
+} from 'react-icons/tb';
+
 export const ROUTEPREFIX: string = '/hello';
 export const APIPREFIX: string = '/ng';
+
+// Semantic icons used throughout the UI, defined here for consistency
+export const EventIcon = TbCalendarEvent;
+export const UserIcon = TbUser;
+export const TeamIcon = TbUsersGroup;
+export const ChallengeIcon = TbCube;

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -31,8 +31,27 @@ async function parseResponseData(res: Response) {
 
   // At this point, we should have a success/failure JSON response from the API.
   if (!res.ok) {
-    // If the response indicates failure, throw it as an error.
-    throw new Error((parsedData as { message: string }).message);
+    // Failures can look a little different depending on where they're coming from.
+    if (
+      typeof parsedData === 'object'
+      && parsedData !== null
+      && 'message' in parsedData
+    ) {
+      // If the response has a message field, use it as the error message.
+      throw new Error((parsedData as { message: string }).message);
+    } else if (
+      typeof parsedData === 'object'
+      && parsedData !== null
+      && 'errors' in parsedData
+    ) {
+      // If the response has an errors field, join the error messages.
+      throw new Error(
+        Object.values((parsedData as { errors: Record<string, string> }).errors).join(', '),
+      );
+    } else {
+      // If no specific error message is provided, throw a generic error.
+      throw new Error(`API request failed with status ${res.status}`);
+    }
   }
 
   // If the response indicates success, return the data.

--- a/frontend/src/grid.ts
+++ b/frontend/src/grid.ts
@@ -8,7 +8,7 @@ ModuleRegistry.registerModules([ AllCommunityModule ]);
 export const radixTheme = themeQuartz
   .withParams(
     {
-      backgroundColor : 'var(--card-background-color)',
+      backgroundColor : 'var(--gray-1)',
       chromeBackgroundColor : 'var(--gray-2)',
       foregroundColor : 'var(--gray-12)',
       accentColor : 'var(--lime-9)',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,7 +35,7 @@ form label[data-invalid="true"] {
 }
 
 form span {
-  @apply text-(--red-11);
+  @apply text-(--red-11) block;
 }
 
 [data-invalid="true"] .rt-TextFieldRoot {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -25,3 +25,19 @@
     --default-font-family: InterVariable, sans-serif;
   }
 }
+
+form label {
+  @apply text-sm text-(--gray-11);
+}
+
+form label[data-invalid="true"] {
+  @apply text-(--red-11);
+}
+
+form span {
+  @apply text-(--red-11);
+}
+
+[data-invalid="true"] .rt-TextFieldRoot {
+  box-shadow: inset 0 0 0 var(--text-field-border-width) var(--red-a7);
+}

--- a/frontend/src/routes/admin/api-test/index.tsx
+++ b/frontend/src/routes/admin/api-test/index.tsx
@@ -1,0 +1,88 @@
+import { apiMutation } from '@/fetchers';
+import {
+  Container, Flex, TextField, TextArea, Button, Select,
+} from '@radix-ui/themes';
+import { ErrorCallout, InfoCallout } from 'components/Callouts';
+import { useState } from 'react';
+
+/**
+ * API test page for development.
+ */
+export default function AdminApiTest() {
+  const [method, setMethod] = useState<'GET' | 'POST' | 'PATCH' | 'DELETE'>('GET');
+  const [route, setRoute] = useState('');
+  const [body, setBody] = useState('');
+  const [response, setResponse] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <Container size="4">
+      <Flex direction="column" gap="4">
+        <Flex direction="row" gap="4">
+          <Select.Root
+            onValueChange={(value) => {
+              setMethod(value as 'GET' | 'POST' | 'PATCH' | 'DELETE');
+            }}
+            defaultValue={method}
+          >
+            <Select.Trigger className="!w-64" />
+            <Select.Content>
+              <Select.Item value="GET">GET</Select.Item>
+              <Select.Item value="POST">POST</Select.Item>
+              <Select.Item value="PATCH">PATCH</Select.Item>
+              <Select.Item value="DELETE">DELETE</Select.Item>
+            </Select.Content>
+          </Select.Root>
+
+          <TextField.Root
+            placeholder="/route"
+            value={route}
+            onChange={(event) => setRoute(event.target.value)}
+            className="grow"
+          >
+            <TextField.Slot>
+              /ng
+            </TextField.Slot>
+          </TextField.Root>
+        </Flex>
+
+        {method !== 'GET' && (
+          <TextArea
+            placeholder="body"
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+          />
+        )}
+
+        <Button onClick={() => {
+          apiMutation(
+            route,
+            (method !== 'GET' && body) ? JSON.parse(body) : undefined,
+            {
+              method,
+            },
+          ).then((r) => {
+            setError(null);
+            setResponse(JSON.stringify(r, null, 2));
+          }).catch((err) => {
+            setResponse(null);
+            setError(err.message);
+          });
+        }}
+        >
+          Send
+        </Button>
+        {response && (
+          <InfoCallout>
+            {response}
+          </InfoCallout>
+        )}
+        {error && (
+          <ErrorCallout>
+            {error}
+          </ErrorCallout>
+        )}
+      </Flex>
+    </Container>
+  );
+}

--- a/frontend/src/routes/admin/api-test/index.tsx
+++ b/frontend/src/routes/admin/api-test/index.tsx
@@ -9,11 +9,11 @@ import { useState } from 'react';
  * API test page for development.
  */
 export default function AdminApiTest() {
-  const [method, setMethod] = useState<'GET' | 'POST' | 'PATCH' | 'DELETE'>('GET');
-  const [route, setRoute] = useState('');
-  const [body, setBody] = useState('');
-  const [response, setResponse] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [ method, setMethod ] = useState<'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'>('GET');
+  const [ route, setRoute ] = useState('');
+  const [ body, setBody ] = useState('');
+  const [ response, setResponse ] = useState<string | null>(null);
+  const [ error, setError ] = useState<string | null>(null);
 
   return (
     <Container size="4">
@@ -21,7 +21,7 @@ export default function AdminApiTest() {
         <Flex direction="row" gap="4">
           <Select.Root
             onValueChange={(value) => {
-              setMethod(value as 'GET' | 'POST' | 'PATCH' | 'DELETE');
+              setMethod(value as 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE');
             }}
             defaultValue={method}
           >
@@ -29,6 +29,7 @@ export default function AdminApiTest() {
             <Select.Content>
               <Select.Item value="GET">GET</Select.Item>
               <Select.Item value="POST">POST</Select.Item>
+              <Select.Item value="PUT">PUT</Select.Item>
               <Select.Item value="PATCH">PATCH</Select.Item>
               <Select.Item value="DELETE">DELETE</Select.Item>
             </Select.Content>

--- a/frontend/src/routes/admin/containers/index.tsx
+++ b/frontend/src/routes/admin/containers/index.tsx
@@ -1,12 +1,8 @@
-import {
-  Callout, Flex, Heading,
-} from '@radix-ui/themes';
-import {
-  TbInfoCircle,
-} from 'react-icons/tb';
+import { Flex, Heading } from '@radix-ui/themes';
 import { AgGridReact } from 'ag-grid-react';
 import type { ColDef } from 'ag-grid-community';
 import { radixTheme } from '@/grid';
+import { InfoCallout } from 'components/Callouts';
 
 /**
  * Admin page to manage challenge networks/containers.
@@ -52,47 +48,18 @@ export default function AdminContainers() {
       />
       <Flex direction="column" gap="4" className="grow basis-1/3">
         <Heading>Services</Heading>
-        <Callout.Root variant="surface" color="jade">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            List of containers that are part of the challenge
-            with statuses, resource usage, and actions.
-          </Callout.Text>
-        </Callout.Root>
+        <InfoCallout>List of containers that are part of the challenge with statuses, resource usage, and actions.</InfoCallout>
 
         <Heading>Network</Heading>
-        <Callout.Root variant="surface" color="jade">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Information about the challenge container network, like address space.
-          </Callout.Text>
-        </Callout.Root>
+        <InfoCallout>Information about the challenge container network, like address space.</InfoCallout>
 
         <Heading>
           Variables
         </Heading>
-        <Callout.Root variant="surface" color="jade">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Faker-generated challenge variables for this challenge instance.
-          </Callout.Text>
-        </Callout.Root>
+        <InfoCallout>Faker-generated challenge variables for this challenge instance.</InfoCallout>
 
         <Heading>Workspaces</Heading>
-        <Callout.Root variant="surface" color="jade">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Links to user workspaces attached to this container network, if any.
-          </Callout.Text>
-        </Callout.Root>
+        <InfoCallout>Links to user workspaces attached to this container network, if any.</InfoCallout>
       </Flex>
     </Flex>
   );

--- a/frontend/src/routes/admin/dashboard/index.tsx
+++ b/frontend/src/routes/admin/dashboard/index.tsx
@@ -1,9 +1,5 @@
-import {
-  Callout, Flex,
-} from '@radix-ui/themes';
-import {
-  TbAlertTriangle,
-} from 'react-icons/tb';
+import { Flex } from '@radix-ui/themes';
+import { WarningCallout } from 'components/Callouts';
 import AdminEventCard from './AdminEventCard';
 import AdminProvisionerCard from './AdminProvisionerCard';
 import AdminActivityCard from './AdminActivityCard';
@@ -15,20 +11,9 @@ import AdminOverviewCard from './AdminOverviewCard';
 export default function AdminDashboard() {
   return (
     <>
-      <Callout.Root
-        color="amber"
-        variant="surface"
-        mb="4"
-      >
-        <Callout.Icon>
-          <TbAlertTriangle />
-        </Callout.Icon>
-        <Callout.Text>
-          Something bad happened!
-        </Callout.Text>
-      </Callout.Root>
+      <WarningCallout>Something bad happened!</WarningCallout>
 
-      <Flex direction={{ initial : 'column', lg : 'row' }} gap="4">
+      <Flex direction={{ initial : 'column', lg : 'row' }} gap="4" mt="4">
         <Flex direction="column" gap="4" className="flex-grow basis-1/2 h-full">
           <AdminOverviewCard />
           <AdminActivityCard />

--- a/frontend/src/routes/admin/events/AdminChallengeCard.tsx
+++ b/frontend/src/routes/admin/events/AdminChallengeCard.tsx
@@ -1,0 +1,12 @@
+import { Card, Heading, Text } from '@radix-ui/themes';
+
+export default function AdminChallengeCard() {
+  return (
+    <Card>
+      <Heading size="3">Challenge</Heading>
+      <Text color="gray">
+        This is a placeholder for the challenge card. It will display challenge details and actions.
+      </Text>
+    </Card>
+  );
+}

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -164,6 +164,7 @@ export default function EventDataForm({
             type="number"
             defaultValue={initial?.max_team_size.toString() || '1'}
             min={1}
+            max={8}
             required
           />
         </Form.Control>

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -1,0 +1,229 @@
+import type { Event } from '@/types';
+import {
+  Button, Checkbox, Flex, TextArea, TextField,
+} from '@radix-ui/themes';
+import { ErrorCallout } from 'components/Callouts';
+import { Form } from 'radix-ui';
+import { useState } from 'react';
+
+function adjustDateForInput(date: Date | null): string {
+  // Adjust the date to be in the format required by datetime-local input
+  if (date === null) return '';
+  const dateObj = new Date(date);
+  const offset = dateObj.getTimezoneOffset();
+  const localDate = new Date(dateObj.getTime() - (offset * 60 * 1000));
+  return localDate.toISOString().slice(0, 16);
+}
+
+export default function EventDataForm({
+  initial,
+  onSubmit,
+  error,
+}: {
+  initial?: Omit<Event, 'id'>,
+  onSubmit?: (event: Omit<Event, 'id'>) => void,
+  error?: string
+}) {
+  // allow reset/submit only if the form has been touched
+  // these buttons being enabled indicates unsaved changes
+  const [ canReset, setCanReset ] = useState(false);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setCanReset(false);
+    const formData = new FormData(e.target as HTMLFormElement);
+
+    const {
+      name,
+      description,
+      start_time : startTime,
+      end_time : endTime,
+      locked : isLocked,
+      public : isPublic,
+      max_team_size : maxTeamSize,
+      registration_open : isOpen,
+      registration_start_date : openTime,
+      registration_end_date : closeTime,
+    } = Object.fromEntries(formData.entries());
+
+    console.log(Object.fromEntries(formData.entries()));
+
+    return onSubmit?.({
+      name : name as string,
+      description : description as string,
+      start_time : new Date(startTime as string),
+      end_time : new Date(endTime as string),
+      locked : isLocked === 'on',
+      public : isPublic === 'on',
+      max_team_size : Number(maxTeamSize),
+      registration_open : isOpen === 'on',
+      registration_start_date : new Date(openTime as string),
+      registration_end_date : new Date(closeTime as string),
+    });
+  }
+
+  return (
+
+    <Form.Root
+      className="flex flex-col gap-2"
+      onSubmitCapture={(e) => handleSubmit(e)}
+      onChange={() => {
+        setCanReset(true);
+      }}
+      onReset={() => {
+        setCanReset(false);
+      }}
+    >
+      { error && (
+        <ErrorCallout>
+          {error}
+        </ErrorCallout>
+      ) }
+      <Form.Field name="Name">
+        <Form.Label>Name</Form.Label>
+        <Form.Control asChild>
+          <TextField.Root
+            name="name"
+            defaultValue={initial?.name || ''}
+            placeholder="Event Name"
+            required
+          />
+        </Form.Control>
+        <Form.Message match="valueMissing">
+          Event name is required.
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Field name="description">
+        <Form.Label>Description</Form.Label>
+        <Form.Control asChild>
+          <TextArea
+            defaultValue={initial?.description || ''}
+            placeholder="Event Description"
+            rows={4}
+            resize="vertical"
+          />
+        </Form.Control>
+      </Form.Field>
+
+      <Flex direction="row" gap="2" className="*:grow *:basis-0">
+        <Form.Field name="registration_start_date">
+          <Form.Label>Registration Opens</Form.Label>
+          <Form.Control asChild>
+            <TextField.Root
+              type="datetime-local"
+              onChange={(e) => { e.target.form?.reportValidity(); }}
+              defaultValue={adjustDateForInput(initial?.registration_start_date || null)}
+            />
+          </Form.Control>
+          <Form.Message match="badInput" />
+        </Form.Field>
+        <Form.Field name="registration_end_date">
+          <Form.Label>Registration Closes</Form.Label>
+          <Form.Control asChild>
+            <TextField.Root
+              type="datetime-local"
+              onChange={(e) => { e.target.form?.reportValidity(); }}
+              defaultValue={adjustDateForInput(initial?.registration_end_date || null)}
+            />
+          </Form.Control>
+          <Form.Message match="badInput" />
+        </Form.Field>
+      </Flex>
+
+      <Flex direction="row" gap="2" className="*:grow *:basis-0">
+        <Form.Field name="start_time">
+          <Form.Label>Event Starts</Form.Label>
+          <Form.Control asChild>
+            <TextField.Root
+              type="datetime-local"
+              defaultValue={adjustDateForInput(initial?.start_time || null)}
+              required
+            />
+          </Form.Control>
+          <Form.Message match="valueMissing" />
+          <Form.Message match="badInput" />
+        </Form.Field>
+
+        <Form.Field name="end_time">
+          <Form.Label>Event Ends</Form.Label>
+          <Form.Control asChild>
+            <TextField.Root
+              type="datetime-local"
+              name="end_time"
+              defaultValue={adjustDateForInput(initial?.end_time || null)}
+              required
+            />
+          </Form.Control>
+          <Form.Message match="valueMissing" />
+          <Form.Message match="badInput" />
+        </Form.Field>
+      </Flex>
+      <Form.Field name="max_team_size">
+        <Form.Label>Max Team Size</Form.Label>
+        <Form.Control asChild>
+          <TextField.Root
+            type="number"
+            defaultValue={initial?.max_team_size.toString() || '1'}
+            min={1}
+            required
+          />
+        </Form.Control>
+        <Form.Message match="valueMissing" />
+        <Form.Message match="rangeOverflow" />
+        <Form.Message match="rangeUnderflow" />
+
+      </Form.Field>
+
+      <Flex direction="row" gap="2" className="*:grow *:basis-0 my-1" wrap="wrap">
+        <Form.Field name="public" className="flex gap-1">
+          <Form.Control asChild>
+            <Checkbox
+              defaultChecked={initial?.public}
+              size="3"
+            />
+          </Form.Control>
+          <Form.Label>Public</Form.Label>
+        </Form.Field>
+        <Form.Field name="locked" className="flex gap-1">
+          <Form.Control asChild>
+            <Checkbox defaultChecked={initial?.locked} size="3" />
+          </Form.Control>
+          <Form.Label>Locked</Form.Label>
+
+        </Form.Field>
+        <Form.Field name="registration_open" className="flex gap-1">
+          <Form.Control asChild>
+            <Checkbox
+              defaultChecked={initial?.registration_open}
+              size="3"
+            />
+          </Form.Control>
+          <Form.Label>Registration Open</Form.Label>
+        </Form.Field>
+
+      </Flex>
+
+      <Flex direction="row-reverse" gap="2">
+        <Form.Submit asChild>
+          <Button
+            type="submit"
+            disabled={!canReset}
+          >
+            {initial ? 'Save' : 'Create '}
+          </Button>
+        </Form.Submit>
+
+        <Button
+          variant="soft"
+          type="reset"
+          color="gray"
+          disabled={!canReset}
+        >
+          {initial ? 'Revert' : 'Clear'}
+        </Button>
+
+      </Flex>
+    </Form.Root>
+  );
+}

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -46,8 +46,6 @@ export default function EventDataForm({
       registration_end_date : closeTime,
     } = Object.fromEntries(formData.entries());
 
-    console.log(Object.fromEntries(formData.entries()));
-
     return onSubmit?.({
       name : name as string,
       description : description as string,
@@ -63,7 +61,6 @@ export default function EventDataForm({
   }
 
   return (
-
     <Form.Root
       className="flex flex-col gap-2"
       onSubmitCapture={(e) => handleSubmit(e)}
@@ -159,6 +156,7 @@ export default function EventDataForm({
           <Form.Message match="badInput" />
         </Form.Field>
       </Flex>
+
       <Form.Field name="max_team_size">
         <Form.Label>Max Team Size</Form.Label>
         <Form.Control asChild>
@@ -172,7 +170,6 @@ export default function EventDataForm({
         <Form.Message match="valueMissing" />
         <Form.Message match="rangeOverflow" />
         <Form.Message match="rangeUnderflow" />
-
       </Form.Field>
 
       <Flex direction="row" gap="2" className="*:grow *:basis-0 my-1" wrap="wrap">
@@ -201,7 +198,6 @@ export default function EventDataForm({
           </Form.Control>
           <Form.Label>Registration Open</Form.Label>
         </Form.Field>
-
       </Flex>
 
       <Flex direction="row-reverse" gap="2">
@@ -213,7 +209,6 @@ export default function EventDataForm({
             {initial ? 'Save' : 'Create '}
           </Button>
         </Form.Submit>
-
         <Button
           variant="soft"
           type="reset"
@@ -222,7 +217,6 @@ export default function EventDataForm({
         >
           {initial ? 'Revert' : 'Clear'}
         </Button>
-
       </Flex>
     </Form.Root>
   );

--- a/frontend/src/routes/admin/events/EventSidebar.tsx
+++ b/frontend/src/routes/admin/events/EventSidebar.tsx
@@ -1,55 +1,52 @@
-import { useEvent } from '@/hooks/events';
+import { updateEvent } from '@/hooks/events';
 import {
-  Flex, Heading, Spinner,
+  Button,
+  Flex, Heading,
 } from '@radix-ui/themes';
-import { Link, useSearchParams } from 'react-router';
-import Statistic from 'components/Statistic';
-import { ErrorCallout } from 'components/Callouts';
-import { EventIcon } from '@/constants';
-import AdminDataList from 'components/AdminDataList';
+import { Link } from 'react-router';
+import AdminSidebar from 'components/AdminSidebar';
+import type { Event } from '@/types';
+import { useState } from 'react';
+import { TeamIcon, UserIcon } from '@/constants';
 import AdminChallengeCard from './AdminChallengeCard';
+import EventDataForm from './EventDataForm';
 
-export default function EventSidebar() {
-  const [searchParams] = useSearchParams();
-
-  const eventId = Number(searchParams.get('id'));
-  const { data, error, isLoading } = useEvent(eventId);
-
-  if (isLoading) {
-    return (
-      <Spinner />
-    );
-  }
-
-  if (error) {
-    return (
-      <ErrorCallout>{error.message}</ErrorCallout>
-    );
-  }
-
-  if (!eventId || !data) {
-    return (
-      <Flex direction="column" align="center" justify="center" className="w-full h-full">
-        <EventIcon className="text-(--gray-9) text-9xl" />
-        <Heading className="text-(--gray-9)" size="4">
-          Select an event to view details.
-        </Heading>
-      </Flex>
-    );
-  }
-
+export default function EventSidebar({ entity }: { entity: Event }) {
+  const [ formError, setFormError ] = useState<string|undefined>();
   return (
-    <>
-      <Heading>{data.event.name}</Heading>
+    <AdminSidebar title="Event Details">
 
-      <AdminDataList data={data.event} />
+      <EventDataForm
+        initial={entity}
+        onSubmit={
+          (e) => {
+            updateEvent(entity.id, e).then(() => {
+              setFormError(undefined);
+            }).catch((err) => {
+              setFormError(err.message);
+            });
+          }
+        }
+        error={formError}
+      />
 
-      <Flex direction="row" gap="4">
-        <Link to={`/admin/teams?event=${data.event.id}`}><Statistic value={data.event.team_count} label="Teams" /></Link>
-        <Statistic value={data.event.total_members} label="Users" />
+      <Flex direction="row" gap="4" className="*:!grow w-full">
+        <Button variant="soft" asChild>
+          <Link to={`/admin/teams?event=${entity.id}`}>
+            <TeamIcon />
+            Teams
+          </Link>
+        </Button>
+        <Button variant="soft" asChild>
+          <Link to={`/admin/users?event=${entity.id}`}>
+            <UserIcon />
+            Users
+          </Link>
+        </Button>
       </Flex>
       <Heading>Challenges</Heading>
       <AdminChallengeCard />
-    </>
+
+    </AdminSidebar>
   );
 }

--- a/frontend/src/routes/admin/events/EventSidebar.tsx
+++ b/frontend/src/routes/admin/events/EventSidebar.tsx
@@ -1,0 +1,55 @@
+import { useEvent } from '@/hooks/events';
+import {
+  Flex, Heading, Spinner,
+} from '@radix-ui/themes';
+import { Link, useSearchParams } from 'react-router';
+import Statistic from 'components/Statistic';
+import { ErrorCallout } from 'components/Callouts';
+import { EventIcon } from '@/constants';
+import AdminDataList from 'components/AdminDataList';
+import AdminChallengeCard from './AdminChallengeCard';
+
+export default function EventSidebar() {
+  const [searchParams] = useSearchParams();
+
+  const eventId = Number(searchParams.get('id'));
+  const { data, error, isLoading } = useEvent(eventId);
+
+  if (isLoading) {
+    return (
+      <Spinner />
+    );
+  }
+
+  if (error) {
+    return (
+      <ErrorCallout>{error.message}</ErrorCallout>
+    );
+  }
+
+  if (!eventId || !data) {
+    return (
+      <Flex direction="column" align="center" justify="center" className="w-full h-full">
+        <EventIcon className="text-(--gray-9) text-9xl" />
+        <Heading className="text-(--gray-9)" size="4">
+          Select an event to view details.
+        </Heading>
+      </Flex>
+    );
+  }
+
+  return (
+    <>
+      <Heading>{data.event.name}</Heading>
+
+      <AdminDataList data={data.event} />
+
+      <Flex direction="row" gap="4">
+        <Link to={`/admin/teams?event=${data.event.id}`}><Statistic value={data.event.team_count} label="Teams" /></Link>
+        <Statistic value={data.event.total_members} label="Users" />
+      </Flex>
+      <Heading>Challenges</Heading>
+      <AdminChallengeCard />
+    </>
+  );
+}

--- a/frontend/src/routes/admin/events/index.tsx
+++ b/frontend/src/routes/admin/events/index.tsx
@@ -1,64 +1,119 @@
 import {
-  Button, Flex,
+  Button, Dialog, Flex,
 } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
 import { TbPlus } from 'react-icons/tb';
-import { apiMutation } from '@/fetchers';
-import { useEvents } from '@/hooks/events';
-import { useSearchParams } from 'react-router';
+import { createEvent, useAllEvents } from '@/hooks/events';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
+import { useState } from 'react';
 import EventSidebar from './EventSidebar';
+import EventDataForm from './EventDataForm';
 
 /**
  * Event management page for admins, will also include challenge YAML uploading.
  */
 export default function AdminEvents() {
-  const { data, error, isLoading } = useEvents();
-  const [ searchParams ] = useSearchParams();
-
-  const eventId = searchParams.get('id');
-
-  const rowData = data?.events ?? [];
+  const { data, error, isLoading } = useAllEvents();
+  const rowData = data ?? [];
 
   const colDefs: ColDef<typeof rowData[number]>[] = [
-    { field : 'id', width : 100, headerName : 'ID' },
-    { field : 'name', width : 250 },
-    { field : 'description', flex : 1 },
     {
-      field : 'start_time', headerName : 'Start Time', sort : 'desc', valueFormatter : (params) => params.value && new Date(params.value).toLocaleString(),
+      field : 'name', width : 250, filter : true, floatingFilter : true,
     },
     {
-      field : 'end_time', headerName : 'End Time', valueFormatter : (params) => params.value && new Date(params.value).toLocaleString(),
+      field : 'description', width : 300, filter : true, floatingFilter : true,
     },
     {
-      field : 'locked', width : 100,
+      field : 'start_time',
+      headerName : 'Start Time',
+      sort : 'desc',
+      valueFormatter : (params) => params.value && params.value.toLocaleString(),
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'end_time',
+      headerName : 'End Time',
+      valueFormatter : (params) => params.value && params.value.toLocaleString(),
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'registration_start_date',
+      headerName : 'Registration Start',
+      valueFormatter : (params) => params.value && params.value.toLocaleString(),
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'registration_end_date',
+      headerName : 'Registration End',
+      valueFormatter : (params) => params.value && params.value.toLocaleString(),
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'max_team_size',
+      width : 150,
+      headerName : 'Max Team Size',
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'public',
+      width : 100,
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'registration_open',
+      width : 100,
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'locked',
+      width : 100,
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'id',
+      width : 100,
+      headerName : 'ID',
+      filter : true,
+      floatingFilter : true,
     },
   ];
 
+  const [ open, setOpen ] = useState(false);
+
   if (error) {
-    return (<ErrorCallout>{error.message}</ErrorCallout>);
+    return <ErrorCallout>{error.message}</ErrorCallout>;
   }
 
   return (
     <Flex direction="column" gap="4" className="h-full w-full">
       <Flex direction="row" gap="4" className="shrink-0">
-        <Button onClick={() => {
-          apiMutation('/events', {
-            name : 'New Event',
-            description : 'Event description',
-            start_time : '2025-07-04T12:00:00',
-            end_time : '2025-07-04T14:00:00',
-            max_team_size : 5,
-            locked : false,
-          }, {
-            method : 'POST',
-          });
-        }}
-        >
-          <TbPlus />
-          Create Event
-        </Button>
+        <Dialog.Root open={open} onOpenChange={setOpen}>
+          <Dialog.Trigger>
+            <Button variant="solid">
+              <TbPlus />
+              Create Event
+            </Button>
+          </Dialog.Trigger>
+          <Dialog.Content>
+            <Dialog.Title>Create New Event</Dialog.Title>
+            <EventDataForm onSubmit={(d) => {
+              createEvent(d);
+
+              // close the dialog after submission
+              setOpen(false);
+            }}
+            />
+          </Dialog.Content>
+        </Dialog.Root>
       </Flex>
       <Flex direction="row" gap="4" className="grow">
         <AdminGrid
@@ -66,10 +121,8 @@ export default function AdminEvents() {
           columnDefs={colDefs}
           loading={isLoading}
           getRowId={(params) => params.data.id.toString()}
+          sidebarComponent={EventSidebar}
         />
-        <Flex direction="column" gap="4" className="w-128 grow-0 shrink-0 overflow-y-auto">
-          <EventSidebar key={eventId} />
-        </Flex>
       </Flex>
     </Flex>
   );

--- a/frontend/src/routes/admin/events/index.tsx
+++ b/frontend/src/routes/admin/events/index.tsx
@@ -1,63 +1,75 @@
-import { Callout, Flex, Heading } from '@radix-ui/themes';
+import {
+  Button, Flex,
+} from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
-import { AgGridReact } from 'ag-grid-react';
-import { TbInfoCircle } from 'react-icons/tb';
-import { radixTheme } from '@/grid';
+import { TbPlus } from 'react-icons/tb';
+import { apiMutation } from '@/fetchers';
+import { useEvents } from '@/hooks/events';
+import { useSearchParams } from 'react-router';
+import AdminGrid from 'components/AdminGrid';
+import { ErrorCallout } from 'components/Callouts';
+import EventSidebar from './EventSidebar';
 
 /**
  * Event management page for admins, will also include challenge YAML uploading.
  */
 export default function AdminEvents() {
-  const rowData = [
+  const { data, error, isLoading } = useEvents();
+  const [ searchParams ] = useSearchParams();
+
+  const eventId = searchParams.get('id');
+
+  const rowData = data?.events ?? [];
+
+  const colDefs: ColDef<typeof rowData[number]>[] = [
+    { field : 'id', width : 100, headerName : 'ID' },
+    { field : 'name', width : 250 },
+    { field : 'description', flex : 1 },
     {
-      name : 'PC7 Teams Round 1', start : 'date', end : 'date', teamSize : '5', registeredTeams : '10', registeredUsers : '50',
+      field : 'start_time', headerName : 'Start Time', sort : 'desc', valueFormatter : (params) => params.value && new Date(params.value).toLocaleString(),
+    },
+    {
+      field : 'end_time', headerName : 'End Time', valueFormatter : (params) => params.value && new Date(params.value).toLocaleString(),
+    },
+    {
+      field : 'locked', width : 100,
     },
   ];
 
-  const colDefs: ColDef<typeof rowData[number]>[] = [
-    { field : 'name' },
-    { field : 'start' },
-    { field : 'end' },
-    { field : 'teamSize', headerName : 'Max Team Size' },
-    { field : 'registeredTeams' },
-    { field : 'registeredUsers' },
-  ];
+  if (error) {
+    return (<ErrorCallout>{error.message}</ErrorCallout>);
+  }
 
   return (
-    <Flex direction="row" gap="4" className="h-full w-full">
-      <AgGridReact
-        className="grow basis-2/3"
-        theme={radixTheme}
-        rowData={rowData}
-        columnDefs={colDefs}
-        gridOptions={{
-          rowSelection : {
-            mode : 'singleRow',
-            checkboxes : false,
-            enableClickSelection : true,
-          },
+    <Flex direction="column" gap="4" className="h-full w-full">
+      <Flex direction="row" gap="4" className="shrink-0">
+        <Button onClick={() => {
+          apiMutation('/events', {
+            name : 'New Event',
+            description : 'Event description',
+            start_time : '2025-07-04T12:00:00',
+            end_time : '2025-07-04T14:00:00',
+            max_team_size : 5,
+            locked : false,
+          }, {
+            method : 'POST',
+          });
         }}
-      />
-      <Flex direction="column" gap="4" className="grow basis-1/3">
-        <Heading>Information</Heading>
-        <Callout.Root variant="surface" color="jade">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Event info form. Configure name, description, start/end, team size, time limit, etc.
-          </Callout.Text>
-        </Callout.Root>
-
-        <Heading>Challenges</Heading>
-        <Callout.Root variant="surface" color="jade">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Table of challenges associated with the event, with yaml dropzone/upload.
-          </Callout.Text>
-        </Callout.Root>
+        >
+          <TbPlus />
+          Create Event
+        </Button>
+      </Flex>
+      <Flex direction="row" gap="4" className="grow">
+        <AdminGrid
+          rowData={rowData}
+          columnDefs={colDefs}
+          loading={isLoading}
+          getRowId={(params) => params.data.id.toString()}
+        />
+        <Flex direction="column" gap="4" className="w-128 grow-0 shrink-0 overflow-y-auto">
+          <EventSidebar key={eventId} />
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/frontend/src/routes/admin/layout.tsx
+++ b/frontend/src/routes/admin/layout.tsx
@@ -1,9 +1,10 @@
+import { EventIcon, TeamIcon, UserIcon } from '@/constants';
 import { Card, Flex } from '@radix-ui/themes';
 import { NavigationMenu } from 'radix-ui';
 import type { IconType } from 'react-icons';
 import {
-  TbBell, TbCalendarEvent, TbChartPie, TbLayoutDashboard, TbMessage,
-  TbPackages, TbSettings, TbUser, TbUsersGroup,
+  TbBell, TbChartPie, TbLayoutDashboard, TbMessage,
+  TbPackages, TbSettings,
 } from 'react-icons/tb';
 import { NavLink, Outlet } from 'react-router';
 
@@ -25,8 +26,12 @@ function NavItem({
         <NavLink
           to={to}
           end
-          className="flex items-center gap-2 [&[aria-current='page']]:bg-[var(--lime-9)]
-            [&[aria-current='page']]:text-[var(--accent-contrast)] p-2 rounded overflow-hidden"
+          className="
+            flex items-center gap-2
+            [&[aria-current='page']]:bg-[var(--lime-9)]
+            [&[aria-current='page']]:text-[var(--accent-contrast)]
+            p-2 rounded overflow-hidden
+          "
         >
           {Icon && <Icon className="text-xl shrink-0" />}
           <span>{label}</span>
@@ -50,10 +55,10 @@ export default function AdminLayout() {
             <NavigationMenu.List>
               <NavItem to="/admin" label="Dashboard" icon={TbLayoutDashboard} />
               <NavItem to="/admin/reports" label="Reports" icon={TbChartPie} />
-              <NavItem to="/admin/events" label="Events" icon={TbCalendarEvent} />
+              <NavItem to="/admin/events" label="Events" icon={EventIcon} />
               <NavItem to="/admin/containers" label="Containers" icon={TbPackages} />
-              <NavItem to="/admin/users" label="Users" icon={TbUser} />
-              <NavItem to="/admin/teams" label="Teams" icon={TbUsersGroup} />
+              <NavItem to="/admin/users" label="Users" icon={UserIcon} />
+              <NavItem to="/admin/teams" label="Teams" icon={TeamIcon} />
               <NavItem to="/admin/notifications" label="Notifications" icon={TbBell} />
               <NavItem to="/admin/tickets" label="Tickets" icon={TbMessage} />
               <NavItem to="/admin/settings" label="Settings" icon={TbSettings} />

--- a/frontend/src/routes/admin/layout.tsx
+++ b/frontend/src/routes/admin/layout.tsx
@@ -3,8 +3,7 @@ import { Card, Flex } from '@radix-ui/themes';
 import { NavigationMenu } from 'radix-ui';
 import type { IconType } from 'react-icons';
 import {
-  TbBell, TbChartPie, TbLayoutDashboard, TbMessage,
-  TbPackages, TbSettings,
+  TbBell, TbBraces, TbChartPie, TbLayoutDashboard, TbMessage, TbPackages, TbSettings,
 } from 'react-icons/tb';
 import { NavLink, Outlet } from 'react-router';
 
@@ -62,6 +61,7 @@ export default function AdminLayout() {
               <NavItem to="/admin/notifications" label="Notifications" icon={TbBell} />
               <NavItem to="/admin/tickets" label="Tickets" icon={TbMessage} />
               <NavItem to="/admin/settings" label="Settings" icon={TbSettings} />
+              <NavItem to="/admin/api-test" label="API Test" icon={TbBraces} />
             </NavigationMenu.List>
           </NavigationMenu.Root>
         </Card>

--- a/frontend/src/routes/admin/reports/index.tsx
+++ b/frontend/src/routes/admin/reports/index.tsx
@@ -1,7 +1,7 @@
 import {
-  Callout, Card, Grid, Heading,
+  Card, Grid, Heading,
 } from '@radix-ui/themes';
-import { TbInfoCircle } from 'react-icons/tb';
+import { InfoCallout } from 'components/Callouts';
 
 /**
  * Provides admins with more detailed reports, along with CSV exports.
@@ -11,59 +11,19 @@ export default function AdminReports() {
     <Grid columns={{ initial : '1', md : '2', xl : '3' }} gap="4">
       <Card>
         <Heading>Report 1</Heading>
-        <Callout.Root
-          color="jade"
-          variant="surface"
-        >
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Graph or table showing at-a-glance data, with option to download.
-          </Callout.Text>
-        </Callout.Root>
+        <InfoCallout>Graph or table showing at-a-glance data, with option to download.</InfoCallout>
       </Card>
       <Card>
         <Heading>Report 2</Heading>
-        <Callout.Root
-          color="jade"
-          variant="surface"
-        >
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Graph or table showing at-a-glance data, with option to download.
-          </Callout.Text>
-        </Callout.Root>
+        <InfoCallout>Graph or table showing at-a-glance data, with option to download.</InfoCallout>
       </Card>
       <Card>
         <Heading>Report 3</Heading>
-        <Callout.Root
-          color="jade"
-          variant="surface"
-        >
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Graph or table showing at-a-glance data, with option to download.
-          </Callout.Text>
-        </Callout.Root>
+        <InfoCallout>Graph or table showing at-a-glance data, with option to download.</InfoCallout>
       </Card>
       <Card>
         <Heading>Report 4</Heading>
-        <Callout.Root
-          color="jade"
-          variant="surface"
-        >
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Graph or table showing at-a-glance data, with option to download.
-          </Callout.Text>
-        </Callout.Root>
+        <InfoCallout>Graph or table showing at-a-glance data, with option to download.</InfoCallout>
       </Card>
     </Grid>
   );

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -1,87 +1,81 @@
 import {
-  Flex, Heading, Spinner, Table,
+  Button, Flex, Heading, Table,
 } from '@radix-ui/themes';
 import {
+  TbDoorExit, TbPlusMinus, TbStar,
   TbUser,
-  TbUsersGroup,
 } from 'react-icons/tb';
-import { useSearchParams } from 'react-router';
-import { useTeam } from '@/hooks/team';
-import { useUsers } from '@/hooks/users';
+import { useTeamMembers } from '@/hooks/team';
 import Entity from 'components/Entity';
-import type { TeamMember } from '@/types';
-import { ErrorCallout } from 'components/Callouts';
+import type { Team } from '@/types';
+import { ErrorCallout, InfoCallout } from 'components/Callouts';
+import AdminSidebar from 'components/AdminSidebar';
+import RoleBadge from 'components/RoleBadge';
+import AdminDataList from 'components/AdminDataList';
 
-function TeamMemberRow({ member }: { member: TeamMember}) {
-  // Temporary lookup into all users since the useUser endpoint has not merged yet.
-  const { data } = useUsers();
-  return (
-    <Table.Row>
-      <Table.Cell>
-        <Entity
-          label={data?.users.find((u) => u.id === member.user_id)?.name ?? 'Unknown User'}
-          to={`/admin/users?id=${member.user_id}`}
-          icon={TbUser}
-        />
-      </Table.Cell>
-      <Table.Cell>{member.role}</Table.Cell>
-      <Table.Cell>{new Date(member.joined_at).toLocaleString()}</Table.Cell>
-    </Table.Row>
-  );
-}
-
-export default function TeamSidebar() {
-  const [searchParams] = useSearchParams();
-  const teamId = Number(searchParams.get('id'));
-
-  const { data, error, isLoading } = useTeam(teamId);
-
-  if (error) {
-    return (
-      <ErrorCallout>{error.message}</ErrorCallout>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <Flex direction="column" align="center" justify="center" className="w-full h-full">
-        <Spinner />
-      </Flex>
-    );
-  }
-
-  if (!teamId || !data) {
-    return (
-      <Flex direction="column" align="center" justify="center" className="w-full h-full">
-        <TbUsersGroup className="text-(--gray-9) text-9xl" />
-        <Heading className="text-(--gray-9)" size="4">
-          Select a team to view details.
-        </Heading>
-      </Flex>
-    );
-  }
+export default function TeamSidebar({ entity }: { entity: Team }) {
+  const { data : members, error : membersError } = useTeamMembers(entity.id);
 
   return (
-    <>
-      <Heading>{data.team.name}</Heading>
+    <AdminSidebar title="Team Details">
+      <AdminDataList data={{ ...entity }} />
 
       <Heading>Members</Heading>
 
-      <Table.Root className="w-full">
-        <Table.Header>
-          <Table.Row>
-            <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>Role</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>Joined</Table.ColumnHeaderCell>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          {data.team_members.map((member) => (
-            <TeamMemberRow key={member.user_id} member={member} />
-          ))}
-        </Table.Body>
-      </Table.Root>
-
-    </>
+      {membersError && <ErrorCallout>{membersError.message}</ErrorCallout> }
+      {members && (
+        <Table.Root className="w-full">
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Role</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Joined</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell />
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {members.map((member) => (
+              <Table.Row key={member.id}>
+                <Table.Cell>
+                  <Entity
+                    label={member.user_name}
+                    to={`/admin/users?id=${member.user_id}`}
+                    icon={TbUser}
+                  />
+                </Table.Cell>
+                <Table.Cell><RoleBadge value={member.role} /></Table.Cell>
+                <Table.Cell>{member.joined_at.toLocaleString()}</Table.Cell>
+                <Table.Cell>
+                  <Flex direction="row" align="center" justify="end" className="h-full *:!m-0">
+                    <Button variant="ghost" color="red" disabled={member.role === 'captain'}>
+                      <TbDoorExit />
+                      Kick
+                    </Button>
+                    <Button variant="ghost" color="amber" disabled={member.role === 'captain'}>
+                      <TbStar />
+                      Promote
+                    </Button>
+                  </Flex>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
+      <Flex direction="row" gap="2" justify="between" align="center">
+        <Heading>Activity</Heading>
+        <Button variant="soft" color="amber">
+          <TbPlusMinus />
+          Point Adjust
+        </Button>
+      </Flex>
+      <InfoCallout>
+        Attempts, hint redemptions, and manual awards for this team.
+      </InfoCallout>
+      <Heading>Challenges</Heading>
+      <InfoCallout>
+        Deployed challenge instances for this team.
+      </InfoCallout>
+    </AdminSidebar>
   );
 }

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -12,6 +12,7 @@ import { ErrorCallout, InfoCallout } from 'components/Callouts';
 import AdminSidebar from 'components/AdminSidebar';
 import RoleBadge from 'components/RoleBadge';
 import AdminDataList from 'components/AdminDataList';
+import { UserIcon } from '@/constants';
 
 export default function TeamSidebar({ entity }: { entity: Team }) {
   const { data : members, error : membersError } = useTeamMembers(entity.id);
@@ -40,7 +41,7 @@ export default function TeamSidebar({ entity }: { entity: Team }) {
                   <Entity
                     label={member.user_name}
                     to={`/admin/users?id=${member.user_id}`}
-                    icon={TbUser}
+                    icon={UserIcon}
                   />
                 </Table.Cell>
                 <Table.Cell><RoleBadge value={member.role} /></Table.Cell>
@@ -49,11 +50,11 @@ export default function TeamSidebar({ entity }: { entity: Team }) {
                   <Flex direction="row" align="center" justify="end" className="h-full *:!m-0">
                     <Button variant="ghost" color="red" disabled={member.role === 'captain'}>
                       <TbDoorExit />
-                      Kick
+                      Remove
                     </Button>
                     <Button variant="ghost" color="amber" disabled={member.role === 'captain'}>
                       <TbStar />
-                      Promote
+                      Assign Captain
                     </Button>
                   </Flex>
                 </Table.Cell>

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -1,10 +1,10 @@
 import {
-  Button, Flex, Heading, Table,
+  Button,
+  Flex,
+  Heading,
+  Table,
 } from '@radix-ui/themes';
-import {
-  TbDoorExit, TbPlusMinus, TbStar,
-  TbUser,
-} from 'react-icons/tb';
+import { TbDoorExit, TbPlusMinus, TbStar } from 'react-icons/tb';
 import { useTeamMembers } from '@/hooks/team';
 import Entity from 'components/Entity';
 import type { Team } from '@/types';

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -1,0 +1,87 @@
+import {
+  Flex, Heading, Spinner, Table,
+} from '@radix-ui/themes';
+import {
+  TbUser,
+  TbUsersGroup,
+} from 'react-icons/tb';
+import { useSearchParams } from 'react-router';
+import { useTeam } from '@/hooks/team';
+import { useUsers } from '@/hooks/users';
+import Entity from 'components/Entity';
+import type { TeamMember } from '@/types';
+import { ErrorCallout } from 'components/Callouts';
+
+function TeamMemberRow({ member }: { member: TeamMember}) {
+  // Temporary lookup into all users since the useUser endpoint has not merged yet.
+  const { data } = useUsers();
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Entity
+          label={data?.users.find((u) => u.id === member.user_id)?.name ?? 'Unknown User'}
+          to={`/admin/users?id=${member.user_id}`}
+          icon={TbUser}
+        />
+      </Table.Cell>
+      <Table.Cell>{member.role}</Table.Cell>
+      <Table.Cell>{new Date(member.joined_at).toLocaleString()}</Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function TeamSidebar() {
+  const [searchParams] = useSearchParams();
+  const teamId = Number(searchParams.get('id'));
+
+  const { data, error, isLoading } = useTeam(teamId);
+
+  if (error) {
+    return (
+      <ErrorCallout>{error.message}</ErrorCallout>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Flex direction="column" align="center" justify="center" className="w-full h-full">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  if (!teamId || !data) {
+    return (
+      <Flex direction="column" align="center" justify="center" className="w-full h-full">
+        <TbUsersGroup className="text-(--gray-9) text-9xl" />
+        <Heading className="text-(--gray-9)" size="4">
+          Select a team to view details.
+        </Heading>
+      </Flex>
+    );
+  }
+
+  return (
+    <>
+      <Heading>{data.team.name}</Heading>
+
+      <Heading>Members</Heading>
+
+      <Table.Root className="w-full">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>Role</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>Joined</Table.ColumnHeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {data.team_members.map((member) => (
+            <TeamMemberRow key={member.user_id} member={member} />
+          ))}
+        </Table.Body>
+      </Table.Root>
+
+    </>
+  );
+}

--- a/frontend/src/routes/admin/teams/index.tsx
+++ b/frontend/src/routes/admin/teams/index.tsx
@@ -1,6 +1,3 @@
-import {
-  Badge,
-} from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
@@ -9,40 +6,9 @@ import { useEvent } from '@/hooks/events';
 import Entity from 'components/Entity';
 import { useAllTeams } from '@/hooks/team';
 import { useSearchParams } from 'react-router';
-import type { accentColors } from '@radix-ui/themes/props';
 import { EventIcon } from '@/constants';
+import MemberCountBadge from 'components/MemberCountBadge';
 import TeamSidebar from './TeamSidebar';
-
-function MemberCountBadge({ team }: { team: Team }) {
-  const { data : event } = useEvent(team.event_id);
-
-  if (!event) {
-    return <Badge variant="soft" color="gray">Loading...</Badge>;
-  }
-
-  let badgeColor: (typeof accentColors[number]) = 'lime';
-  if (team.member_count > event.max_team_size) {
-    badgeColor = 'red';
-  } else if (team.member_count === 1) {
-    if (event.max_team_size > 1) {
-      badgeColor = 'red';
-    } else {
-      badgeColor = 'jade';
-    }
-  } else if (team.member_count === event.max_team_size) {
-    badgeColor = 'amber';
-  } else if (team.member_count === 0) {
-    badgeColor = 'red';
-  }
-
-  return (
-    <Badge variant="soft" color={badgeColor} size="2">
-      {team.member_count}
-      /
-      {event.max_team_size}
-    </Badge>
-  );
-}
 
 function EventCellRenderer({ value }: { value: number }) {
   const { data, error, isLoading } = useEvent(value);

--- a/frontend/src/routes/admin/teams/index.tsx
+++ b/frontend/src/routes/admin/teams/index.tsx
@@ -1,81 +1,59 @@
-import { Callout, Flex, Heading } from '@radix-ui/themes';
-import { TbInfoCircle } from 'react-icons/tb';
-import { AgGridReact } from 'ag-grid-react';
+import {
+  Flex,
+} from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
-import { radixTheme } from '@/grid';
+import AdminGrid from 'components/AdminGrid';
+import { useEventTeams } from '@/hooks/team';
+import { ErrorCallout } from 'components/Callouts';
+import TeamSidebar from './TeamSidebar';
 
 /**
  * Team management page for admins.
  */
 export default function AdminTeams() {
-  const rowData = [
-    {
-      name : 'Team 1234', event : 'pc7-teams', status : 'Started', members : '5/5', submissions : '10', score : '150', challenges : '3',
-    },
-    {
-      name : 'Team 5678', event : 'pc7-teams', status : 'Not Started', members : '2/5', submissions : '0', score : '0', challenges : '0',
-    },
-    {
-      name : 'user123', event : 'pc7-individual', status : 'Started', members : '1/1', submissions : '5', score : '75', challenges : '2',
-    },
-  ];
+  // Since useTeams() is not available yet, hardcode the event ID for now.
+  const { data, error, isLoading } = useEventTeams(2);
+
+  if (error) {
+    return <ErrorCallout>{error.message}</ErrorCallout>;
+  }
+
+  const rowData = data?.teams ?? [];
+
   const colDefs: ColDef<typeof rowData[number]>[] = [
     { field : 'name' },
-    { field : 'event' },
-    { field : 'status', width : 150 },
-    { field : 'members', width : 100 },
-    { field : 'submissions' },
-    { field : 'score', width : 100 },
-    { field : 'challenges', headerName : 'Active Challenges' },
+    {
+      // field : 'event_id',
+      // Also hardcoded.
+      valueGetter : () => 2,
+      headerName : 'Event',
+      width : 200,
+      filter : 'agNumberColumnFilter',
+      floatingFilter : true,
+      // Will eventually be rendered as event name instead of ID.
+      // Need to fetch in the cell renderer component.
+    },
+    {
+      headerName : 'Members',
+      width : 100,
+      valueFormatter : (params) => `${params.data?.member_count}/${params.data?.max_team_size}`,
+    },
+    { field : 'ranked', width : 80 },
+    {
+      field : 'invite_code', headerName : 'Invite Code', width : 150,
+    },
   ];
 
   return (
     <Flex direction="row" gap="4" className="h-full w-full">
-      <AgGridReact
-        className="grow basis-2/3"
-        theme={radixTheme}
+      <AdminGrid
         rowData={rowData}
         columnDefs={colDefs}
-        gridOptions={{
-          rowSelection : {
-            mode : 'singleRow',
-            checkboxes : false,
-            enableClickSelection : true,
-          },
-        }}
+        loading={isLoading}
+        getRowId={(params) => params.data.id.toString()}
       />
-      <Flex direction="column" gap="4" className="grow basis-1/3">
-        <Heading>Members</Heading>
-        <Callout.Root variant="surface" color="jade">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            List of team members linking to user entries. Also controls to add/drop team members.
-          </Callout.Text>
-        </Callout.Root>
-
-        <Heading>Submissions</Heading>
-        <Callout.Root variant="surface" color="jade">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Recent flag submissions made by the team.
-          </Callout.Text>
-        </Callout.Root>
-
-        <Heading>
-          Challenges
-        </Heading>
-        <Callout.Root variant="surface" color="jade">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Challenge instances provisioned for this team.
-          </Callout.Text>
-        </Callout.Root>
+      <Flex direction="column" gap="4" className="w-128 shrink-0 grow-0 overflow-y-auto">
+        <TeamSidebar />
       </Flex>
     </Flex>
   );

--- a/frontend/src/routes/admin/teams/index.tsx
+++ b/frontend/src/routes/admin/teams/index.tsx
@@ -1,60 +1,140 @@
 import {
-  Flex,
+  Badge,
 } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
-import { useEventTeams } from '@/hooks/team';
 import { ErrorCallout } from 'components/Callouts';
+import type { Team } from '@/types';
+import { useEvent } from '@/hooks/events';
+import Entity from 'components/Entity';
+import { useAllTeams } from '@/hooks/team';
+import { useSearchParams } from 'react-router';
+import type { accentColors } from '@radix-ui/themes/props';
+import { EventIcon } from '@/constants';
 import TeamSidebar from './TeamSidebar';
+
+function MemberCountBadge({ team }: { team: Team }) {
+  const { data : event } = useEvent(team.event_id);
+
+  if (!event) {
+    return <Badge variant="soft" color="gray">Loading...</Badge>;
+  }
+
+  let badgeColor: (typeof accentColors[number]) = 'lime';
+  if (team.member_count > event.max_team_size) {
+    badgeColor = 'red';
+  } else if (team.member_count === 1) {
+    if (event.max_team_size > 1) {
+      badgeColor = 'red';
+    } else {
+      badgeColor = 'jade';
+    }
+  } else if (team.member_count === event.max_team_size) {
+    badgeColor = 'amber';
+  } else if (team.member_count === 0) {
+    badgeColor = 'red';
+  }
+
+  return (
+    <Badge variant="soft" color={badgeColor} size="2">
+      {team.member_count}
+      /
+      {event.max_team_size}
+    </Badge>
+  );
+}
+
+function EventCellRenderer({ value }: { value: number }) {
+  const { data, error, isLoading } = useEvent(value);
+
+  if (isLoading) {
+    return <span>Loading...</span>;
+  }
+
+  if (error) {
+    return (
+      <span>
+        Error:
+        {error.message}
+      </span>
+    );
+  }
+
+  return (
+    <Entity icon={EventIcon} to={`/admin/events?id=${value}`} label={data?.name ?? 'Unknown Event'} />
+  );
+}
 
 /**
  * Team management page for admins.
  */
 export default function AdminTeams() {
-  // Since useTeams() is not available yet, hardcode the event ID for now.
-  const { data, error, isLoading } = useEventTeams(2);
+  const [ searchParams ] = useSearchParams();
+  const eventId = searchParams.get('event');
+
+  const { data, error, isLoading } = useAllTeams();
 
   if (error) {
     return <ErrorCallout>{error.message}</ErrorCallout>;
   }
 
-  const rowData = data?.teams ?? [];
+  const rowData = data ?? [];
 
   const colDefs: ColDef<typeof rowData[number]>[] = [
-    { field : 'name' },
     {
-      // field : 'event_id',
-      // Also hardcoded.
-      valueGetter : () => 2,
+      field : 'name',
+      width : 250,
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'event_id',
       headerName : 'Event',
       width : 200,
       filter : 'agNumberColumnFilter',
       floatingFilter : true,
-      // Will eventually be rendered as event name instead of ID.
-      // Need to fetch in the cell renderer component.
+      cellRenderer : EventCellRenderer,
     },
     {
       headerName : 'Members',
       width : 100,
-      valueFormatter : (params) => `${params.data?.member_count}/${params.data?.max_team_size}`,
+      field : 'member_count',
+      cellRenderer : (params: { data: Team }) => MemberCountBadge({ team : params.data }),
+      filter : true,
+      floatingFilter : true,
     },
-    { field : 'ranked', width : 80 },
     {
-      field : 'invite_code', headerName : 'Invite Code', width : 150,
+      field : 'ranked',
+      width : 100,
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'invite_code',
+      headerName : 'Invite Code',
+      width : 300,
+      filter : true,
+      floatingFilter : true,
     },
   ];
 
   return (
-    <Flex direction="row" gap="4" className="h-full w-full">
-      <AdminGrid
-        rowData={rowData}
-        columnDefs={colDefs}
-        loading={isLoading}
-        getRowId={(params) => params.data.id.toString()}
-      />
-      <Flex direction="column" gap="4" className="w-128 shrink-0 grow-0 overflow-y-auto">
-        <TeamSidebar />
-      </Flex>
-    </Flex>
+    <AdminGrid
+      rowData={rowData}
+      columnDefs={colDefs}
+      loading={isLoading}
+      getRowId={(params) => params.data.id.toString()}
+      initialState={{
+        filter : {
+          filterModel : {
+            event_id : {
+              type : 'equals',
+              filter : eventId ?? '',
+            },
+          },
+        },
+      }}
+      sidebarComponent={TeamSidebar}
+    />
   );
 }

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -1,0 +1,82 @@
+import {
+  Flex, Heading, Spinner, Table,
+} from '@radix-ui/themes';
+import {
+  TbUser,
+  TbUsersGroup,
+} from 'react-icons/tb';
+import { useSearchParams } from 'react-router';
+import { useUserTeams } from '@/hooks/team';
+import { useUsers } from '@/hooks/users';
+import Entity from 'components/Entity';
+import { ErrorCallout } from 'components/Callouts';
+import { EventIcon } from '@/constants';
+import AdminDataList from 'components/AdminDataList';
+
+export default function UserSidebar() {
+  const [searchParams] = useSearchParams();
+
+  const userId = Number(searchParams.get('id'));
+
+  // Temporary lookup into all users since the useUser endpoint has not merged yet.
+  const { data : allUsers, error, isLoading } = useUsers();
+  const data = allUsers?.users.find((u) => u.id === userId);
+
+  const { data : teamData, error : teamError, isLoading : teamLoading } = useUserTeams(userId);
+
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (error) {
+    return <ErrorCallout>{error.message}</ErrorCallout>;
+  }
+
+  if (!userId || !data) {
+    return (
+      <Flex direction="column" align="center" justify="center" className="w-full h-full">
+        <TbUser className="text-(--gray-9) text-9xl" />
+        <Heading className="text-(--gray-9)" size="4">
+          Select a user to view details.
+        </Heading>
+      </Flex>
+    );
+  }
+
+  return (
+    <>
+      <Heading>{data.name}</Heading>
+      <AdminDataList data={data} />
+      <Heading>Registrations</Heading>
+      {teamError && <ErrorCallout>{teamError.message}</ErrorCallout> }
+      {teamLoading && <Spinner />}
+      {teamData && (
+        <Table.Root>
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Event</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Team</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Joined At</Table.ColumnHeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {/* Need consistent serialization from the backend for types to match here - these should really be TeamMember objects */}
+            {teamData?.teams.map((team) => (
+              <Table.Row key={team.id}>
+                <Table.Cell>
+                  <Entity label={team.event_name} icon={EventIcon} to={`/admin/events?id=${team.event_id}`} />
+                </Table.Cell>
+                <Table.Cell>
+                  <Entity label={team.team_name} icon={TbUsersGroup} to={`/admin/teams?event=${team.event_id}&id=${team.team_id}`} />
+                </Table.Cell>
+                <Table.Cell>
+                  {new Date(team.joined_at).toLocaleString()}
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
+    </>
+  );
+}

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -1,82 +1,93 @@
 import {
-  Flex, Heading, Spinner, Table,
+  Button, Flex, Heading, Table,
 } from '@radix-ui/themes';
 import {
-  TbUser,
+  TbPlus,
   TbUsersGroup,
 } from 'react-icons/tb';
-import { useSearchParams } from 'react-router';
-import { useUserTeams } from '@/hooks/team';
-import { useUsers } from '@/hooks/users';
 import Entity from 'components/Entity';
 import { ErrorCallout } from 'components/Callouts';
 import { EventIcon } from '@/constants';
 import AdminDataList from 'components/AdminDataList';
+import { useTeamMembers, useUserTeams } from '@/hooks/team';
+import { useUserEvents } from '@/hooks/events';
+import _ from 'lodash';
+import type { Event, Team, User } from '@/types';
+import AdminSidebar from 'components/AdminSidebar';
+import RoleBadge from 'components/RoleBadge';
 
-export default function UserSidebar() {
-  const [searchParams] = useSearchParams();
-
-  const userId = Number(searchParams.get('id'));
-
-  // Temporary lookup into all users since the useUser endpoint has not merged yet.
-  const { data : allUsers, error, isLoading } = useUsers();
-  const data = allUsers?.users.find((u) => u.id === userId);
-
-  const { data : teamData, error : teamError, isLoading : teamLoading } = useUserTeams(userId);
-
-  if (isLoading) {
-    return <Spinner />;
+function RegistrationRow({ userId, team, event }: { userId: number, team: Team, event: Event }) {
+  const { data : teamMembers } = useTeamMembers(team.id);
+  if (!teamMembers) {
+    return null;
   }
 
-  if (error) {
-    return <ErrorCallout>{error.message}</ErrorCallout>;
-  }
-
-  if (!userId || !data) {
-    return (
-      <Flex direction="column" align="center" justify="center" className="w-full h-full">
-        <TbUser className="text-(--gray-9) text-9xl" />
-        <Heading className="text-(--gray-9)" size="4">
-          Select a user to view details.
-        </Heading>
-      </Flex>
-    );
+  const membership = teamMembers.find((member) => member.user_id === userId);
+  if (!membership) {
+    return null;
   }
 
   return (
-    <>
-      <Heading>{data.name}</Heading>
-      <AdminDataList data={data} />
-      <Heading>Registrations</Heading>
-      {teamError && <ErrorCallout>{teamError.message}</ErrorCallout> }
-      {teamLoading && <Spinner />}
-      {teamData && (
+    <Table.Row key={team.id}>
+      <Table.Cell>
+        <Entity label={event.name} icon={EventIcon} to={`/admin/events?id=${event.id}`} />
+      </Table.Cell>
+      <Table.Cell>
+        <Entity label={team.name} icon={TbUsersGroup} to={`/admin/teams?event=${team.event_id}&id=${team.id}`} />
+      </Table.Cell>
+      <Table.Cell>
+        <RoleBadge value={membership.role} />
+      </Table.Cell>
+      <Table.Cell>
+        {membership?.joined_at.toLocaleString()}
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function UserSidebar({ entity }: { entity: User }) {
+  const { data : teamsData, error : teamsError } = useUserTeams(entity.id);
+  const { data : eventsData, error : eventsError } = useUserEvents(entity.id);
+
+  const eventsMap = _.keyBy(eventsData, 'id');
+
+  return (
+    <AdminSidebar title="User Details">
+      <AdminDataList data={{ ...entity }} />
+
+      <Flex direction="row" gap="4" justify="between" align="center">
+        <Heading>Registrations</Heading>
+        <Button variant="soft">
+          <TbPlus />
+          Register
+        </Button>
+      </Flex>
+      {teamsError && <ErrorCallout>{teamsError.message}</ErrorCallout> }
+      {eventsError && <ErrorCallout>{eventsError.message}</ErrorCallout> }
+      {teamsData && eventsData && (
         <Table.Root>
           <Table.Header>
             <Table.Row>
               <Table.ColumnHeaderCell>Event</Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>Team</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Joined At</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Role</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Joined</Table.ColumnHeaderCell>
             </Table.Row>
           </Table.Header>
           <Table.Body>
-            {/* Need consistent serialization from the backend for types to match here - these should really be TeamMember objects */}
-            {teamData?.teams.map((team) => (
-              <Table.Row key={team.id}>
-                <Table.Cell>
-                  <Entity label={team.event_name} icon={EventIcon} to={`/admin/events?id=${team.event_id}`} />
-                </Table.Cell>
-                <Table.Cell>
-                  <Entity label={team.team_name} icon={TbUsersGroup} to={`/admin/teams?event=${team.event_id}&id=${team.team_id}`} />
-                </Table.Cell>
-                <Table.Cell>
-                  {new Date(team.joined_at).toLocaleString()}
-                </Table.Cell>
-              </Table.Row>
+            {teamsData?.map((team) => (
+              <RegistrationRow
+                key={team.id}
+                userId={entity.id}
+                team={team}
+                event={eventsMap[team.event_id]}
+              />
             ))}
           </Table.Body>
         </Table.Root>
       )}
-    </>
+
+      <Heading>Workspace</Heading>
+    </AdminSidebar>
   );
 }

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -1,13 +1,10 @@
 import {
   Button, Flex, Heading, Table,
 } from '@radix-ui/themes';
-import {
-  TbPlus,
-  TbUsersGroup,
-} from 'react-icons/tb';
+import { TbPlus } from 'react-icons/tb';
 import Entity from 'components/Entity';
 import { ErrorCallout } from 'components/Callouts';
-import { EventIcon } from '@/constants';
+import { EventIcon, TeamIcon } from '@/constants';
 import AdminDataList from 'components/AdminDataList';
 import { useTeamMembers, useUserTeams } from '@/hooks/team';
 import { useUserEvents } from '@/hooks/events';
@@ -33,7 +30,7 @@ function RegistrationRow({ userId, team, event }: { userId: number, team: Team, 
         <Entity label={event.name} icon={EventIcon} to={`/admin/events?id=${event.id}`} />
       </Table.Cell>
       <Table.Cell>
-        <Entity label={team.name} icon={TbUsersGroup} to={`/admin/teams?event=${team.event_id}&id=${team.id}`} />
+        <Entity label={team.name} icon={TeamIcon} to={`/admin/teams?event=${team.event_id}&id=${team.id}`} />
       </Table.Cell>
       <Table.Cell>
         <RoleBadge value={membership.role} />

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -1,111 +1,43 @@
 import type { ColDef } from 'ag-grid-community';
-import { AgGridReact } from 'ag-grid-react';
 import { useState } from 'react';
-import {
-  Button, Callout, Flex, Heading,
-} from '@radix-ui/themes';
-import {
-  TbInfoCircle, TbPlus, TbTrash,
-} from 'react-icons/tb';
-import { radixTheme } from '@/grid';
+import { Flex } from '@radix-ui/themes';
+import AdminGrid from 'components/AdminGrid';
+import { useUsers } from '@/hooks/users';
+import { ErrorCallout } from 'components/Callouts';
+import UserSidebar from './UserSidebar';
 
 /**
  * User management page for admins.
  */
 export default function AdminUsers() {
-  const [ rowData ] = useState([
-    {
-      name : 'Alice', role : 'Admin', uuid : '550e8400-e29b-41d4-a716-446655440000', lastLogin : 'xxxx-yy-zz',
-    },
-    {
-      name : 'Bob', role : 'User', uuid : '550e8400-e29b-41d4-a716-446655440001', lastLogin : 'xxxx-yy-zz',
-    },
-    {
-      name : 'Charlie', role : 'Support', uuid : '550e8400-e29b-41d4-a716-446655440002', lastLogin : 'xxxx-yy-zz',
-    },
-    {
-      name : 'David', role : 'User', uuid : '550e8400-e29b-41d4-a716-446655440003', lastLogin : 'xxxx-yy-zz',
-    },
-    {
-      name : 'Eve', role : 'Admin', uuid : '550e8400-e29b-41d4-a716-446655440004', lastLogin : 'xxxx-yy-zz',
-    },
-  ]);
+  const { data, error, isLoading } = useUsers();
+  const rowData = data?.users ?? [];
 
   const [ colDefs ] = useState<ColDef<typeof rowData[number]>[]>([
-    { field : 'name' },
+    {
+      field : 'name', filter : true, floatingFilter : true, width : 200,
+    },
     { field : 'role' },
-    { field : 'uuid' },
-    { field : 'lastLogin', width : 150 },
+    { field : 'id' },
+    { field : 'registered_at', width : 150, valueFormatter : (params) => new Date(params.value).toLocaleString() },
   ]);
+
+  if (error) {
+    return (
+      <ErrorCallout>{error.message}</ErrorCallout>
+    );
+  }
 
   return (
     <Flex direction="row" gap="4" className="w-full h-full">
-      <AgGridReact
-        className="grow basis-2/3"
-        theme={radixTheme}
+      <AdminGrid
         rowData={rowData}
         columnDefs={colDefs}
-        gridOptions={{
-          rowSelection : {
-            mode : 'singleRow',
-            checkboxes : false,
-            enableClickSelection : true,
-          },
-        }}
-
+        loading={isLoading}
+        getRowId={(params) => params.data.id.toString()}
       />
-      <Flex direction="column" gap="4" height="100%" flexGrow="1" className="basis-1/3" overflowY="auto">
-        <Flex direction="row" gap="2" justify="between" align="center">
-          <Heading>Information</Heading>
-          <Button variant="soft" color="red">
-            <TbTrash />
-            Delete
-          </Button>
-        </Flex>
-        <Callout.Root
-          color="jade"
-          variant="surface"
-        >
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            User info form with name, role, etc.
-          </Callout.Text>
-        </Callout.Root>
-        <Heading>Workspace</Heading>
-        <Callout.Root
-          color="jade"
-          variant="surface"
-        >
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Information about the user&apos;s workspace and relevant admin actions.
-            (Remote access, restart, etc.)
-          </Callout.Text>
-        </Callout.Root>
-
-        <Flex direction="row" gap="2" justify="between" align="center">
-          <Heading>Registrations</Heading>
-          <Button variant="soft">
-            <TbPlus />
-            Register
-          </Button>
-        </Flex>
-        <Callout.Root
-          color="jade"
-          variant="surface"
-        >
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            Table of events the user is registered for,
-            linking to each team and event.
-          </Callout.Text>
-        </Callout.Root>
+      <Flex direction="column" gap="4" height="100%" className="w-128 grow-0 shrink-0 overflow-y-auto" overflowY="auto">
+        <UserSidebar />
       </Flex>
 
     </Flex>

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -1,26 +1,53 @@
-import type { ColDef } from 'ag-grid-community';
-import { useState } from 'react';
-import { Flex } from '@radix-ui/themes';
 import AdminGrid from 'components/AdminGrid';
-import { useUsers } from '@/hooks/users';
+import { useAllUsers } from '@/hooks/users';
 import { ErrorCallout } from 'components/Callouts';
+import RoleBadge from 'components/RoleBadge';
+import type { ColDef } from 'ag-grid-community';
 import UserSidebar from './UserSidebar';
 
 /**
  * User management page for admins.
  */
 export default function AdminUsers() {
-  const { data, error, isLoading } = useUsers();
-  const rowData = data?.users ?? [];
+  const { data, error, isLoading } = useAllUsers();
+  const rowData = data ?? [];
 
-  const [ colDefs ] = useState<ColDef<typeof rowData[number]>[]>([
+  const colDefs: ColDef<typeof rowData[number]>[] = [
     {
-      field : 'name', filter : true, floatingFilter : true, width : 200,
+      field : 'name',
+      filter : true,
+      floatingFilter : true,
+      width : 200,
     },
-    { field : 'role' },
-    { field : 'id' },
-    { field : 'registered_at', width : 150, valueFormatter : (params) => new Date(params.value).toLocaleString() },
-  ]);
+    {
+      field : 'email',
+      filter : true,
+      floatingFilter : true,
+      width : 250,
+    },
+    {
+      field : 'role',
+      cellRenderer : RoleBadge,
+      filter : true,
+      floatingFilter : true,
+      width : 120,
+    },
+    {
+      field : 'registered_at',
+      headerName : 'Registered At',
+      width : 220,
+      valueFormatter : (params) => params.value && params.value.toLocaleString(),
+      filter : true,
+      floatingFilter : true,
+    },
+    {
+      field : 'id',
+      width : 100,
+      headerName : 'ID',
+      filter : true,
+      floatingFilter : true,
+    },
+  ];
 
   if (error) {
     return (
@@ -29,17 +56,12 @@ export default function AdminUsers() {
   }
 
   return (
-    <Flex direction="row" gap="4" className="w-full h-full">
-      <AdminGrid
-        rowData={rowData}
-        columnDefs={colDefs}
-        loading={isLoading}
-        getRowId={(params) => params.data.id.toString()}
-      />
-      <Flex direction="column" gap="4" height="100%" className="w-128 grow-0 shrink-0 overflow-y-auto" overflowY="auto">
-        <UserSidebar />
-      </Flex>
-
-    </Flex>
+    <AdminGrid
+      rowData={rowData}
+      columnDefs={colDefs}
+      loading={isLoading}
+      getRowId={(params) => params.data.id.toString()}
+      sidebarComponent={UserSidebar}
+    />
   );
 }

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from 'react-router';
 
 import EventHeader from 'components/EventHeader';
 import HeaderContainer from 'components/HeaderContainer';
+import { TeamIcon } from '@/constants';
 import LeaderboardTab from './OverviewTabs/LeaderboardTab';
 import ChallengesTab from './OverviewTabs/ChallengesTab';
 import TeamTab from './OverviewTabs/TeamTab';
@@ -45,7 +46,7 @@ export default function Overview() {
               Leaderboard
             </Tabs.Trigger>
             <Tabs.Trigger value="team">
-              <TbUsersGroup className="mr-1" />
+              <TeamIcon className="mr-1" />
               Team
             </Tabs.Trigger>
           </Tabs.List>

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -2,12 +2,12 @@ import {
   Container, Tabs,
 } from '@radix-ui/themes';
 
-import { TbCube, TbStar } from 'react-icons/tb';
+import { TbStar } from 'react-icons/tb';
 import { useSearchParams } from 'react-router';
 
 import EventHeader from 'components/EventHeader';
 import HeaderContainer from 'components/HeaderContainer';
-import { TeamIcon } from '@/constants';
+import { ChallengeIcon, TeamIcon } from '@/constants';
 import LeaderboardTab from './OverviewTabs/LeaderboardTab';
 import ChallengesTab from './OverviewTabs/ChallengesTab';
 import TeamTab from './OverviewTabs/TeamTab';
@@ -38,7 +38,7 @@ export default function Overview() {
         <Container size="2" mb="4">
           <Tabs.List className="*:!basis-0 *:!grow" loop={false}>
             <Tabs.Trigger value="challenges">
-              <TbCube className="mr-1" />
+              <ChallengeIcon className="mr-1" />
               Challenges
             </Tabs.Trigger>
             <Tabs.Trigger value="leaderboard">

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -2,7 +2,7 @@ import {
   Container, Tabs,
 } from '@radix-ui/themes';
 
-import { TbCube, TbStar, TbUsersGroup } from 'react-icons/tb';
+import { TbCube, TbStar } from 'react-icons/tb';
 import { useSearchParams } from 'react-router';
 
 import EventHeader from 'components/EventHeader';


### PR DESCRIPTION
- Grids for events, users, teams connected to the backend
- Can select an item to expand a sidebar with information/controls for that item 
    - Can switch between multiple items quickly without navigating between many pages
    - Sidebars can link to other grids with an entity pre-selected to allow for fast navigation (i.e. jumping from a user to the team they're on)
    - Keyboard navigation focus jumps to the sidebar when opened, can start tabbing through controls or shift-tab back to the grid
    - Sidebars are passed row data from the grid (can avoid re-fetching an item that's already part of a larger list the client already has)
- Form component for creating/updating events with early validation logic

Things to keep working on in the future:
- Allow filtering the user grid by event. Also figure out how to present registered events on the user grid.
- Allow selecting events from a list in event filters instead of taking a numeric ID
- Sync filter changes in the grid back to the URL params
- Improve event form validation logic
- Forms for user/team updates
- Connect up admin-side team management operations
- Tidy up loading/error states