### PR TITLE
Restore timestamp validation/serialization fixes

### DIFF
--- a/backend/ng/core/utils/validator.py
+++ b/backend/ng/core/utils/validator.py
@@ -275,6 +275,11 @@ class BaseValidator:
                 self.errors[field] = ValidationErrorMessages.FIELD_DATETIME_PAST.format(field=friendly_name)
                 return None
 
+            # SQLAlchemy expects to work with naive datetime objects (tzinfo=None),
+            # so tzinfo must be removed here before sending this value to the model.
+            # Leaving tzinfo as UTC here instead of changing it to None will break things.
+            dt_value = dt_value.replace(tzinfo=None)
+
             self._add_parsed_data(field, dt_value)
             return dt_value
         except (ValueError, TypeError):

--- a/backend/ng/event/models/Event.py
+++ b/backend/ng/event/models/Event.py
@@ -77,12 +77,8 @@ class Event(db.Model):
             "locked": self.locked,
             "public": self.public,
             "registration_open": self.registration_open,
-            "registration_start_date": self.registration_start_date.isoformat() + "Z"
-            if self.registration_start_date
-            else None,
-            "registration_end_date": self.registration_end_date.isoformat() + "Z"
-            if self.registration_end_date
-            else None,
+            "registration_start_date": self.registration_start_date.isoformat() + "Z" if self.registration_start_date else None,
+            "registration_end_date": self.registration_end_date.isoformat() + "Z" if self.registration_end_date else None,
         }
 
         return data

--- a/backend/ng/user/models/User.py
+++ b/backend/ng/user/models/User.py
@@ -60,14 +60,14 @@ class User(db.Model):
                 "name": self.ctfd_user.name,
                 "email": self.ctfd_user.email,
                 "roles": [role.name for role in self.roles],
-                "registered_at": self.ctfd_user.created.isoformat(),
+                "registered_at": self.ctfd_user.created.isoformat() + "Z",
             }
         else:
             return {
                 "id": self.id,
                 "name": self.ctfd_user.name,
                 "email": self.ctfd_user.email,
-                "registered_at": self.ctfd_user.created.isoformat(),
+                "registered_at": self.ctfd_user.created.isoformat() + "Z",
             }
 
     @classmethod


### PR DESCRIPTION
Fixes regression involving datetime validation to ensure that models always deal with naive (`tzinfo=None`) datetimes.