### PR TITLE
Modal refactor and form styling updates

### DIFF
--- a/frontend/src/components/AdminSidebar.tsx
+++ b/frontend/src/components/AdminSidebar.tsx
@@ -1,8 +1,8 @@
-import { Flex, Heading } from '@radix-ui/themes';
+import { Flex } from '@radix-ui/themes';
 import { useEffect, useRef, type ReactNode } from 'react';
 
-export default function AdminSidebar({ children, title }: {children: ReactNode, title: string}) {
-  const headerRef = useRef<HTMLHeadingElement>(null);
+export default function AdminSidebar({ children }: {children: ReactNode}) {
+  const headerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     // Steal focus when the sidebar is mounted
@@ -11,8 +11,7 @@ export default function AdminSidebar({ children, title }: {children: ReactNode, 
   }, []);
 
   return (
-    <Flex direction="column" gap="4" className="basis-1/2 min-w-128 grow-0 shrink-0 overflow-y-auto">
-      <Heading ref={headerRef} tabIndex={-1}>{title}</Heading>
+    <Flex direction="column" gap="4" className="basis-1/2 min-w-128 grow-0 shrink-0 overflow-y-auto outline-0" ref={headerRef} tabIndex={-1}>
       {children}
     </Flex>
   );

--- a/frontend/src/components/AdminSidebarHeader.tsx
+++ b/frontend/src/components/AdminSidebarHeader.tsx
@@ -1,0 +1,18 @@
+import { Flex, Heading } from '@radix-ui/themes';
+
+export default function AdminSidebarHeader({
+  title,
+  children,
+} : {
+  title: string;
+  children?: React.ReactNode
+}) {
+  return (
+    <Flex direction="row" align="center" justify="between" gap="4">
+      <Heading>{title}</Heading>
+      <Flex direction="row" align="center" gap="2">
+        {children}
+      </Flex>
+    </Flex>
+  );
+}

--- a/frontend/src/components/Entity.tsx
+++ b/frontend/src/components/Entity.tsx
@@ -18,7 +18,7 @@ export default function Entity({
     <RadixLink asChild>
       <Link to={to}>
         <Flex direction="row" align="center" gap="1" className="h-full">
-          <Icon />
+          <Icon className="shrink-0" />
           <span>{label}</span>
         </Flex>
       </Link>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,57 +1,139 @@
-import { Button, Dialog, Flex } from '@radix-ui/themes';
-import { useState, type ReactNode } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  Flex,
+} from '@radix-ui/themes';
+import type { accentColors } from '@radix-ui/themes/props';
+import { Form } from 'radix-ui';
+import { useEffect, useState, type ReactNode } from 'react';
 import { TbX } from 'react-icons/tb';
+import { ErrorCallout } from './Callouts';
 
 interface ModalProps {
   title: string,
-  buttonText: string,
-  children: ReactNode,
-  onSubmit: () => void,
-  onSubmitText: string,
-  onSubmitColor?: 'lime' | 'red'
+  description?: string,
+  children?: ReactNode,
+  trigger: ReactNode,
+  onSubmit?: (formData: FormData) => Promise<unknown>,
+  onOpenChange?: (open: boolean) => void,
+  submitVerb?: string,
+  submitColor?: typeof accentColors[number],
+  submitDisabled?: boolean,
+  requireTouchingForm?: boolean,
 }
 
 export default function Modal({
-  title, buttonText, children, onSubmit, onSubmitText, onSubmitColor = 'lime',
-}:ModalProps) {
+  title,
+  description,
+  children,
+  trigger,
+  onSubmit,
+  onOpenChange,
+  submitVerb = 'Submit',
+  submitColor,
+  submitDisabled = false,
+  requireTouchingForm = false,
+} : ModalProps) {
   const [ open, setOpen ] = useState<boolean>(false);
+  const [ error, setError ] = useState<string | null>(null);
+  const [ formTouched, setFormTouched ] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!open) {
+      // reset state when modal closes
+      setFormTouched(false);
+      setError(null);
+    }
+  }, [ open ]);
 
   return (
-    <Dialog.Root open={open} onOpenChange={setOpen}>
+    <Dialog.Root open={open} onOpenChange={(o) => { onOpenChange?.(o); setOpen(o); }}>
       <Dialog.Trigger>
-        <Button>{buttonText}</Button>
+        {trigger}
       </Dialog.Trigger>
 
-      <Dialog.Content aria-describedby={undefined}>
-        <Flex direction="row">
-          <Dialog.Title
-            className="pb-2"
-          >
-            {title}
-          </Dialog.Title>
-          <Dialog.Close>
-            <button type="button" aria-label="Close" className="absolute left-auto right-4 top-4">
-              <TbX />
-            </button>
-          </Dialog.Close>
-        </Flex>
-        {children}
-        <Flex gap="3" mt="3" justify="end">
-          <Dialog.Close>
-            <Button variant="solid" color="gray">
-              Cancel
-            </Button>
-          </Dialog.Close>
-          <Button
-            color={onSubmitColor}
-            onClick={() => {
-              onSubmit();
+      <Dialog.Content
+        className="flex flex-col gap-3"
+        // aria-describedby should be set to undefined if no description is provided, otherwise it should not be set at all.
+        // as far as i know, prop spreading is the only way to accomplish this.
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {
+          ...(!description ? { 'aria-describedby' : undefined } : {})
+        }
+      >
+        <Box>
+          <Flex direction="row" justify="between" align="center">
+            <Dialog.Title mb="0">{title}</Dialog.Title>
+            <Dialog.Close>
+              <Button
+                type="button"
+                aria-label="Close"
+                variant="ghost"
+                color="gray"
+                className="!m-0 !p-1"
+              >
+                <TbX className="text-xl" />
+              </Button>
+            </Dialog.Close>
+          </Flex>
+          {description && (
+          <Dialog.Description color="gray">
+            {description}
+          </Dialog.Description>
+          )}
+        </Box>
+        {error && (
+          <ErrorCallout>
+            {error}
+          </ErrorCallout>
+        )}
+        <Form.Root
+          className="flex flex-col gap-3"
+          onSubmitCapture={(e) => {
+            e.preventDefault();
+
+            if (onSubmit) {
+              const formData = new FormData(e.currentTarget);
+              onSubmit(formData)
+                .then(() => {
+                  // if promise resolves, close the modal
+                  setOpen(false);
+                })
+                .catch((err) => {
+                  // if promise rejects, set the error message
+                  setError(err.message);
+                });
+            } else {
+              // if no submit handler is defined, just close the modal
               setOpen(false);
-            }}
-          >
-            {onSubmitText}
-          </Button>
-        </Flex>
+            }
+          }}
+          onChange={() => {
+            setFormTouched(true);
+          }}
+        >
+          {children}
+          <Flex direction="row-reverse" justify="start" align="center" gap="2">
+            <Form.Submit asChild>
+              <Button
+                type="submit"
+                color={onSubmit ? submitColor : 'gray'}
+                variant={onSubmit ? 'solid' : 'soft'}
+                disabled={submitDisabled || (requireTouchingForm && !formTouched)}
+              >
+                {onSubmit ? submitVerb : 'Close'}
+              </Button>
+            </Form.Submit>
+            {onSubmit && (
+              <Dialog.Close>
+                <Button type="button" variant="soft" color="gray">
+                  Cancel
+                </Button>
+              </Dialog.Close>
+            )}
+          </Flex>
+        </Form.Root>
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -31,7 +31,7 @@ export default function Modal({
   onSubmit,
   onOpenChange,
   submitVerb = 'Submit',
-  submitColor,
+  submitColor = 'lime',
   submitDisabled = false,
   requireTouchingForm = false,
 } : ModalProps) {

--- a/frontend/src/components/RoleBadge.tsx
+++ b/frontend/src/components/RoleBadge.tsx
@@ -5,6 +5,10 @@ export default function RoleBadge({ value }: { value: string }) {
   const color = ROLES[value]?.color || 'gray';
   const Icon = ROLES[value]?.icon;
 
+  if (!value) {
+    return null;
+  }
+
   return (
     <Badge color={color} variant="soft">
       {Icon && <Icon />}

--- a/frontend/src/hooks/events.ts
+++ b/frontend/src/hooks/events.ts
@@ -1,5 +1,5 @@
-import useSWR, { mutate } from 'swr';
 import { apiMutation } from '@/fetchers';
+import useSWR, { mutate } from 'swr';
 import type { Event } from '../types';
 
 /**
@@ -52,7 +52,7 @@ export function useUserEvents(userId: number | null) {
  * @param team_name The leaderboard name
  */
 export function registerMyEvent(eventId: number, teamName: string) {
-  apiMutation(`/events/${eventId}/me/register`, { team_name : teamName }, {
+  return apiMutation(`/events/${eventId}/me/register`, { team_name : teamName }, {
     method : 'POST',
   }).then(() => {
     mutate('/users/me/events');
@@ -73,7 +73,7 @@ export function useMyEvents() {
  * @param event The event object to create
  */
 export function createEvent(event: Omit<Event, 'id'>) {
-  apiMutation('/admin/events', event, {
+  return apiMutation('/admin/events', event, {
     method : 'POST',
   }).then(() => {
     mutate('/admin/events');

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,18 +26,82 @@
   }
 }
 
+/* Styles for radix form elements */
 form label {
   @apply text-sm text-(--gray-11);
 }
 
 form label[data-invalid="true"] {
-  @apply text-(--red-11);
+  @apply text-(--accent-11);
 }
 
-form span {
-  @apply text-(--red-11) block;
+/* Validation messages should be block so they stack vertically */
+form div span[id^=radix-] {
+  @apply text-(--accent-11) block;
+}
+
+/* Give invalid form elements a red accent color */
+/* Effectively sets their color prop to red. */
+[data-invalid="true"] {
+  --accent-1: var(--red-1);
+  --accent-2: var(--red-2);
+  --accent-3: var(--red-3);
+  --accent-4: var(--red-4);
+  --accent-5: var(--red-5);
+  --accent-6: var(--red-6);
+  --accent-7: var(--red-7);
+  --accent-8: var(--red-8);
+  --accent-9: var(--red-9);
+  --accent-10: var(--red-10);
+  --accent-11: var(--red-11);
+  --accent-12: var(--red-12);
+  --accent-a1: var(--red-a1);
+  --accent-a2: var(--red-a2);
+  --accent-a3: var(--red-a3);
+  --accent-a4: var(--red-a4);
+  --accent-a5: var(--red-a5);
+  --accent-a6: var(--red-a6);
+  --accent-a7: var(--red-a7);
+  --accent-a8: var(--red-a8);
+  --accent-a9: var(--red-a9);
+  --accent-a10: var(--red-a10);
+  --accent-a11: var(--red-a11);
+  --accent-a12: var(--red-a12);
+  --accent-contrast: var(--red-contrast);
+  --accent-surface: var(--red-surface);
+  --accent-indicator: var(--red-indicator);
+  --accent-track: var(--red-track);
+  --focus-1: var(--accent-1);
+  --focus-2: var(--accent-2);
+  --focus-3: var(--accent-3);
+  --focus-4: var(--accent-4);
+  --focus-5: var(--accent-5);
+  --focus-6: var(--accent-6);
+  --focus-7: var(--accent-7);
+  --focus-8: var(--accent-8);
+  --focus-9: var(--accent-9);
+  --focus-10: var(--accent-10);
+  --focus-11: var(--accent-11);
+  --focus-12: var(--accent-12);
+  --focus-a1: var(--accent-a1);
+  --focus-a2: var(--accent-a2);
+  --focus-a3: var(--accent-a3);
+  --focus-a4: var(--accent-a4);
+  --focus-a5: var(--accent-a5);
+  --focus-a6: var(--accent-a6);
+  --focus-a7: var(--accent-a7);
+  --focus-a8: var(--accent-a8);
+  --focus-a9: var(--accent-a9);
+  --focus-a10: var(--accent-a10);
+  --focus-a11: var(--accent-a11);
+  --focus-a12: var(--accent-a12);
 }
 
 [data-invalid="true"] .rt-TextFieldRoot {
-  box-shadow: inset 0 0 0 var(--text-field-border-width) var(--red-a7);
+  @apply !ring !ring-(--accent-7);
+}
+
+/* Tailwind utility to set alternative stylistic set on text to disambiguate characters */
+@utility ss02 {
+  font-feature-settings: 'ss02' 1;
 }

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -1,14 +1,11 @@
 import type { Event } from '@/types';
 import {
-  Button,
   Checkbox,
   Flex,
   TextArea,
   TextField,
 } from '@radix-ui/themes';
-import { ErrorCallout } from 'components/Callouts';
 import { Form } from 'radix-ui';
-import { useState } from 'react';
 
 function adjustDateForInput(date: Date | null): string {
   // Adjust the date to be in the format required by datetime-local input
@@ -21,65 +18,11 @@ function adjustDateForInput(date: Date | null): string {
 
 export default function EventDataForm({
   initial,
-  onSubmit,
-  error,
 }: {
   initial?: Omit<Event, 'id'>,
-  onSubmit?: (event: Omit<Event, 'id'>) => void,
-  error?: string
 }) {
-  // allow reset/submit only if the form has been touched
-  // these buttons being enabled indicates unsaved changes
-  const [ canReset, setCanReset ] = useState(false);
-
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setCanReset(false);
-    const formData = new FormData(e.target as HTMLFormElement);
-
-    const {
-      name,
-      description,
-      start_time : startTime,
-      end_time : endTime,
-      locked : isLocked,
-      public : isPublic,
-      max_team_size : maxTeamSize,
-      registration_open : isOpen,
-      registration_start_date : openTime,
-      registration_end_date : closeTime,
-    } = Object.fromEntries(formData.entries());
-
-    return onSubmit?.({
-      name : name as string,
-      description : description as string,
-      start_time : new Date(startTime as string),
-      end_time : new Date(endTime as string),
-      locked : isLocked === 'on',
-      public : isPublic === 'on',
-      max_team_size : Number(maxTeamSize),
-      registration_open : isOpen === 'on',
-      registration_start_date : new Date(openTime as string),
-      registration_end_date : new Date(closeTime as string),
-    });
-  }
-
   return (
-    <Form.Root
-      className="flex flex-col gap-2"
-      onSubmitCapture={(e) => handleSubmit(e)}
-      onChange={() => {
-        setCanReset(true);
-      }}
-      onReset={() => {
-        setCanReset(false);
-      }}
-    >
-      { error && (
-        <ErrorCallout>
-          {error}
-        </ErrorCallout>
-      ) }
+    <>
       <Form.Field name="Name">
         <Form.Label>Name</Form.Label>
         <Form.Control asChild>
@@ -191,7 +134,7 @@ export default function EventDataForm({
           <Form.Control asChild>
             <Checkbox defaultChecked={initial?.locked} size="3" />
           </Form.Control>
-          <Form.Label>Locked</Form.Label>
+          <Form.Label>Disable Team Management</Form.Label>
 
         </Form.Field>
         <Form.Field name="registration_open" className="flex gap-1">
@@ -204,25 +147,6 @@ export default function EventDataForm({
           <Form.Label>Registration Open</Form.Label>
         </Form.Field>
       </Flex>
-
-      <Flex direction="row-reverse" gap="2">
-        <Form.Submit asChild>
-          <Button
-            type="submit"
-            disabled={!canReset}
-          >
-            {initial ? 'Save' : 'Create '}
-          </Button>
-        </Form.Submit>
-        <Button
-          variant="soft"
-          type="reset"
-          color="gray"
-          disabled={!canReset}
-        >
-          {initial ? 'Revert' : 'Clear'}
-        </Button>
-      </Flex>
-    </Form.Root>
+    </>
   );
 }

--- a/frontend/src/routes/admin/events/EventModal.tsx
+++ b/frontend/src/routes/admin/events/EventModal.tsx
@@ -53,7 +53,6 @@ export default function EventModal({
       }
       onSubmit={handleSubmit}
       submitVerb={eventToUpdate ? 'Update' : 'Create'}
-      submitColor={eventToUpdate ? 'amber' : 'lime'}
       requireTouchingForm={!!eventToUpdate}
     >
       <EventDataForm initial={eventToUpdate} />

--- a/frontend/src/routes/admin/events/EventModal.tsx
+++ b/frontend/src/routes/admin/events/EventModal.tsx
@@ -1,0 +1,62 @@
+import { createEvent, updateEvent } from '@/hooks/events';
+import type { Event } from '@/types';
+import { Button } from '@radix-ui/themes';
+import Modal from 'components/Modal';
+import { TbPencil, TbPlus } from 'react-icons/tb';
+import EventDataForm from './EventDataForm';
+
+export default function EventModal({
+  eventToUpdate,
+}: {
+  eventToUpdate?: Event;
+}) {
+  const handleSubmit = async (data: FormData) => {
+    const entries = Object.fromEntries(data.entries());
+    const event: Omit<Event, 'id'> = {
+      name : entries.name as string,
+      description : entries.description as string,
+      start_time : new Date(entries.start_time as string),
+      end_time : new Date(entries.end_time as string),
+      locked : entries.locked === 'on',
+      public : entries.public === 'on',
+      max_team_size : Number(entries.max_team_size),
+      registration_open : entries.registration_open === 'on',
+      registration_start_date : new Date(entries.registration_start_date as string),
+      registration_end_date : new Date(entries.registration_end_date as string),
+    };
+
+    if (eventToUpdate) {
+      // Update existing event
+      return updateEvent(eventToUpdate.id, event);
+    }
+
+    return createEvent(event);
+  };
+
+  return (
+    <Modal
+      title={eventToUpdate ? 'Edit Event' : 'Create Event'}
+      trigger={
+        eventToUpdate
+          ? (
+            <Button variant="soft" color="amber">
+              <TbPencil />
+              Edit
+            </Button>
+          )
+          : (
+            <Button variant="solid" color="lime">
+              <TbPlus />
+              Create Event
+            </Button>
+          )
+      }
+      onSubmit={handleSubmit}
+      submitVerb={eventToUpdate ? 'Update' : 'Create'}
+      submitColor={eventToUpdate ? 'amber' : 'lime'}
+      requireTouchingForm={!!eventToUpdate}
+    >
+      <EventDataForm initial={eventToUpdate} />
+    </Modal>
+  );
+}

--- a/frontend/src/routes/admin/events/EventSidebar.tsx
+++ b/frontend/src/routes/admin/events/EventSidebar.tsx
@@ -1,48 +1,28 @@
-import { updateEvent } from '@/hooks/events';
-import { Button, Flex, Heading } from '@radix-ui/themes';
-import { Link } from 'react-router';
-import AdminSidebar from 'components/AdminSidebar';
+import { TeamIcon } from '@/constants';
 import type { Event } from '@/types';
-import { useState } from 'react';
-import { TeamIcon, UserIcon } from '@/constants';
-import AdminChallengeCard from './AdminChallengeCard';
-import EventDataForm from './EventDataForm';
+import { Button } from '@radix-ui/themes';
+import AdminSidebar from 'components/AdminSidebar';
+import AdminSidebarHeader from 'components/AdminSidebarHeader';
+import EventHeader from 'components/EventHeader';
+import { Link } from 'react-router';
+import EventModal from './EventModal';
 
 export default function EventSidebar({ entity }: { entity: Event }) {
-  const [ formError, setFormError ] = useState<string|undefined>();
   return (
-    <AdminSidebar title="Event Details">
-
-      <EventDataForm
-        initial={entity}
-        onSubmit={
-          (e) => {
-            updateEvent(entity.id, e).then(() => {
-              setFormError(undefined);
-            }).catch((err) => {
-              setFormError(err.message);
-            });
-          }
-        }
-        error={formError}
-      />
-
-      <Flex direction="row" gap="4" className="*:!grow w-full">
-        <Button variant="soft" asChild>
+    <AdminSidebar>
+      <AdminSidebarHeader title="Event Details">
+        <Button variant="soft" color="jade" asChild>
           <Link to={`/admin/teams?event=${entity.id}`}>
             <TeamIcon />
             Teams
           </Link>
         </Button>
-        <Button variant="soft" asChild>
-          <Link to={`/admin/users?event=${entity.id}`}>
-            <UserIcon />
-            Users
-          </Link>
-        </Button>
-      </Flex>
-      <Heading>Challenges</Heading>
-      <AdminChallengeCard />
+        <EventModal eventToUpdate={entity} />
+      </AdminSidebarHeader>
+
+      <EventHeader
+        event={entity}
+      />
 
     </AdminSidebar>
   );

--- a/frontend/src/routes/admin/events/index.tsx
+++ b/frontend/src/routes/admin/events/index.tsx
@@ -1,12 +1,10 @@
-import { Button, Dialog, Flex } from '@radix-ui/themes';
+import { useAllEvents } from '@/hooks/events';
+import { Flex } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
-import { TbPlus } from 'react-icons/tb';
-import { createEvent, useAllEvents } from '@/hooks/events';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
-import { useState } from 'react';
+import EventModal from './EventModal';
 import EventSidebar from './EventSidebar';
-import EventDataForm from './EventDataForm';
 
 /**
  * Event management page for admins, will also include challenge YAML uploading.
@@ -85,8 +83,6 @@ export default function AdminEvents() {
     },
   ];
 
-  const [ open, setOpen ] = useState(false);
-
   if (error) {
     return <ErrorCallout>{error.message}</ErrorCallout>;
   }
@@ -94,24 +90,7 @@ export default function AdminEvents() {
   return (
     <Flex direction="column" gap="4" className="h-full w-full">
       <Flex direction="row" gap="4" className="shrink-0">
-        <Dialog.Root open={open} onOpenChange={setOpen}>
-          <Dialog.Trigger>
-            <Button variant="solid">
-              <TbPlus />
-              Create Event
-            </Button>
-          </Dialog.Trigger>
-          <Dialog.Content>
-            <Dialog.Title>Create New Event</Dialog.Title>
-            <EventDataForm onSubmit={(d) => {
-              createEvent(d);
-
-              // close the dialog after submission
-              setOpen(false);
-            }}
-            />
-          </Dialog.Content>
-        </Dialog.Root>
+        <EventModal />
       </Flex>
       <Flex direction="row" gap="4" className="grow">
         <AdminGrid

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -1,27 +1,29 @@
+import { UserIcon } from '@/constants';
+import { useTeamMembers } from '@/hooks/team';
+import type { Team } from '@/types';
 import {
   Button,
   Flex,
   Heading,
   Table,
 } from '@radix-ui/themes';
-import { TbDoorExit, TbPlusMinus, TbStar } from 'react-icons/tb';
-import { useTeamMembers } from '@/hooks/team';
-import Entity from 'components/Entity';
-import type { Team } from '@/types';
-import { ErrorCallout, InfoCallout } from 'components/Callouts';
-import AdminSidebar from 'components/AdminSidebar';
-import RoleBadge from 'components/RoleBadge';
 import AdminDataList from 'components/AdminDataList';
-import { UserIcon } from '@/constants';
+import AdminSidebar from 'components/AdminSidebar';
+import AdminSidebarHeader from 'components/AdminSidebarHeader';
+import { ErrorCallout, InfoCallout } from 'components/Callouts';
+import Entity from 'components/Entity';
+import RoleBadge from 'components/RoleBadge';
+import { TbDoorExit, TbPlusMinus, TbStar } from 'react-icons/tb';
 
 export default function TeamSidebar({ entity }: { entity: Team }) {
   const { data : members, error : membersError } = useTeamMembers(entity.id);
 
   return (
-    <AdminSidebar title="Team Details">
+    <AdminSidebar>
+      <AdminSidebarHeader title="Team Details" />
       <AdminDataList data={{ ...entity }} />
 
-      <Heading>Members</Heading>
+      <AdminSidebarHeader title="Team Details" />
 
       {membersError && <ErrorCallout>{membersError.message}</ErrorCallout> }
       {members && (
@@ -63,13 +65,12 @@ export default function TeamSidebar({ entity }: { entity: Team }) {
           </Table.Body>
         </Table.Root>
       )}
-      <Flex direction="row" gap="2" justify="between" align="center">
-        <Heading>Activity</Heading>
+      <AdminSidebarHeader title="Activity">
         <Button variant="soft" color="amber">
           <TbPlusMinus />
           Point Adjust
         </Button>
-      </Flex>
+      </AdminSidebarHeader>
       <InfoCallout>
         Attempts, hint redemptions, and manual awards for this team.
       </InfoCallout>

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -1,20 +1,16 @@
-import {
-  Button,
-  Flex,
-  Heading,
-  Table,
-} from '@radix-ui/themes';
-import { TbPlus } from 'react-icons/tb';
-import Entity from 'components/Entity';
-import { ErrorCallout } from 'components/Callouts';
 import { EventIcon, TeamIcon } from '@/constants';
-import AdminDataList from 'components/AdminDataList';
-import { useTeamMembers, useUserTeams } from '@/hooks/team';
 import { useUserEvents } from '@/hooks/events';
-import _ from 'lodash';
+import { useTeamMembers, useUserTeams } from '@/hooks/team';
 import type { Event, Team, User } from '@/types';
+import { Button, Table } from '@radix-ui/themes';
+import AdminDataList from 'components/AdminDataList';
 import AdminSidebar from 'components/AdminSidebar';
+import AdminSidebarHeader from 'components/AdminSidebarHeader';
+import { ErrorCallout } from 'components/Callouts';
+import Entity from 'components/Entity';
 import RoleBadge from 'components/RoleBadge';
+import _ from 'lodash';
+import { TbPlus } from 'react-icons/tb';
 
 function RegistrationRow({ userId, team, event }: { userId: number, team: Team, event: Event }) {
   const { data : teamMembers } = useTeamMembers(team.id);
@@ -52,16 +48,17 @@ export default function UserSidebar({ entity }: { entity: User }) {
   const eventsMap = _.keyBy(eventsData, 'id');
 
   return (
-    <AdminSidebar title="User Details">
+    <AdminSidebar>
+      <AdminSidebarHeader title="User Details" />
+
       <AdminDataList data={{ ...entity }} />
 
-      <Flex direction="row" gap="4" justify="between" align="center">
-        <Heading>Registrations</Heading>
+      <AdminSidebarHeader title="Registrations">
         <Button variant="soft">
           <TbPlus />
           Register
         </Button>
-      </Flex>
+      </AdminSidebarHeader>
       {teamsError && <ErrorCallout>{teamsError.message}</ErrorCallout> }
       {eventsError && <ErrorCallout>{eventsError.message}</ErrorCallout> }
       {teamsData && eventsData && (
@@ -87,7 +84,7 @@ export default function UserSidebar({ entity }: { entity: User }) {
         </Table.Root>
       )}
 
-      <Heading>Workspace</Heading>
+      <AdminSidebarHeader title="Workspace" />
     </AdminSidebar>
   );
 }

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -9,7 +9,7 @@ import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout } from 'components/Callouts';
 import Entity from 'components/Entity';
 import RoleBadge from 'components/RoleBadge';
-import _ from 'lodash';
+import { keyBy } from 'lodash';
 import { TbPlus } from 'react-icons/tb';
 
 function RegistrationRow({ userId, team, event }: { userId: number, team: Team, event: Event }) {
@@ -45,7 +45,7 @@ export default function UserSidebar({ entity }: { entity: User }) {
   const { data : teamsData, error : teamsError } = useUserTeams(entity.id);
   const { data : eventsData, error : eventsError } = useUserEvents(entity.id);
 
-  const eventsMap = _.keyBy(eventsData, 'id');
+  const eventsMap = keyBy(eventsData, 'id');
 
   return (
     <AdminSidebar>

--- a/frontend/src/routes/events/OverviewTabs/TeamTab/AddMemberModal.tsx
+++ b/frontend/src/routes/events/OverviewTabs/TeamTab/AddMemberModal.tsx
@@ -1,63 +1,38 @@
-import { useState } from 'react';
-import {
-  Box,
-  Button,
-  Dialog,
-  Flex,
-  TextField,
-} from '@radix-ui/themes';
-import { TbX } from 'react-icons/tb';
+import { Button, TextField } from '@radix-ui/themes';
+import Modal from 'components/Modal';
 
 interface AddMemberModalProps {
   inviteCode: string,
 }
 
 export default function AddMemberModal({ inviteCode }: AddMemberModalProps) {
-  const [ open, setOpen ] = useState<boolean>(false);
   const inviteURL = `${window.location.origin}/teamSetup/invite/${inviteCode}`;
 
   return (
-    <Box maxWidth="200px">
-      <Dialog.Root open={open} onOpenChange={setOpen}>
-        <Dialog.Trigger>
-          <Button>Add Member</Button>
-        </Dialog.Trigger>
-
-        <Dialog.Content aria-describedby={undefined}>
-          <Flex direction="row">
-            <Dialog.Title
-              className="pb-2"
-            >
-              Invite Members by shaing this link.
-            </Dialog.Title>
-            <Dialog.Close>
-              <button type="button" aria-label="Close" className="absolute left-auto right-4 top-4">
-                <TbX />
-              </button>
-            </Dialog.Close>
-          </Flex>
-          <Flex mb="3" direction="column">
-            <TextField.Root
-              size="3"
-              value={inviteURL}
-              type="text"
-              readOnly
-            >
-              <TextField.Slot pr="3" side="right">
-                <Button
-                  size="1"
-                  onClick={() => {
-                  // Clipboard only works in secure context (https)
-                    navigator.clipboard.writeText(inviteURL);
-                  }}
-                >
-                  Copy
-                </Button>
-              </TextField.Slot>
-            </TextField.Root>
-          </Flex>
-        </Dialog.Content>
-      </Dialog.Root>
-    </Box>
+    <Modal
+      trigger={(<Button className="!max-w-32">Add Member</Button>)}
+      title="Invite Members"
+      description="Invite members to your team by sharing this link."
+    >
+      <TextField.Root
+        size="3"
+        value={inviteURL}
+        type="text"
+        readOnly
+      >
+        <TextField.Slot pr="3" side="right">
+          <Button
+            size="1"
+            type="button"
+            onClick={() => {
+              // Clipboard only works in secure context (https)
+              navigator.clipboard.writeText(inviteURL);
+            }}
+          >
+            Copy
+          </Button>
+        </TextField.Slot>
+      </TextField.Root>
+    </Modal>
   );
 }

--- a/frontend/src/routes/events/OverviewTabs/TeamTab/AssignCaptainModal.tsx
+++ b/frontend/src/routes/events/OverviewTabs/TeamTab/AssignCaptainModal.tsx
@@ -17,14 +17,13 @@ export default function AssignCaptainModal({ id, name }:AssignCaptainModalProps)
       title={`Are you sure you want to assign ${name}?`}
       description="You will no longer be a Team Captain. By assigning a new member as Team Captain, you will lose your ability to add and remove team members."
       trigger={(
-        <Button variant="soft" color="amber">
+        <Button variant="soft" color="lime">
           <TbStar />
           Assign Captain
         </Button>
       )}
       onSubmit={assignCaptain}
       submitVerb="Assign"
-      submitColor="amber"
     />
   );
 }

--- a/frontend/src/routes/events/OverviewTabs/TeamTab/AssignCaptainModal.tsx
+++ b/frontend/src/routes/events/OverviewTabs/TeamTab/AssignCaptainModal.tsx
@@ -1,5 +1,6 @@
-import { Text } from '@radix-ui/themes';
+import { Button } from '@radix-ui/themes';
 import Modal from 'components/Modal';
+import { TbStar } from 'react-icons/tb';
 
 interface AssignCaptainModalProps {
   id: string,
@@ -7,20 +8,23 @@ interface AssignCaptainModalProps {
 }
 
 export default function AssignCaptainModal({ id, name }:AssignCaptainModalProps) {
-  const assignCaptain = () => {
+  const assignCaptain = async () => {
     console.log('assign captain', id);
   };
 
   return (
     <Modal
       title={`Are you sure you want to assign ${name}?`}
-      buttonText="Assign Captain"
+      description="You will no longer be a Team Captain. By assigning a new member as Team Captain, you will lose your ability to add and remove team members."
+      trigger={(
+        <Button variant="soft" color="amber">
+          <TbStar />
+          Assign Captain
+        </Button>
+      )}
       onSubmit={assignCaptain}
-      onSubmitText="Assign"
-    >
-      <Text>
-        You will no longer be a Team Captain. By assigning a new member as Team Captain, you will lose your ability to add and remove team members.
-      </Text>
-    </Modal>
+      submitVerb="Assign"
+      submitColor="amber"
+    />
   );
 }

--- a/frontend/src/routes/events/OverviewTabs/TeamTab/LeaveTeamModal.tsx
+++ b/frontend/src/routes/events/OverviewTabs/TeamTab/LeaveTeamModal.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import { map } from 'lodash';
-import { Flex, Text, Select } from '@radix-ui/themes';
+import { Button, Select, Text } from '@radix-ui/themes';
 import Modal from 'components/Modal';
+import { map } from 'lodash';
+import { useState } from 'react';
+import { TbDoorExit } from 'react-icons/tb';
 
 type memberListType = {
   id: string,
@@ -14,9 +15,9 @@ interface LeaveTeamModalProps {
 }
 
 export default function LeaveTeamModal({ transferCaptain, membersList }: LeaveTeamModalProps) {
-  const [ newCaptain, setNewCaptain ] = useState<string | undefined>(undefined);
+  const [ newCaptain, setNewCaptain ] = useState<string>('');
 
-  const leaveTeam = () => {
+  const leaveTeam = async () => {
     console.log('leaveTeam action', newCaptain);
     // action for selecting a new captain
     // action for leaving team
@@ -25,31 +26,45 @@ export default function LeaveTeamModal({ transferCaptain, membersList }: LeaveTe
   return (
     <Modal
       title="Are you sure you want to leave the team?"
-      buttonText="Leave Team"
+      description="You will no longer have access to participate with this team."
+      trigger={(
+        <Button variant="soft" color="red">
+          <TbDoorExit />
+          Leave Team
+        </Button>
+      )}
       onSubmit={leaveTeam}
-      onSubmitText="Leave"
-      onSubmitColor="red"
+      onOpenChange={(open) => {
+        if (open) {
+          // reset captain state when modal is closed and reopened
+          setNewCaptain('');
+        }
+      }}
+      submitVerb="Leave"
+      submitColor="red"
+      submitDisabled={transferCaptain && newCaptain === ''}
     >
-      <Flex gap="4" direction="column">
-        {transferCaptain && (
-          <>
-            <Text>
-              All teams must have at least one captain. Please select a new captain before leaving.
-            </Text>
-            <Select.Root defaultValue="" onValueChange={setNewCaptain}>
-              <Select.Trigger placeholder="Select a member" />
-              <Select.Content position="popper">
-                <Select.Group>
-                  {map(membersList, (member: { id: string, name: string}) => (
-                    <Select.Item key={member.id} value={member.id}>{member.name}</Select.Item>
-                  ))}
-                </Select.Group>
-              </Select.Content>
-            </Select.Root>
-          </>
-        )}
-        <Text>You will no longer have access to participate with this team.</Text>
-      </Flex>
+      {transferCaptain && (
+      <>
+        <Text>
+          All teams must have at least one captain. Please select a new captain before leaving.
+        </Text>
+
+        <Select.Root
+          defaultValue=""
+          onValueChange={setNewCaptain}
+        >
+          <Select.Trigger placeholder="Select a member" />
+          <Select.Content position="popper">
+            <Select.Group>
+              {map(membersList, (member: { id: string, name: string}) => (
+                <Select.Item key={member.id} value={member.id}>{member.name}</Select.Item>
+              ))}
+            </Select.Group>
+          </Select.Content>
+        </Select.Root>
+      </>
+      )}
     </Modal>
   );
 }

--- a/frontend/src/routes/events/OverviewTabs/TeamTab/RemovePlayerModal.tsx
+++ b/frontend/src/routes/events/OverviewTabs/TeamTab/RemovePlayerModal.tsx
@@ -1,5 +1,6 @@
-import { Text } from '@radix-ui/themes';
+import { Button } from '@radix-ui/themes';
 import Modal from 'components/Modal';
+import { TbDoorExit } from 'react-icons/tb';
 
 interface RemovePlayerModalProps {
   id: string,
@@ -7,22 +8,23 @@ interface RemovePlayerModalProps {
 }
 
 export default function RemovePlayerModal({ id, name }:RemovePlayerModalProps) {
-  const removePlayer = () => {
+  const removePlayer = async () => {
     console.log('remove the player', id);
   };
 
   return (
     <Modal
       title={`Are you sure you want to remove ${name}?`}
-      buttonText="Remove"
+      description="They will no longer have access to participate with this team. The invite code for the team will change."
+      trigger={(
+        <Button variant="soft" color="red">
+          <TbDoorExit />
+          Remove Player
+        </Button>
+      )}
       onSubmit={removePlayer}
-      onSubmitText="Remove"
-      onSubmitColor="red"
-    >
-      <Text>
-        They will no longer have access to participate with this team.
-        The invite code for the team will change.
-      </Text>
-    </Modal>
+      submitVerb="Remove"
+      submitColor="red"
+    />
   );
 }

--- a/frontend/src/routes/events/OverviewTabs/TeamTab/TransferTeamModal.tsx
+++ b/frontend/src/routes/events/OverviewTabs/TeamTab/TransferTeamModal.tsx
@@ -7,6 +7,7 @@ import {
 import Modal from 'components/Modal';
 import { map } from 'lodash';
 import { useState } from 'react';
+import { TbArrowRight } from 'react-icons/tb';
 
 type memberListType = {
   id: string,
@@ -35,7 +36,8 @@ export default function TransferTeamModal({ transferCaptain, membersList }: Tran
       submitVerb="Transfer"
       onSubmit={transferTeam}
       trigger={(
-        <Button variant="soft" color="amber">
+        <Button variant="soft" color="lime">
+          <TbArrowRight />
           Transfer Team
         </Button>
       )}

--- a/frontend/src/routes/events/OverviewTabs/TeamTab/TransferTeamModal.tsx
+++ b/frontend/src/routes/events/OverviewTabs/TeamTab/TransferTeamModal.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react';
-import { map } from 'lodash';
 import {
-  Flex,
+  Button,
+  Select,
   Text,
   TextField,
-  Select,
 } from '@radix-ui/themes';
 import Modal from 'components/Modal';
+import { map } from 'lodash';
+import { useState } from 'react';
 
 type memberListType = {
   id: string,
@@ -19,10 +19,10 @@ interface TransferTeamModalProps {
 }
 
 export default function TransferTeamModal({ transferCaptain, membersList }: TransferTeamModalProps) {
-  const [ newCaptain, setNewCaptain ] = useState<string | undefined>(undefined);
+  const [ newCaptain, setNewCaptain ] = useState<string>('');
   const [ inviteCode, setInviteCode ] = useState<string>('');
 
-  const transferTeam = () => {
+  const transferTeam = async () => {
     console.log('transferTeam action', newCaptain, inviteCode);
     // action for selecting a new captain
     // action for leaving team
@@ -31,11 +31,24 @@ export default function TransferTeamModal({ transferCaptain, membersList }: Tran
   return (
     <Modal
       title="Are you sure you want to transfer teams?"
-      buttonText="Transfer Team"
+      description="You will no longer have access to participate with this team, and will be moved to a new team."
+      submitVerb="Transfer"
       onSubmit={transferTeam}
-      onSubmitText="Submit"
+      trigger={(
+        <Button variant="soft" color="amber">
+          Transfer Team
+        </Button>
+      )}
+      onOpenChange={(open) => {
+        if (open) {
+          // reset state when modal is closed and reopened
+          setNewCaptain('');
+          setInviteCode('');
+        }
+      }}
+      submitDisabled={(transferCaptain && newCaptain === '') || inviteCode === ''}
     >
-      <Flex gap="4" direction="column">
+      <>
         {transferCaptain && (
           <>
             <Text>
@@ -62,7 +75,7 @@ export default function TransferTeamModal({ transferCaptain, membersList }: Tran
           defaultValue=""
           onChange={(e) => setInviteCode(e.target.value)}
         />
-      </Flex>
+      </>
     </Modal>
   );
 }

--- a/frontend/src/routes/events/OverviewTabs/TeamTab/index.tsx
+++ b/frontend/src/routes/events/OverviewTabs/TeamTab/index.tsx
@@ -1,11 +1,11 @@
-import { map } from 'lodash';
 import { Flex, Table } from '@radix-ui/themes';
-import EditTeamName from './EditTeamName';
+import { map } from 'lodash';
 import AddMemberModal from './AddMemberModal';
-import RemovePlayerModal from './RemovePlayerModal';
-import LeaveTeamModal from './LeaveTeamModal';
-import TransferTeamModal from './TransferTeamModal';
 import AssignCaptainModal from './AssignCaptainModal';
+import EditTeamName from './EditTeamName';
+import LeaveTeamModal from './LeaveTeamModal';
+import RemovePlayerModal from './RemovePlayerModal';
+import TransferTeamModal from './TransferTeamModal';
 
 export default function TeamManagement() {
   const selfId = '1'; // its a me, Mario

--- a/frontend/src/routes/events/RegistrationModal.tsx
+++ b/frontend/src/routes/events/RegistrationModal.tsx
@@ -21,7 +21,6 @@ export default function RegistrationModal({ eventId }: {eventId : Event['id']}) 
       )}
       onSubmit={register}
       submitVerb="Register"
-      submitColor="lime"
     >
       <Form.Field name="leaderboard_name">
         <Form.Label>

--- a/frontend/src/routes/events/RegistrationModal.tsx
+++ b/frontend/src/routes/events/RegistrationModal.tsx
@@ -1,43 +1,42 @@
-import {
-  Em,
-  Flex,
-  Text,
-  TextField,
-} from '@radix-ui/themes';
-import { useState } from 'react';
-import Modal from 'components/Modal';
 import { registerMyEvent } from '@/hooks/events';
 import type { Event } from '@/types';
+import { Button, TextField } from '@radix-ui/themes';
+import Modal from 'components/Modal';
+import { Form } from 'radix-ui';
 
 export default function RegistrationModal({ eventId }: {eventId : Event['id']}) {
-  const [ leaderboardName, setLeaderboardName ] = useState<string>('');
-
   // Todo: alternate case when team game vs individual
 
-  const register = () => {
-    registerMyEvent(eventId, leaderboardName);
+  const register = async (data: FormData) => {
+    const leaderboardName = data.get('leaderboard_name') as string;
+    return registerMyEvent(eventId, leaderboardName);
   };
 
   return (
     <Modal
       title="Are you sure you want to register for this event?"
-      buttonText="Register"
+      description="Please do not use your real name."
+      trigger={(
+        <Button variant="soft">Register</Button>
+      )}
       onSubmit={register}
-      onSubmitText="Register"
+      submitVerb="Register"
+      submitColor="lime"
     >
-      <Flex direction="column" gap="3">
-        <Text><Em>Please do not use your real name.</Em></Text>
-        <Text as="div" size="2" mb="1" weight="bold">
-          Leaderboard Name:
-        </Text>
-        <TextField.Root
-          placeholder="Enter your leaderboard name"
-          value={leaderboardName}
-          onChange={(e) => {
-            setLeaderboardName(e.target.value);
-          }}
-        />
-      </Flex>
+      <Form.Field name="leaderboard_name">
+        <Form.Label>
+          Leaderboard Name
+        </Form.Label>
+        <Form.Control asChild>
+          <TextField.Root
+            placeholder="Enter your leaderboard name"
+            required
+          />
+        </Form.Control>
+        <Form.Message match="valueMissing">
+          Please enter a leaderboard name.
+        </Form.Message>
+      </Form.Field>
     </Modal>
   );
 }


### PR DESCRIPTION
Updates the modal component to work with forms and promise-based submit actions. Also adds more flexibility in defining the modal trigger element and allows disabling the submit button when certain conditions are true (or if the form has not been edited.)

As part of this change, I also moved the event editing form into a modal similar to event creation. This is activated by an edit button to prevent accidental changes, which may have occurred with the previous sidebar form.