### PR TITLE
Search param double nav fixes, serialize grid filters into url

### DIFF
--- a/frontend/src/components/AdminGrid.tsx
+++ b/frontend/src/components/AdminGrid.tsx
@@ -1,8 +1,8 @@
 import { radixTheme } from '@/grid';
 import { Flex, Spinner } from '@radix-ui/themes';
-import type { ColDef, GridState } from 'ag-grid-community';
+import type { ColDef, GridApi } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
 /**
@@ -11,22 +11,73 @@ import { useSearchParams } from 'react-router';
 export default function AdminGrid<T>({
   rowData,
   columnDefs,
-  initialState,
   loading = false,
   sidebarComponent : Sidebar,
   getRowId,
 }: {
-    rowData: T[];
-    columnDefs: ColDef<T>[];
-    initialState?: GridState;
-    loading?: boolean;
-    sidebarComponent?: React.ComponentType<{entity: T}>;
-    getRowId: (params: { data: T }) => string;
+  rowData: T[];
+  columnDefs: ColDef<T>[];
+  loading?: boolean;
+  sidebarComponent?: React.ComponentType<{entity: T}>;
+  getRowId: (params: { data: T }) => string;
 }) {
   const [ searchParams, setSearchParams ] = useSearchParams();
   const selectedId = searchParams.get('id');
 
+  const [ gridApi, setGridApi ] = useState<GridApi<T> | null>(null);
+
   const [ selectedData, setSelectedData ] = useState<T | null>(null);
+
+  const updateSelection = useCallback(() => {
+    if (!gridApi) return;
+    if (selectedId) {
+      const node = gridApi.getRowNode(selectedId);
+      node?.setSelected(true, true);
+      setSelectedData(node?.data ?? null);
+    } else {
+      gridApi.deselectAll();
+      setSelectedData(null);
+    }
+  }, [ gridApi, selectedId ]);
+
+  // If the selected ID changes in the URL, update the selection.
+  // This will also set the selected data object based on the selected row data.
+  useEffect(() => {
+    updateSelection();
+  }, [ updateSelection ]);
+
+  // Update grid filter model when URL changes
+  useEffect(() => {
+    if (!gridApi) return;
+    if (searchParams.has('filter')) {
+      const filterModel = searchParams.get('filter')!;
+      try {
+        gridApi.setFilterModel(JSON.parse(atob(filterModel)));
+      } catch {
+        // If parsing fails, reset filters
+        gridApi.setFilterModel({});
+      }
+    } else {
+      gridApi.setFilterModel({});
+    }
+  }, [ gridApi, searchParams ]);
+
+  // Use filter model from the URL to set initial filter state
+  const initialState = {
+    filter : {
+      filterModel : (() => {
+        const filter = searchParams.get('filter');
+        if (filter) {
+          try {
+            return JSON.parse(atob(filter));
+          } catch {
+            return {};
+          }
+        }
+        return {};
+      })(),
+    },
+  };
 
   return (
     <Flex direction="row" gap="4" className="w-full h-full">
@@ -49,21 +100,38 @@ export default function AdminGrid<T>({
               prev.set('id', event.node.id!);
               return prev;
             });
-            setSelectedData(event.data ?? null);
           }
-          if (event.api.getSelectedNodes().length === 0) {
+          if (event.api.getSelectedNodes().length === 0 && selectedId) {
             setSearchParams((prev) => {
               prev.delete('id');
               return prev;
             });
-            setSelectedData(null);
           }
         }}
-        onRowDataUpdated={(params) => {
-          if (selectedId) {
-            const node = params.api.getRowNode(selectedId);
-            node?.setSelected(true);
-            setSelectedData(node?.data ?? null);
+        onRowDataUpdated={updateSelection} // ensure selection is accurate when grid rows load
+        onGridReady={(params) => {
+          setGridApi(params.api);
+        }}
+        onFilterChanged={(params) => {
+          // Update the URL when grid filter model changes
+          const filterModel = params.api.getFilterModel();
+          if (Object.keys(filterModel).length > 0) {
+            const filterString = btoa(JSON.stringify(filterModel));
+
+            // don't double nav if the filter won't change
+            if (searchParams.get('filter') === filterString) return;
+
+            setSearchParams((prev) => {
+              prev.set('filter', filterString);
+              return prev;
+            });
+          } else {
+            if (!searchParams.has('filter')) return;
+
+            setSearchParams((prev) => {
+              prev.delete('filter');
+              return prev;
+            });
           }
         }}
         initialState={initialState}

--- a/frontend/src/routes/admin/events/EventSidebar.tsx
+++ b/frontend/src/routes/admin/events/EventSidebar.tsx
@@ -17,7 +17,7 @@ export default function EventSidebar({ entity }: { entity: Event }) {
     <AdminSidebar>
       <AdminSidebarHeader title="Event Details">
         <Button variant="soft" color={COLOR_INFO} asChild>
-          <Link to={`/admin/teams?event=${entity.id}`}>
+          <Link to={`/admin/teams?filter=${btoa(JSON.stringify({ event_id : { filterType : 'number', type : 'equals', filter : entity.id } }))}`}>
             <TeamIcon />
             Teams
           </Link>

--- a/frontend/src/routes/admin/teams/index.tsx
+++ b/frontend/src/routes/admin/teams/index.tsx
@@ -1,12 +1,11 @@
+import { EventIcon } from '@/constants';
+import { useEvent } from '@/hooks/events';
+import { useAllTeams } from '@/hooks/team';
+import type { Team } from '@/types';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
-import type { Team } from '@/types';
-import { useEvent } from '@/hooks/events';
 import Entity from 'components/Entity';
-import { useAllTeams } from '@/hooks/team';
-import { useSearchParams } from 'react-router';
-import { EventIcon } from '@/constants';
 import MemberCountBadge from 'components/MemberCountBadge';
 import TeamSidebar from './TeamSidebar';
 
@@ -35,9 +34,6 @@ function EventCellRenderer({ value }: { value: number }) {
  * Team management page for admins.
  */
 export default function AdminTeams() {
-  const [ searchParams ] = useSearchParams();
-  const eventId = searchParams.get('event');
-
   const { data, error, isLoading } = useAllTeams();
 
   if (error) {
@@ -58,6 +54,10 @@ export default function AdminTeams() {
       headerName : 'Event',
       width : 200,
       filter : 'agNumberColumnFilter',
+      filterParams : {
+        filterOptions : [ 'equals' ],
+        maxNumConditions : 1,
+      },
       floatingFilter : true,
       cellRenderer : EventCellRenderer,
     },
@@ -90,16 +90,6 @@ export default function AdminTeams() {
       columnDefs={colDefs}
       loading={isLoading}
       getRowId={(params) => params.data.id.toString()}
-      initialState={{
-        filter : {
-          filterModel : {
-            event_id : {
-              type : 'equals',
-              filter : eventId ?? '',
-            },
-          },
-        },
-      }}
       sidebarComponent={TeamSidebar}
     />
   );

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -29,7 +29,11 @@ function RegistrationRow({ userId, team, event }: { userId: number, team: Team, 
         <Entity label={event.name} icon={EventIcon} to={`/admin/events?id=${event.id}`} />
       </Table.Cell>
       <Table.Cell>
-        <Entity label={team.name} icon={TeamIcon} to={`/admin/teams?event=${team.event_id}&id=${team.id}`} />
+        <Entity
+          label={team.name}
+          icon={TeamIcon}
+          to={`/admin/teams?id=${team.id}&filter=${btoa(JSON.stringify({ event_id : { filterType : 'number', type : 'equals', filter : event.id } }))}`}
+        />
       </Table.Cell>
       <Table.Cell>
         <RoleBadge value={membership.role} />

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -31,6 +31,9 @@ export default function Overview() {
       <Tabs.Root
         value={currentTab}
         onValueChange={(tab) => {
+          if (tab === searchParams.get('tab')) {
+            return;
+          }
           setSearchParams((prev) => {
             prev.set('tab', tab);
             return prev;


### PR DESCRIPTION
Fixes some double navigations related to search params that resulted in inconsistent back button behavior. Also sets up proper two-way data flow for filters/selection between the grid and the URL params - the full grid filter state is now encoded as base64 in the URL, which resolves some inconsistent behavior in the grid when navigating forward/back.