### PR TITLE
User Support page

### DIFF
--- a/frontend/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/frontend/src/components/RichTextEditor/RichTextEditor.tsx
@@ -22,20 +22,20 @@ import styles from './milkdown.module.css';
 function CrepeEditor({
   initialValue = '',
   onChange,
-  version = 0
+  version = 0,
 }: {
   initialValue?: string,
   onChange: (value: string) => void,
   version: number
 }) {
   const features = {
-    'image-block': false,
-    latex: false,
+    'image-block' : false,
+    latex : false,
   };
 
   const featureConfigs = {
-    placeholder: {
-      text: 'Type here...',
+    placeholder : {
+      text : 'Type here...',
     },
   };
 
@@ -44,7 +44,7 @@ function CrepeEditor({
       root,
       features,
       featureConfigs,
-      defaultValue: initialValue,
+      defaultValue : initialValue,
     });
 
     crepe.editor.use(automd);
@@ -58,7 +58,7 @@ function CrepeEditor({
     });
 
     return crepe;
-  }, [version]);
+  }, [ version ]);
 
   return <Milkdown />;
 }
@@ -66,7 +66,7 @@ function CrepeEditor({
 export default function MilkdownEditorWrapper({
   initialValue = '',
   onChange,
-  version = 0
+  version = 0,
 }: {
   initialValue?: string,
   onChange: (value: string) => void,
@@ -75,7 +75,7 @@ export default function MilkdownEditorWrapper({
   return (
     <MilkdownProvider>
       <div className={styles.milkdownEditor}>
-        <CrepeEditor initialValue={initialValue} onChange={onChange} version={version}/>
+        <CrepeEditor initialValue={initialValue} onChange={onChange} version={version} />
       </div>
     </MilkdownProvider>
   );

--- a/frontend/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/frontend/src/components/RichTextEditor/RichTextEditor.tsx
@@ -22,18 +22,20 @@ import styles from './milkdown.module.css';
 function CrepeEditor({
   initialValue = '',
   onChange,
-} : {
-  initialValue? : string,
-  onChange : (value : string) => void,
+  version = 0
+}: {
+  initialValue?: string,
+  onChange: (value: string) => void,
+  version: number
 }) {
   const features = {
-    'image-block' : false,
-    latex : false,
+    'image-block': false,
+    latex: false,
   };
 
   const featureConfigs = {
-    placeholder : {
-      text : 'Type here...',
+    placeholder: {
+      text: 'Type here...',
     },
   };
 
@@ -42,7 +44,7 @@ function CrepeEditor({
       root,
       features,
       featureConfigs,
-      defaultValue : initialValue,
+      defaultValue: initialValue,
     });
 
     crepe.editor.use(automd);
@@ -56,7 +58,7 @@ function CrepeEditor({
     });
 
     return crepe;
-  }, []);
+  }, [version]);
 
   return <Milkdown />;
 }
@@ -64,14 +66,16 @@ function CrepeEditor({
 export default function MilkdownEditorWrapper({
   initialValue = '',
   onChange,
-} : {
-  initialValue? : string,
-  onChange : (value : string) => void,
+  version = 0
+}: {
+  initialValue?: string,
+  onChange: (value: string) => void,
+  version?: number
 }) {
   return (
     <MilkdownProvider>
       <div className={styles.milkdownEditor}>
-        <CrepeEditor initialValue={initialValue} onChange={onChange} />
+        <CrepeEditor initialValue={initialValue} onChange={onChange} version={version}/>
       </div>
     </MilkdownProvider>
   );

--- a/frontend/src/hooks/support.ts
+++ b/frontend/src/hooks/support.ts
@@ -1,0 +1,50 @@
+import useSWR, { mutate } from 'swr';
+import { apiMutation } from '@/fetchers';
+import type { Ticket, TicketMessage } from '@/types';
+
+export function useMyTickets() {
+  return useSWR<Ticket[], Error>('/support/me/tickets');
+}
+
+export function createTicket(formData: {
+  subject: string,
+  text: string,
+  event_id?: number,
+  challenge_id?: number
+}) {
+  return apiMutation('/support/tickets/create', formData, {
+    method : 'POST',
+  }).then(
+    // This is for doing the navigation. Can only have one .then
+    (data): Ticket => data.id,
+  ).finally(() => {
+    mutate('/support/me/tickets');
+  });
+}
+
+export function useMyTicketMessages(ticketId : number) {
+  return useSWR<{
+  ticket: Ticket,
+  messages: TicketMessage[]
+}, Error>(
+  ticketId ? `/support/me/tickets/${ticketId}` : null,
+);
+}
+
+export function addNewTicketMessage(ticketId: number, text: string) {
+  return apiMutation(`/support/me/tickets/${ticketId}/add_message`, { text }, {
+    method : 'POST',
+  }).then(() => {
+    mutate('/support/me/tickets');
+    mutate(`/support/me/tickets/${ticketId}`);
+  });
+}
+
+export function resolveMyTicket(ticketId: number) {
+  return apiMutation(`/support/me/tickets/${ticketId}/close`, {}, {
+    method : 'POST',
+  }).then(() => {
+    mutate('/support/me/tickets');
+    mutate(`/support/me/tickets/${ticketId}`);
+  });
+}

--- a/frontend/src/routes/support/CreateTicket.tsx
+++ b/frontend/src/routes/support/CreateTicket.tsx
@@ -20,44 +20,44 @@ import { ErrorCallout } from 'components/Callouts';
 
 export default function CreateTicket() {
   const navigate = useNavigate();
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [text, setText] = useState<string>();
-  const [selectedEvent, setSelectedEvent] = useState<string | undefined>();
-  const [selectedChallenge, setSelectedChallenge] = useState<string | undefined>();
+  const [ error, setError ] = useState<string | null>(null);
+  const [ loading, setLoading ] = useState<boolean>(false);
+  const [ text, setText ] = useState<string>();
+  const [ selectedEvent, setSelectedEvent ] = useState<string | undefined>();
+  const [ selectedChallenge, setSelectedChallenge ] = useState<string | undefined>();
 
-  const { data: events, error: eventsError } = useMyEvents();
-  const { data: challenges, error: challengeError } = useMyChallenges(Number(selectedEvent));
+  const { data : events, error : eventsError } = useMyEvents();
+  const { data : challenges, error : challengeError } = useMyChallenges(Number(selectedEvent));
 
   if (!isUndefined(eventsError)) {
-    return <ErrorCallout>{eventsError?.message}</ErrorCallout>
-  } else if (!isUndefined(challengeError)) {
-    <ErrorCallout>{challengeError?.message}</ErrorCallout>
+    return <ErrorCallout>{eventsError?.message}</ErrorCallout>;
+  } if (!isUndefined(challengeError)) {
+    <ErrorCallout>{challengeError?.message}</ErrorCallout>;
   }
 
   const create = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setLoading(true)
+    setLoading(true);
 
     const formData = new FormData(e.currentTarget);
     const data = Object.fromEntries(formData.entries());
     const parsed = {
       ...data,
-      event_id: data?.event_id ? Number(data.event_id) : undefined,
-      challenge_id: data?.challenge_id ? Number(data.challenge_id) : undefined,
+      event_id : data?.event_id ? Number(data.event_id) : undefined,
+      challenge_id : data?.challenge_id ? Number(data.challenge_id) : undefined,
     };
-    
+
     createTicket(parsed).then((ticketId) => {
       navigate(`/support/${ticketId}`);
     }).catch((err) => {
       setError(err.message);
     }).finally(() => {
-      setLoading(false)
-    })
+      setLoading(false);
+    });
   };
 
   return (
-    <Container size='4'>
+    <Container size="4">
       <Flex gap="3" direction="column">
         <Box maxWidth="200px">
           <Button
@@ -107,14 +107,14 @@ export default function CreateTicket() {
             )}
           </Form.Field>
 
-          <Form.Field name="event_id" className='mt-2'>
-            <Form.Label className='mr-2'>Event:</Form.Label>
+          <Form.Field name="event_id" className="mt-2">
+            <Form.Label className="mr-2">Event:</Form.Label>
             <Select.Root
               name="event_id"
               value={selectedEvent}
               onValueChange={(v: string) => setSelectedEvent(v)}
             >
-              <Select.Trigger placeholder="Select an event" className='w-[200px]' />
+              <Select.Trigger placeholder="Select an event" className="w-[200px]" />
               <Select.Content>
                 <Select.Group>
                   {map(events, (event) => (
@@ -132,8 +132,8 @@ export default function CreateTicket() {
 
           {!isEmpty(selectedEvent)
             && (
-              <Form.Field name="challenge_id" className='mt-2'>
-                <Form.Label className='mr-2'>Challenge:</Form.Label>
+              <Form.Field name="challenge_id" className="mt-2">
+                <Form.Label className="mr-2">Challenge:</Form.Label>
                 <Select.Root
                   name="challenge_id"
                   value={selectedChallenge}
@@ -156,12 +156,12 @@ export default function CreateTicket() {
               </Form.Field>
             )}
 
-          {error && <ErrorCallout className='mt-2'>{error}</ErrorCallout>}
+          {error && <ErrorCallout className="mt-2">{error}</ErrorCallout>}
 
           <Form.Submit asChild>
             <Button
               type="submit"
-              className='!mt-2'
+              className="!mt-2"
               loading={loading}
               disabled={loading}
             >

--- a/frontend/src/routes/support/CreateTicket.tsx
+++ b/frontend/src/routes/support/CreateTicket.tsx
@@ -1,28 +1,175 @@
 import {
   Box,
   Button,
+  Container,
   Flex,
   Heading,
+  TextField,
+  Select,
 } from '@radix-ui/themes';
 import { TbArrowLeft } from 'react-icons/tb';
 import { useNavigate } from 'react-router';
+import RichTextEditor from 'components/RichTextEditor';
+import { useState } from 'react';
+import { Form } from 'radix-ui';
+import { isEmpty, isUndefined, map } from 'lodash';
+import { createTicket } from '@/hooks/support';
+import { useMyEvents } from '@/hooks/events';
+import { useMyChallenges } from '@/hooks/challenge';
+import { ErrorCallout } from 'components/Callouts';
 
 export default function CreateTicket() {
   const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [text, setText] = useState<string>();
+  const [selectedEvent, setSelectedEvent] = useState<string | undefined>();
+  const [selectedChallenge, setSelectedChallenge] = useState<string | undefined>();
+
+  const { data: events, error: eventsError } = useMyEvents();
+  const { data: challenges, error: challengeError } = useMyChallenges(Number(selectedEvent));
+
+  if (!isUndefined(eventsError)) {
+    return <ErrorCallout>{eventsError?.message}</ErrorCallout>
+  } else if (!isUndefined(challengeError)) {
+    <ErrorCallout>{challengeError?.message}</ErrorCallout>
+  }
+
+  const create = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true)
+
+    const formData = new FormData(e.currentTarget);
+    const data = Object.fromEntries(formData.entries());
+    const parsed = {
+      ...data,
+      event_id: data?.event_id ? Number(data.event_id) : undefined,
+      challenge_id: data?.challenge_id ? Number(data.challenge_id) : undefined,
+    };
+    
+    createTicket(parsed).then((ticketId) => {
+      navigate(`/support/${ticketId}`);
+    }).catch((err) => {
+      setError(err.message);
+    }).finally(() => {
+      setLoading(false)
+    })
+  };
+
   return (
-    <Flex gap="3" direction="column">
-      <Box maxWidth="200px">
-        <Button
-          variant="ghost"
-          onClick={() => { navigate('/support'); }}
-        >
-          <TbArrowLeft />
-          {' '}
-          Support
-        </Button>
-      </Box>
-      <Heading size="7">Create a New Support Ticket</Heading>
-      <div>Chat box goes here with submit button</div>
-    </Flex>
+    <Container size='4'>
+      <Flex gap="3" direction="column">
+        <Box maxWidth="200px">
+          <Button
+            variant="ghost"
+            onClick={() => { navigate('/support'); }}
+          >
+            <TbArrowLeft />
+            Support
+          </Button>
+        </Box>
+        <Heading size="7">Create a New Support Ticket</Heading>
+
+        <Form.Root onSubmit={create}>
+          <Form.Field name="subject">
+            <Form.Label>Subject: *</Form.Label>
+            <Form.Control asChild>
+              <TextField.Root
+                placeholder="Enter a subject for your ticket"
+                required
+              />
+            </Form.Control>
+            <Form.Message match="valueMissing">
+              Subject is a required field
+            </Form.Message>
+          </Form.Field>
+
+          <Form.Field name="text">
+            <Form.Label>Message: *</Form.Label>
+            {/* Hidden input to track value and error handling */}
+            <Form.Control asChild>
+              <input
+                type="hidden"
+                name="text"
+                value={text}
+                required
+              />
+            </Form.Control>
+            {/* Displayed editor */}
+            <RichTextEditor
+              initialValue={text}
+              onChange={setText}
+            />
+            {text === '' && (
+              <Form.Message>
+                Message is a required field.
+              </Form.Message>
+            )}
+          </Form.Field>
+
+          <Form.Field name="event_id" className='mt-2'>
+            <Form.Label className='mr-2'>Event:</Form.Label>
+            <Select.Root
+              name="event_id"
+              value={selectedEvent}
+              onValueChange={(v: string) => setSelectedEvent(v)}
+            >
+              <Select.Trigger placeholder="Select an event" className='w-[200px]' />
+              <Select.Content>
+                <Select.Group>
+                  {map(events, (event) => (
+                    <Select.Item
+                      key={event.id}
+                      value={String(event.id)}
+                    >
+                      {event.name}
+                    </Select.Item>
+                  ))}
+                </Select.Group>
+              </Select.Content>
+            </Select.Root>
+          </Form.Field>
+
+          {!isEmpty(selectedEvent)
+            && (
+              <Form.Field name="challenge_id" className='mt-2'>
+                <Form.Label className='mr-2'>Challenge:</Form.Label>
+                <Select.Root
+                  name="challenge_id"
+                  value={selectedChallenge}
+                  onValueChange={(v: string) => setSelectedChallenge(v)}
+                >
+                  <Select.Trigger placeholder="Select a challenge" />
+                  <Select.Content>
+                    <Select.Group>
+                      {map(challenges, (challenge) => (
+                        <Select.Item
+                          key={challenge.challenge_id}
+                          value={String(challenge.challenge_id)}
+                        >
+                          {challenge.challenge_name}
+                        </Select.Item>
+                      ))}
+                    </Select.Group>
+                  </Select.Content>
+                </Select.Root>
+              </Form.Field>
+            )}
+
+          {error && <ErrorCallout className='mt-2'>{error}</ErrorCallout>}
+
+          <Form.Submit asChild>
+            <Button
+              type="submit"
+              className='!mt-2'
+              loading={loading}
+              disabled={loading}
+            >
+              Submit Ticket
+            </Button>
+          </Form.Submit>
+        </Form.Root>
+      </Flex>
+    </Container>
   );
 }

--- a/frontend/src/routes/support/Detail.tsx
+++ b/frontend/src/routes/support/Detail.tsx
@@ -8,26 +8,26 @@ import {
   Heading,
   Separator,
   Text,
-  Section
+  Section,
 } from '@radix-ui/themes';
 import { StatusBadge } from 'components/StatusBadge';
 import { ErrorCallout } from 'components/Callouts';
 import { TbArrowLeft } from 'react-icons/tb';
 import { useNavigate, useParams } from 'react-router';
 import { isNil, isUndefined, map } from 'lodash';
-import RichTextEditor from 'components/RichTextEditor'
+import RichTextEditor from 'components/RichTextEditor';
 import { useMyTicketMessages, addNewTicketMessage, resolveMyTicket } from '@/hooks/support';
 
 export default function Detail() {
   const navigate = useNavigate();
   const { idTicket } = useParams();
-  const { data, error: errorMessages } = useMyTicketMessages(Number(idTicket));
-  const [version, setVersion] = useState<number>(0) // To reinit the RichTextEditor
-  const [newText, setNewText] = useState<string>('');
-  const [replyError, setReplyError] = useState<string | null>(null);
-  const [resolveError, setResolveError] = useState<boolean>(false);
-  const [resolveLoading, setResolveLoading] = useState<boolean>(false);
-  const [replyLoading, setReplyLoading] = useState<boolean>(false);
+  const { data, error : errorMessages } = useMyTicketMessages(Number(idTicket));
+  const [ version, setVersion ] = useState<number>(0); // To reinit the RichTextEditor
+  const [ newText, setNewText ] = useState<string>('');
+  const [ replyError, setReplyError ] = useState<string | null>(null);
+  const [ resolveError, setResolveError ] = useState<boolean>(false);
+  const [ resolveLoading, setResolveLoading ] = useState<boolean>(false);
+  const [ replyLoading, setReplyLoading ] = useState<boolean>(false);
 
   if (isNil(data) || errorMessages) {
     return (
@@ -36,7 +36,7 @@ export default function Detail() {
           ? 'The data for this ticket could not be found'
           : errorMessages.message}
       </ErrorCallout>
-    )
+    );
   }
 
   const { messages, ticket } = data;
@@ -44,14 +44,14 @@ export default function Detail() {
   const {
     subject,
     status,
-    event_name: eventName,
-    team_name: teamName,
-    challenge_name: challengeName,
+    event_name : eventName,
+    team_name : teamName,
+    challenge_name : challengeName,
   } = ticket;
 
   const resolveTicket = () => {
-    setResolveLoading(true)
-    setResolveError(false)
+    setResolveLoading(true);
+    setResolveError(false);
 
     resolveMyTicket(ticket.id)
       .catch((err) => setResolveError(err.message))
@@ -59,20 +59,20 @@ export default function Detail() {
   };
 
   const sendNewMessage = async () => {
-    setReplyError(null)
-    setReplyLoading(true)
+    setReplyError(null);
+    setReplyLoading(true);
 
-    //add a new message to the ticket
+    // add a new message to the ticket
     addNewTicketMessage(ticket.id, newText)
       .catch((err) => setReplyError(err.message))
       .then(() => {
-        setNewText('')
-        setVersion(prev => prev + 1) //This forces reMount of RichTextEditor
+        setNewText('');
+        setVersion((prev) => prev + 1); // This forces reMount of RichTextEditor
       }).finally(() => setReplyLoading(false));
   };
 
   return (
-    <Container size='4'>
+    <Container size="4">
       <Flex direction="row" gap="4">
         <Flex gap="3" direction="column" className="w-5/7">
           <Box maxWidth="200px">
@@ -85,7 +85,7 @@ export default function Detail() {
             </Button>
           </Box>
           <Heading size="7">Ticket Detail</Heading>
-          <Flex gap='2'>
+          <Flex gap="2">
             <Heading size="3">Subject:</Heading>
             <Text>{subject}</Text>
           </Flex>
@@ -117,7 +117,7 @@ export default function Detail() {
               </Card>
             ))}
           </div>
-          <Flex gap='2' direction='column'>
+          <Flex gap="2" direction="column">
             <RichTextEditor
               initialValue={newText}
               onChange={setNewText}
@@ -140,28 +140,28 @@ export default function Detail() {
 
         <Card size="3" className="w-2/7 h-fit">
           <Flex direction="column" gap="4">
-            <Section size='1'>
+            <Section size="1">
               Event
               <Separator size="4" />
               <Text>
                 {isNil(eventName) ? 'N/A' : eventName}
               </Text>
             </Section>
-            <Section size='1'>
+            <Section size="1">
               Team
               <Separator size="4" />
               <Text>
                 {isNil(teamName) ? 'N/A' : teamName}
               </Text>
             </Section>
-            <Section size='1'>
+            <Section size="1">
               Challenge
               <Separator size="4" />
               <Text>
                 {isNil(challengeName) ? 'N/A' : challengeName}
               </Text>
             </Section>
-            <Section size='1'>
+            <Section size="1">
               Status
               <Separator size="4" />
               {StatusBadge(status)}

--- a/frontend/src/routes/support/Detail.tsx
+++ b/frontend/src/routes/support/Detail.tsx
@@ -108,7 +108,7 @@ export default function Detail() {
               <Card className="mt-2" key={message.id}>
                 <Flex justify="between">
                   <Text weight="bold" size="2">{message.author_name}</Text>
-                  <Text weight="bold" size="2">{new Date(message.created_at).toString()}</Text>
+                  <Text weight="bold" size="2">{message.created_at.toLocaleString()}</Text>
                 </Flex>
                 <Separator size="4" className="mb-1" />
                 <Text as="p">

--- a/frontend/src/routes/support/Detail.tsx
+++ b/frontend/src/routes/support/Detail.tsx
@@ -1,101 +1,174 @@
+import { useState } from 'react';
 import {
   Box,
   Button,
   Card,
+  Container,
   Flex,
   Heading,
   Separator,
   Text,
+  Section
 } from '@radix-ui/themes';
 import { StatusBadge } from 'components/StatusBadge';
+import { ErrorCallout } from 'components/Callouts';
 import { TbArrowLeft } from 'react-icons/tb';
-import { useNavigate } from 'react-router';
-// import Editor from 'components/Editor'; //milkdown
-import { map } from 'lodash';
-/* import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import remarkBreaks from 'remark-breaks';
-import rehypeRaw from 'rehype-raw';
-import rehypeSanitize from 'rehype-sanitize'; */
+import { useNavigate, useParams } from 'react-router';
+import { isNil, isUndefined, map } from 'lodash';
+import RichTextEditor from 'components/RichTextEditor'
+import { useMyTicketMessages, addNewTicketMessage, resolveMyTicket } from '@/hooks/support';
 
 export default function Detail() {
-  const status = 'inprogress';
-  const event = 'blah event';
-  const challenge = 'blah challenge';
-  const repliesArray = [
-    { user : 'user1', timestamp : '2025-11-1', text : 'blah' },
-    { user : 'user2', timestamp : '2025-11-1', text : 'blah' },
-    { user : 'user3', timestamp : '2025-11-1', text : 'blah' },
-    { user : 'user4', timestamp : '2025-11-1', text : 'blah' },
-  ];
-
   const navigate = useNavigate();
+  const { idTicket } = useParams();
+  const { data, error: errorMessages } = useMyTicketMessages(Number(idTicket));
+  const [version, setVersion] = useState<number>(0) // To reinit the RichTextEditor
+  const [newText, setNewText] = useState<string>('');
+  const [replyError, setReplyError] = useState<string | null>(null);
+  const [resolveError, setResolveError] = useState<boolean>(false);
+  const [resolveLoading, setResolveLoading] = useState<boolean>(false);
+  const [replyLoading, setReplyLoading] = useState<boolean>(false);
 
-  function resolveTicket() {
-    // do server call to resolve ticket
-    // onSuccess go back to details page
-    navigate('/support');
+  if (isNil(data) || errorMessages) {
+    return (
+      <ErrorCallout>
+        {isUndefined(errorMessages)
+          ? 'The data for this ticket could not be found'
+          : errorMessages.message}
+      </ErrorCallout>
+    )
   }
 
-  return (
-    <Flex direction="row" gap="4">
-      <Flex gap="3" direction="column" className="w-4/5">
-        <Box maxWidth="200px">
-          <Button
-            variant="ghost"
-            onClick={() => { navigate('/support'); }}
-          >
-            <TbArrowLeft />
-            Support
-          </Button>
-        </Box>
-        <Heading size="7">Ticket Detail</Heading>
-        <Box maxWidth="200px">
-          <Button
-            onClick={() => resolveTicket()}
-          >
-            Mark Ticket as Resolved
-          </Button>
-        </Box>
-        <div>
-          {map(repliesArray, ({ user, timestamp, text }) => (
-            <Card className="pt-8">
-              <Text>{user}</Text>
-              <Text>{timestamp}</Text>
-              <div className="pb-4">
-                {text}
-                markdownreact here
-              </div>
-            </Card>
-          ))}
-        </div>
-        <div>
-          {/* <Editor
-            value={value}
-            onChange={handleOnChange}
-          /> */}
-        </div>
-      </Flex>
+  const { messages, ticket } = data;
 
-      <Card size="3" className="w-1/5">
-        <Flex direction="column" gap="4">
+  const {
+    subject,
+    status,
+    event_name: eventName,
+    team_name: teamName,
+    challenge_name: challengeName,
+  } = ticket;
+
+  const resolveTicket = () => {
+    setResolveLoading(true)
+    setResolveError(false)
+
+    resolveMyTicket(ticket.id)
+      .catch((err) => setResolveError(err.message))
+      .finally(() => setResolveLoading(false));
+  };
+
+  const sendNewMessage = async () => {
+    setReplyError(null)
+    setReplyLoading(true)
+
+    //add a new message to the ticket
+    addNewTicketMessage(ticket.id, newText)
+      .catch((err) => setReplyError(err.message))
+      .then(() => {
+        setNewText('')
+        setVersion(prev => prev + 1) //This forces reMount of RichTextEditor
+      }).finally(() => setReplyLoading(false));
+  };
+
+  return (
+    <Container size='4'>
+      <Flex direction="row" gap="4">
+        <Flex gap="3" direction="column" className="w-5/7">
+          <Box maxWidth="200px">
+            <Button
+              variant="ghost"
+              onClick={() => { navigate('/support'); }}
+            >
+              <TbArrowLeft />
+              Support
+            </Button>
+          </Box>
+          <Heading size="7">Ticket Detail</Heading>
+          <Flex gap='2'>
+            <Heading size="3">Subject:</Heading>
+            <Text>{subject}</Text>
+          </Flex>
+          <Box maxWidth="200px">
+            <Button
+              onClick={() => resolveTicket()}
+              loading={resolveLoading}
+              disabled={resolveLoading || status === 'closed'}
+            >
+              Mark Ticket as Resolved
+            </Button>
+            {resolveError && (
+              <ErrorCallout>
+                {resolveError}
+              </ErrorCallout>
+            )}
+          </Box>
           <div>
-            Event
-            <Separator size="4" />
-            <Text>{event}</Text>
+            {map(messages, (message) => (
+              <Card className="mt-2" key={message.id}>
+                <Flex justify="between">
+                  <Text weight="bold" size="2">{message.author_name}</Text>
+                  <Text weight="bold" size="2">{new Date(message.created_at).toString()}</Text>
+                </Flex>
+                <Separator size="4" className="mb-1" />
+                <Text as="p">
+                  {message.text}
+                </Text>
+              </Card>
+            ))}
           </div>
-          <div>
-            Challenge
-            <Separator size="4" />
-            <Text>{challenge}</Text>
-          </div>
-          <div>
-            Status
-            <Separator size="4" />
-            {StatusBadge(status)}
-          </div>
+          <Flex gap='2' direction='column'>
+            <RichTextEditor
+              initialValue={newText}
+              onChange={setNewText}
+              version={version}
+            />
+            <Button
+              onClick={sendNewMessage}
+              loading={replyLoading}
+              disabled={replyLoading || status === 'closed'}
+            >
+              Reply
+            </Button>
+            {replyError && (
+              <ErrorCallout>
+                {replyError}
+              </ErrorCallout>
+            )}
+          </Flex>
         </Flex>
-      </Card>
-    </Flex>
+
+        <Card size="3" className="w-2/7 h-fit">
+          <Flex direction="column" gap="4">
+            <Section size='1'>
+              Event
+              <Separator size="4" />
+              <Text>
+                {isNil(eventName) ? 'N/A' : eventName}
+              </Text>
+            </Section>
+            <Section size='1'>
+              Team
+              <Separator size="4" />
+              <Text>
+                {isNil(teamName) ? 'N/A' : teamName}
+              </Text>
+            </Section>
+            <Section size='1'>
+              Challenge
+              <Separator size="4" />
+              <Text>
+                {isNil(challengeName) ? 'N/A' : challengeName}
+              </Text>
+            </Section>
+            <Section size='1'>
+              Status
+              <Separator size="4" />
+              {StatusBadge(status)}
+            </Section>
+          </Flex>
+        </Card>
+      </Flex>
+    </Container>
   );
 }

--- a/frontend/src/routes/support/index.tsx
+++ b/frontend/src/routes/support/index.tsx
@@ -24,8 +24,8 @@ export default function Support() {
     { field : 'subject', headerName : 'Subject' },
     { field : 'event_name', headerName : 'Event Name' },
     { field : 'status', headerName : 'Status', cellRenderer : StatusBadgeCell },
-    { field : 'opened_timestamp', headerName : 'Created Date', valueFormatter : (params) => new Date(params.value).toString() },
-    { field : 'last_updated', headerName : 'Last Updated Date', valueFormatter : (params) => new Date(params.value).toString() },
+    { field : 'opened_timestamp', headerName : 'Created Date', valueFormatter : (params) => params.value.toLocaleString() },
+    { field : 'last_updated', headerName : 'Last Updated Date', valueFormatter : (params) => params.value.toLocaleString() },
   ];
 
   return (

--- a/frontend/src/routes/support/index.tsx
+++ b/frontend/src/routes/support/index.tsx
@@ -12,7 +12,7 @@ import { StatusBadgeCell } from 'components/StatusBadge';
 import { radixTheme } from '@/grid';
 import { useMyTickets } from '@/hooks/support';
 import type { Ticket } from '@/types';
-import { isUndefined } from 'lodash'
+import { isUndefined } from 'lodash';
 import { ErrorCallout } from 'components/Callouts';
 
 export default function Support() {
@@ -21,17 +21,17 @@ export default function Support() {
   const { data, error } = useMyTickets();
 
   const colDefs: ColDef<Ticket>[] = [
-    { field: 'subject', headerName: 'Subject' },
-    { field: 'event_name', headerName: 'Event Name' },
-    { field: 'status', headerName: 'Status', cellRenderer: StatusBadgeCell },
-    { field: 'opened_timestamp', headerName: 'Created Date', valueFormatter: (params) => new Date(params.value).toString() },
-    { field: 'last_updated', headerName: 'Last Updated Date', valueFormatter: (params) => new Date(params.value).toString() },
+    { field : 'subject', headerName : 'Subject' },
+    { field : 'event_name', headerName : 'Event Name' },
+    { field : 'status', headerName : 'Status', cellRenderer : StatusBadgeCell },
+    { field : 'opened_timestamp', headerName : 'Created Date', valueFormatter : (params) => new Date(params.value).toString() },
+    { field : 'last_updated', headerName : 'Last Updated Date', valueFormatter : (params) => new Date(params.value).toString() },
   ];
 
   return (
     <Container size="4">
-      {!isUndefined(error) ?
-        <ErrorCallout>{error?.message}</ErrorCallout>
+      {!isUndefined(error)
+        ? <ErrorCallout>{error?.message}</ErrorCallout>
         : (
           <Flex gap="3" direction="column">
             <Heading size="7">Support Tickets</Heading>

--- a/frontend/src/routes/support/index.tsx
+++ b/frontend/src/routes/support/index.tsx
@@ -10,48 +10,47 @@ import type { ColDef } from 'ag-grid-community';
 import { useNavigate } from 'react-router';
 import { StatusBadgeCell } from 'components/StatusBadge';
 import { radixTheme } from '@/grid';
+import { useMyTickets } from '@/hooks/support';
+import type { Ticket } from '@/types';
+import { isUndefined } from 'lodash'
+import { ErrorCallout } from 'components/Callouts';
 
 export default function Support() {
   const navigate = useNavigate();
-  const rowData = [
-    {
-      id : '1', subject : 'test ticket 1', event : 'track 1 round 1', status : 'open', created : '2022-02-14', updated : '2022-02-15',
-    },
-    {
-      id : '3', subject : 'test ticket 3', event : 'track 1 round 3', status : 'inprogress', created : '2022-02-14', updated : '2022-02-15',
-    },
-    {
-      id : '2', subject : 'test ticket 2', event : 'track 1 round 2', status : 'closed', created : '2022-02-14', updated : '2022-02-15',
-    },
-  ];
 
-  const colDefs: ColDef<typeof rowData[number]>[] = [
-    { field : 'subject' },
-    { field : 'event' },
-    { field : 'status', cellRenderer : StatusBadgeCell },
-    { field : 'created', valueFormatter : (params) => new Date(params.value).toString() },
-    { field : 'updated', valueFormatter : (params) => new Date(params.value).toString() },
+  const { data, error } = useMyTickets();
+
+  const colDefs: ColDef<Ticket>[] = [
+    { field: 'subject', headerName: 'Subject' },
+    { field: 'event_name', headerName: 'Event Name' },
+    { field: 'status', headerName: 'Status', cellRenderer: StatusBadgeCell },
+    { field: 'opened_timestamp', headerName: 'Created Date', valueFormatter: (params) => new Date(params.value).toString() },
+    { field: 'last_updated', headerName: 'Last Updated Date', valueFormatter: (params) => new Date(params.value).toString() },
   ];
 
   return (
     <Container size="4">
-      <Flex gap="3" direction="column">
-        <Heading size="7">Support Tickets</Heading>
-        <Box maxWidth="200px">
-          <Button
-            onClick={() => navigate('/support/createTicket')}
-          >
-            Create Ticket
-          </Button>
-        </Box>
-        <AgGridReact
-          theme={radixTheme}
-          rowData={rowData}
-          columnDefs={colDefs}
-          domLayout="autoHeight"
-          onRowClicked={(e) => navigate(`/support/${e.data?.id}`)}
-        />
-      </Flex>
+      {!isUndefined(error) ?
+        <ErrorCallout>{error?.message}</ErrorCallout>
+        : (
+          <Flex gap="3" direction="column">
+            <Heading size="7">Support Tickets</Heading>
+            <Box maxWidth="200px">
+              <Button
+                onClick={() => navigate('/support/createTicket')}
+              >
+                Create Ticket
+              </Button>
+            </Box>
+            <AgGridReact
+              theme={radixTheme}
+              rowData={data}
+              columnDefs={colDefs}
+              domLayout="autoHeight"
+              onRowClicked={(e) => navigate(`/support/${e.data?.id}`)}
+            />
+          </Flex>
+        )}
     </Container>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -53,6 +53,7 @@ export interface Challenge {
 
 export interface MeChallenge {
   challenge_id: number;
+  challenge_name: string;
   total_points_available: number;
   total_points_scored: number;
   num_questions_solved: number;
@@ -107,4 +108,31 @@ export interface ScoreEvent {
   team_id: number;
   points: number;
   timestamp: Date;
+}
+
+export interface Ticket {
+  id: number;
+  subject: string;
+  event_id?: number;
+  event_name?: string;
+  team_id?: number;
+  team_name?: string;
+  challenge_id?: number;
+  challenge_name?: string;
+  status: 'open' | 'closed' | 'inprogress';
+  last_updated: Date;
+  opened_timestamp: Date;
+  author_id: number;
+  message_count: number;
+  tags: string[]
+}
+
+export interface TicketMessage {
+  author_id: number;
+  author_name: string;
+  author_type: string;
+  created_at: Date;
+  id: number;
+  text: string;
+  ticket_id: number
 }


### PR DESCRIPTION
Support Detail page:
- User can close (not reopen) ticket
- User can reply to ticket (only when ticket isn't closed)

Create Ticket Page:
- User must input a subject and message
- Event, and Challenge fields are optional
- Team is auto-filled based on event and user in the backend

Support Index page:
- Displays a table of the current user's tickets