### PR TITLE
Team activity and manual score adjustment

### DIFF
--- a/backend/ng/scoring/models/HintRedemption.py
+++ b/backend/ng/scoring/models/HintRedemption.py
@@ -35,6 +35,8 @@ class SerializedHintRedemption(TypedDict):
     hint_preview: NotRequired[str]
     challenge_id: NotRequired[int]
     challenge_name: NotRequired[str]
+    event_id: NotRequired[int]
+    event_name: NotRequired[str]
 
 
 class HintRedemption(db.Model):
@@ -82,7 +84,11 @@ class HintRedemption(db.Model):
         if self.hint:
             data["hint_preview"] = self.hint.preview
             data["challenge_id"] = self.hint.challenge_id
-            data["challenge_name"] = self.hint.challenge.name
+            if self.hint.challenge:
+                data["challenge_name"] = self.hint.challenge.name
+                data["event_id"] = self.hint.challenge.event_id
+                if self.hint.challenge.event:
+                    data["event_name"] = self.hint.challenge.event.name
 
         return SerializedHintRedemption(**data)
 

--- a/frontend/src/hooks/team.ts
+++ b/frontend/src/hooks/team.ts
@@ -1,5 +1,14 @@
-import type { Team, TeamMember } from '@/types';
-import useSWR from 'swr';
+import { apiMutation } from '@/fetchers';
+import type {
+  Attempt,
+  HintRedemption,
+  ManualPointAward,
+  Score,
+  ScoreEvent,
+  Team,
+  TeamMember,
+} from '@/types';
+import useSWR, { mutate } from 'swr';
 
 /**
  * Get a list of all teams across the system.
@@ -51,4 +60,43 @@ export function useTeamMembers(teamId: number | null) {
   return useSWR<TeamMember[], Error>(
     teamId ? `/admin/teams/${teamId}/members` : null,
   );
+}
+
+export function useMyTeamScore(eventId: number | null) {
+  return useSWR<Score, Error>(
+    eventId ? `/events/${eventId}/me/team/score` : null,
+  );
+}
+
+export function useTeamScoreHistory(eventId: number| null, teamId: number | null) {
+  return useSWR<{score_events: ScoreEvent[]}, Error>(
+    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/history` : null,
+  );
+}
+
+export function useTeamAttempts(eventId: number | null, teamId: number | null) {
+  return useSWR<Attempt[], Error>(
+    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/attempts` : null,
+  );
+}
+
+export function useTeamHintRedemptions(eventId: number | null, teamId: number | null) {
+  return useSWR<HintRedemption[], Error>(
+    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/hint_redemptions` : null,
+  );
+}
+
+export function useTeamManualAwards(eventId: number | null, teamId: number | null) {
+  return useSWR<ManualPointAward[], Error>(
+    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/manual_awards` : null,
+  );
+}
+
+export function adjustPoints(eventId: number, teamId: number, points: number, reason: string) {
+  return apiMutation(`/admin/scoring/events/${eventId}/teams/${teamId}/award-points`, { points, reason }, {
+    method : 'POST',
+  }).then(() => {
+    mutate(`/admin/scoring/events/${eventId}/teams/${teamId}/history`);
+    mutate(`/admin/scoring/events/${eventId}/teams/${teamId}/manual_awards`);
+  });
 }

--- a/frontend/src/routes/admin/teams/ScoreAdjustModal.tsx
+++ b/frontend/src/routes/admin/teams/ScoreAdjustModal.tsx
@@ -1,0 +1,47 @@
+import { COLOR_WARNING } from '@/constants';
+import { adjustPoints } from '@/hooks/team';
+import type { Team } from '@/types';
+import { Button, TextField } from '@radix-ui/themes';
+import Modal from 'components/Modal';
+import { Form } from 'radix-ui';
+import { TbPlusMinus } from 'react-icons/tb';
+
+export default function ScoreAdjustModal({ team }: { team: Team }) {
+  const handleSubmit = async (data: FormData) => {
+    const { points, reason } = Object.fromEntries(data.entries());
+
+    return adjustPoints(team.event_id, team.id, Number(points), reason as string);
+  };
+
+  return (
+    <Modal
+      title="Point Adjust"
+      description={`Apply a manual score adjustment to ${team.name}.`}
+      trigger={(
+        <Button variant="soft" color={COLOR_WARNING}>
+          <TbPlusMinus />
+          Adjust Score
+        </Button>
+      )}
+      onSubmit={handleSubmit}
+      submitVerb="Adjust"
+      submitColor={COLOR_WARNING}
+    >
+      <Form.Field name="points">
+        <Form.Label>Adjustment</Form.Label>
+        <Form.Control asChild>
+          <TextField.Root type="number" placeholder="Number of points" required />
+        </Form.Control>
+        <Form.Message match="valueMissing" />
+        <Form.Message match="badInput" />
+      </Form.Field>
+      <Form.Field name="reason">
+        <Form.Label>Reason</Form.Label>
+        <Form.Control asChild>
+          <TextField.Root placeholder="Reason for adjustment" required />
+        </Form.Control>
+        <Form.Message match="valueMissing" />
+      </Form.Field>
+    </Modal>
+  );
+}

--- a/frontend/src/routes/admin/teams/TeamActivity.tsx
+++ b/frontend/src/routes/admin/teams/TeamActivity.tsx
@@ -1,0 +1,166 @@
+import {
+  ChallengeIcon,
+  COLOR_HINT,
+  COLOR_NEGATIVE,
+  COLOR_POSITIVE,
+  COLOR_WARNING,
+  UserIcon,
+} from '@/constants';
+import { radixTheme } from '@/grid';
+import { useTeamAttempts, useTeamHintRedemptions, useTeamManualAwards } from '@/hooks/team';
+import type { Attempt, HintRedemption, ManualPointAward } from '@/types';
+import { Badge } from '@radix-ui/themes';
+import type { ColDef } from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+import { ErrorCallout } from 'components/Callouts';
+import Entity from 'components/Entity';
+import { useMemo } from 'react';
+
+const colDefs: ColDef<Attempt | HintRedemption | ManualPointAward>[] = [
+  {
+    headerName : 'Type',
+    valueGetter : ({ data }) => {
+      if (!data) return undefined;
+      if ('submission' in data) return 'Attempt';
+      if ('hint_preview' in data) return 'Hint';
+      if ('reason' in data) return 'Manual';
+      return 'Unknown';
+    },
+    cellRenderer : Badge,
+    cellRendererParams : (
+      { value, data } : {
+        value: 'Attempt' | 'Hint' | 'Manual' | 'Unknown',
+        data: Attempt | HintRedemption | ManualPointAward | undefined
+      },
+    ) => {
+      let color;
+      switch (value) {
+        case 'Attempt':
+          color = (data as Attempt).is_correct ? COLOR_POSITIVE : COLOR_NEGATIVE;
+          break;
+        case 'Hint':
+          color = COLOR_HINT;
+          break;
+        case 'Manual':
+          color = COLOR_WARNING;
+          break;
+        default:
+          color = 'gray';
+      }
+
+      return {
+        children : value.toUpperCase(),
+        color,
+      };
+    },
+    width : 100,
+    filter : true,
+    floatingFilter : true,
+    pinned : true,
+  },
+  {
+    field : 'points',
+    width : 100,
+    filter : true,
+    floatingFilter : true,
+    pinned : true,
+    cellClass : 'tabular-nums text-right',
+  },
+  {
+    field : 'timestamp',
+    valueFormatter : ({ value }) => value.toLocaleString(),
+    filter : true,
+    floatingFilter : true,
+    sort : 'desc',
+  },
+  {
+    headerName : 'User',
+    valueGetter : ({ data }) => {
+      if (!data) return undefined;
+      if ('user_id' in data) return data.user_name ?? `MISSING (${data.user_id})`;
+      if ('admin_id' in data) return data.admin_name ?? `MISSING (${data.admin_id})`;
+      return undefined;
+    },
+    cellRendererSelector : ({ value, data }) => {
+      if (!value || !data) return undefined;
+
+      const id = 'user_id' in data ? data.user_id : data.admin_id;
+
+      return {
+        component : Entity,
+        params : {
+          label : value,
+          to : `/admin/users?id=${id}`,
+          icon : UserIcon,
+        },
+      };
+    },
+    filter : true,
+    floatingFilter : true,
+  },
+  {
+    headerName : 'Challenge',
+    valueGetter : ({ data }) => {
+      if (!data || !('challenge_id' in data)) return undefined; // if no data or it's a manual award
+      return data.challenge_name ?? `MISSING (${data.challenge_id})`;
+    },
+    cellRendererSelector : ({ value, data }) => {
+      if (!value || !data || !('challenge_id' in data)) return undefined;
+
+      return {
+        component : Entity,
+        params : {
+          label : value,
+          to : `/admin/events?id=${data.event_id}`,
+          icon : ChallengeIcon,
+        },
+      };
+    },
+    filter : true,
+    floatingFilter : true,
+  },
+  {
+    field : 'submission',
+    filter : true,
+    floatingFilter : true,
+  },
+  {
+    field : 'hint_preview',
+    headerName : 'Hint',
+    filter : true,
+    floatingFilter : true,
+  },
+  {
+    field : 'reason',
+    filter : true,
+    floatingFilter : true,
+  },
+];
+
+export default function TeamActivity({ eventId, teamId }: { eventId: number, teamId: number }) {
+  const { data : attempts, error : attemptsError, isLoading : attemptsLoading } = useTeamAttempts(eventId, teamId);
+  const { data : hintRedemptions, error : hintsError, isLoading : hintsLoading } = useTeamHintRedemptions(eventId, teamId);
+  const { data : manualAwards, error : manualAwardsError, isLoading : manualAwardsLoading } = useTeamManualAwards(eventId, teamId);
+
+  // memoize merging the arrays, sorting by timestamp (descending)
+  const merged = useMemo(
+    () => [ ...(attempts ?? []), ...(hintRedemptions ?? []), ...(manualAwards ?? []) ]
+      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime()),
+    [ attempts, hintRedemptions, manualAwards ],
+  );
+
+  return (
+    <>
+      {attemptsError && <ErrorCallout>{attemptsError.message}</ErrorCallout>}
+      {hintsError && <ErrorCallout>{hintsError.message}</ErrorCallout>}
+      {manualAwardsError && <ErrorCallout>{manualAwardsError.message}</ErrorCallout>}
+      <AgGridReact
+        columnDefs={colDefs}
+        rowData={merged}
+        theme={radixTheme}
+        loading={attemptsLoading || hintsLoading || manualAwardsLoading}
+        className="min-h-160"
+      />
+    </>
+  );
+}

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -7,25 +7,17 @@ import {
 } from '@/constants';
 import { useTeamMembers } from '@/hooks/team';
 import type { Team } from '@/types';
-import {
-  Button,
-  Flex,
-  Heading,
-  Table,
-} from '@radix-ui/themes';
+import { Button, Flex, Table } from '@radix-ui/themes';
 import AdminDataList from 'components/AdminDataList';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
-import { ErrorCallout, InfoCallout } from 'components/Callouts';
+import { ErrorCallout } from 'components/Callouts';
 import Entity from 'components/Entity';
 import RoleBadge from 'components/RoleBadge';
-import {
-  TbDoorExit,
-  TbPackages,
-  TbPlusMinus,
-  TbStar,
-} from 'react-icons/tb';
+import { TbDoorExit, TbPackages, TbStar } from 'react-icons/tb';
 import { Link } from 'react-router';
+import ScoreAdjustModal from './ScoreAdjustModal';
+import TeamActivity from './TeamActivity';
 
 export default function TeamSidebar({ entity }: { entity: Team }) {
   const { data : members, error : membersError } = useTeamMembers(entity.id);
@@ -95,19 +87,11 @@ export default function TeamSidebar({ entity }: { entity: Team }) {
           </Table.Body>
         </Table.Root>
       )}
+
       <AdminSidebarHeader title="Activity">
-        <Button variant="soft" color="amber">
-          <TbPlusMinus />
-          Point Adjust
-        </Button>
+        <ScoreAdjustModal team={entity} />
       </AdminSidebarHeader>
-      <InfoCallout>
-        Attempts, hint redemptions, and manual awards for this team.
-      </InfoCallout>
-      <Heading>Challenges</Heading>
-      <InfoCallout>
-        Deployed challenge instances for this team.
-      </InfoCallout>
+      <TeamActivity eventId={entity.event_id} teamId={entity.id} />
     </AdminSidebar>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -92,6 +92,38 @@ export interface Attempt {
   points: number;
   submission: string;
   is_correct: boolean;
+  user_name?: string;
+  team_name?: string;
+  challenge_name?: string;
+  question_name?: string;
+}
+
+export interface HintRedemption {
+  id: number;
+  user_id: number;
+  team_id: number;
+  score_event_id?: number;
+  timestamp: Date;
+  points: number;
+  user_name?: string;
+  team_name?: string;
+  hint_preview?: string;
+  challenge_id: number;
+  challenge_name?: string;
+  event_id?: number;
+  event_name?: string;
+}
+
+export interface ManualPointAward {
+  id: number;
+  admin_id: number;
+  team_id: number;
+  score_event_id: number;
+  timestamp: Date;
+  points: number;
+  reason: string;
+  admin_name?: string;
+  team_name?: string;
 }
 
 export interface Score {
@@ -107,6 +139,7 @@ export interface ScoreEvent {
   id: number;
   score_id: number;
   team_id: number;
+  team_name: string;
   points: number;
   timestamp: Date;
 }


### PR DESCRIPTION
- Hooks for team scoring endpoints
- Include event id/name in hints for challenge links in the activity log
- Log of attempts, hint redemptions, and manual adjustments for teams in the admin view
- Manual score adjustment functionality in the admin panel

<img width="1159" height="356" alt="image" src="https://github.com/user-attachments/assets/7ebef471-6428-4d9f-bd94-ae4b043e5be7" />
