### PR TITLE
Miscellaneous event/challenge/dashboard improvements

### DIFF
--- a/frontend/src/components/EventHeader.tsx
+++ b/frontend/src/components/EventHeader.tsx
@@ -1,17 +1,17 @@
+import { DATEFORMAT } from '@/constants';
+import type { Event } from '@/types';
 import {
   AspectRatio,
   Box,
-  Link as LinkTheme,
   Flex,
   Heading,
+  Link as LinkTheme,
   Text,
 } from '@radix-ui/themes';
 import { isNull } from 'lodash';
 import type { ReactNode } from 'react';
 import { TbCalendar, TbUser } from 'react-icons/tb';
 import { Link } from 'react-router';
-import type { Event } from '@/types';
-import { DATEFORMAT } from '@/constants';
 import EventBadge from './EventBadge';
 import RadixMarkdown from './RadixMarkdown';
 
@@ -77,7 +77,9 @@ export default function EventHeader({
           {maxTeamSize && (
             <Text color="gray">
               <TbUser className="inline me-1" />
-              {maxTeamSize === 1 ? 'Individual' : `Teams of 2-${maxTeamSize}`}
+              {maxTeamSize === 1
+                ? 'Individual'
+                : `Teams of ${maxTeamSize === 2 ? '2' : `2-${maxTeamSize}`}`}
             </Text>
           )}
         </Flex>

--- a/frontend/src/components/MemberCountBadge.tsx
+++ b/frontend/src/components/MemberCountBadge.tsx
@@ -34,7 +34,7 @@ export default function MemberCountBadge({ team }: { team: Team }) {
 
   return (
     event && (
-    <Badge variant="soft" color={getBadgeColor(team.member_count, event.max_team_size)} size="2">
+    <Badge variant="soft" color={getBadgeColor(team.member_count, event.max_team_size)} size="2" className="tabular-nums">
       {team.member_count}
       /
       {event.max_team_size}

--- a/frontend/src/routes/dashboard/PastEvents.tsx
+++ b/frontend/src/routes/dashboard/PastEvents.tsx
@@ -1,9 +1,23 @@
-import type { Event } from '@/types';
+import { useMyEvents } from '@/hooks/events';
 import { Grid, Heading } from '@radix-ui/themes';
+import { ErrorCallout } from 'components/Callouts';
 import EventCard from './EventCard';
 
-export default function PastEvents({ events }: { events: Event[] }) {
-  if (events.length === 0) {
+export default function PastEvents() {
+  const { data, error } = useMyEvents();
+  const pastEvents = data?.filter((event) => event.end_time && new Date() > event.end_time);
+
+  if (error) {
+    return (
+      <>
+        <Heading size="6">Your Past Events</Heading>
+        <ErrorCallout>{error.message}</ErrorCallout>
+      </>
+    );
+  }
+
+  if (pastEvents === undefined || pastEvents.length === 0) {
+    // Show nothing if there are no past events or if data is still loading
     return null;
   }
 
@@ -16,7 +30,7 @@ export default function PastEvents({ events }: { events: Event[] }) {
         }}
         gap="4"
       >
-        {events.map((event) => (
+        {pastEvents.map((event) => (
           <EventCard
             key={event.id}
             event={event}

--- a/frontend/src/routes/dashboard/UpcomingEvents.tsx
+++ b/frontend/src/routes/dashboard/UpcomingEvents.tsx
@@ -1,57 +1,56 @@
-import type { Event } from '@/types';
-import {
-  Callout,
-  Grid,
-  Heading,
-  Link as RadixLink,
-} from '@radix-ui/themes';
-import { TbInfoCircle } from 'react-icons/tb';
+import { useMyEvents } from '@/hooks/events';
+import { Grid, Link as RadixLink, Skeleton } from '@radix-ui/themes';
+import { ErrorCallout, InfoCallout } from 'components/Callouts';
 import { Link } from 'react-router';
 import EventCard from './EventCard';
 
-export default function UpcomingEvents({ events }: { events: Event[] }) {
-  const heading = <Heading size="6">Your Upcoming Events</Heading>;
+export default function UpcomingEvents() {
+  const { data, error, isLoading } = useMyEvents();
+  const upcomingEvents = data?.filter((event) => !event.start_time || new Date() < event.start_time);
 
-  if (events.length === 0) {
+  if (error) {
     return (
-      <>
-        {heading}
-        <Callout.Root color="jade" variant="surface">
-          <Callout.Icon>
-            <TbInfoCircle />
-          </Callout.Icon>
-          <Callout.Text>
-            You are not registered for any upcoming events.
-            {' '}
-            <RadixLink asChild><Link to="/events">Register for an upcoming event</Link></RadixLink>
-            {' '}
-            or head to the
-            {' '}
-            <RadixLink asChild><Link to="/practice">practice area</Link></RadixLink>
-            {' '}
-            to hone your skills!
-          </Callout.Text>
-        </Callout.Root>
-      </>
+      <ErrorCallout>{error.message}</ErrorCallout>
+    );
+  }
+
+  if (upcomingEvents !== undefined && upcomingEvents.length === 0) {
+    return (
+      <InfoCallout>
+        You are not registered for any upcoming events.
+        {' '}
+        <RadixLink asChild><Link to="/events">Register for an upcoming event</Link></RadixLink>
+        {' '}
+        or head to the
+        {' '}
+        <RadixLink asChild><Link to="/practice">practice area</Link></RadixLink>
+        {' '}
+        to hone your skills!
+      </InfoCallout>
     );
   }
 
   return (
-    <>
-      {heading}
-      <Grid
-        columns={{
-          initial : '1', xs : '1', sm : '2', lg : '3',
-        }}
-        gap="4"
-      >
-        {events.map((event) => (
-          <EventCard
-            key={event.id}
-            event={event}
-          />
-        ))}
-      </Grid>
-    </>
+    <Grid
+      columns={{
+        initial : '1', xs : '1', sm : '2', lg : '3',
+      }}
+      gap="4"
+    >
+      {isLoading && (
+        <>
+          <Skeleton className="min-h-48" />
+          <Skeleton className="min-h-48" />
+          <Skeleton className="min-h-48" />
+        </>
+      )}
+
+      {upcomingEvents?.map((event) => (
+        <EventCard
+          key={event.id}
+          event={event}
+        />
+      ))}
+    </Grid>
   );
 }

--- a/frontend/src/routes/dashboard/index.tsx
+++ b/frontend/src/routes/dashboard/index.tsx
@@ -1,21 +1,22 @@
 import { useMyEvents } from '@/hooks/events';
-import { Button, Container, Flex } from '@radix-ui/themes';
+import {
+  Container,
+  Flex,
+  Heading,
+  Skeleton,
+} from '@radix-ui/themes';
 import { ErrorCallout, InfoCallout } from 'components/Callouts';
 import EventHeader from 'components/EventHeader';
 import HeaderContainer from 'components/HeaderContainer';
-import { Link } from 'react-router';
 import PastEvents from 'routes/dashboard/PastEvents';
 import UpcomingEvents from 'routes/dashboard/UpcomingEvents';
 
 export default function Dashboard() {
-  const { data, error } = useMyEvents();
+  const { data, error, isLoading } = useMyEvents();
 
-  // Split registered events into past, present, and future
-  const upcomingEvents = data?.filter((event) => !event.start_time || new Date() < event.start_time) || [];
-  const pastEvents = data?.filter((event) => event.end_time && new Date() > event.end_time) || [];
   const liveEvents = data?.filter(
     (event) => event.start_time && event.end_time && new Date() >= event.start_time && new Date() <= event.end_time,
-  ) || [];
+  );
 
   if (error) {
     return <ErrorCallout>{error.message}</ErrorCallout>;
@@ -24,30 +25,27 @@ export default function Dashboard() {
   return (
     <>
       <HeaderContainer>
-        {liveEvents.length === 0 && (
-          <InfoCallout>
-            No events are currently running. This should eventually be something more interesting, i.e. the first upcoming event or practice area.
-          </InfoCallout>
+        {(liveEvents === undefined || liveEvents.length === 0) && (
+          <Skeleton loading={isLoading}>
+            <InfoCallout>
+              No events are currently running. This should eventually be something more interesting, i.e. the first upcoming event or practice area.
+            </InfoCallout>
+          </Skeleton>
         )}
-        {liveEvents.map((event) => (
+        {liveEvents?.map((event) => (
           <EventHeader
             key={event.id}
             event={event}
-          >
-            <Button asChild>
-              <Link to={`/events/${event.id}`}>
-                Go
-              </Link>
-            </Button>
-          </EventHeader>
+          />
         ))}
       </HeaderContainer>
 
       <Container size="4">
         <Flex direction="column" gap="4" my="8">
-          <UpcomingEvents events={upcomingEvents} />
+          <Heading size="6">Your Upcoming Events</Heading>
+          <UpcomingEvents />
 
-          <PastEvents events={pastEvents} />
+          <PastEvents />
         </Flex>
       </Container>
     </>

--- a/frontend/src/routes/dashboard/index.tsx
+++ b/frontend/src/routes/dashboard/index.tsx
@@ -8,6 +8,7 @@ import {
 import { ErrorCallout, InfoCallout } from 'components/Callouts';
 import EventHeader from 'components/EventHeader';
 import HeaderContainer from 'components/HeaderContainer';
+import { isEmpty } from 'lodash';
 import PastEvents from 'routes/dashboard/PastEvents';
 import UpcomingEvents from 'routes/dashboard/UpcomingEvents';
 
@@ -25,7 +26,7 @@ export default function Dashboard() {
   return (
     <>
       <HeaderContainer>
-        {(liveEvents === undefined || liveEvents.length === 0) && (
+        {isEmpty(liveEvents) && (
           <Skeleton loading={isLoading}>
             <InfoCallout>
               No events are currently running. This should eventually be something more interesting, i.e. the first upcoming event or practice area.

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -3,10 +3,10 @@ import { Container, Tabs } from '@radix-ui/themes';
 import { TbStar } from 'react-icons/tb';
 import { useParams, useSearchParams } from 'react-router';
 
-import EventHeader from 'components/EventHeader';
-import HeaderContainer from 'components/HeaderContainer';
 import { ChallengeIcon, TeamIcon } from '@/constants';
 import { useEvent } from '@/hooks/events';
+import EventHeader from 'components/EventHeader';
+import HeaderContainer from 'components/HeaderContainer';
 import ChallengesTab from './OverviewTabs/ChallengesTab';
 import LeaderboardTab from './OverviewTabs/LeaderboardTab';
 import TeamTab from './OverviewTabs/TeamTab';
@@ -50,13 +50,12 @@ export default function Overview() {
               <TbStar className="mr-1" />
               Leaderboard
             </Tabs.Trigger>
-            {data?.max_team_size > 1
-              && (
+            {data && data.max_team_size > 1 && (
               <Tabs.Trigger value="team">
                 <TeamIcon className="mr-1" />
                 Team
               </Tabs.Trigger>
-              )}
+            )}
           </Tabs.List>
         </Container>
 
@@ -68,9 +67,11 @@ export default function Overview() {
           <LeaderboardTab />
         </Tabs.Content>
 
-        <Tabs.Content value="team">
-          <TeamTab />
-        </Tabs.Content>
+        {data && data.max_team_size > 1 && (
+          <Tabs.Content value="team">
+            <TeamTab />
+          </Tabs.Content>
+        )}
       </Tabs.Root>
     </>
   );

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/ChallengeCard.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/ChallengeCard.tsx
@@ -12,6 +12,30 @@ import ChallengeIcon from 'components/ChallengeIcon';
 import * as tb from 'react-icons/tb';
 import { Link } from 'react-router';
 
+function getPercentageIcon(progress: number) {
+  let percentage: number;
+  if (progress <= 0) {
+    percentage = 0;
+  } else if (Math.abs(progress - 0.25) < 0.02) {
+    percentage = 25;
+  } else if (Math.abs(progress - 0.33) < 0.02) {
+    percentage = 33;
+  } else if (Math.abs(progress - 0.66) < 0.02) {
+    percentage = 66;
+  } else if (Math.abs(progress - 0.75) < 0.02) {
+    percentage = 75;
+  } else if (progress >= 1) {
+    percentage = 100;
+  } else {
+    // don't allow rounding to an empty or full circle - clamp between 10 and 90
+    percentage = Math.min(90, Math.max(10, Math.round(progress * 10) * 10));
+  }
+
+  const iconName = `TbPercentage${percentage}`;
+  const Icon = tb[iconName as keyof typeof tb] || tb.TbPercentage0;
+  return <Icon />;
+}
+
 export default function ChallengeCard({
   challenge,
   progress,
@@ -46,14 +70,14 @@ export default function ChallengeCard({
           )}
           {inProgress && (
             <Text size="2" color={color}>
-              <tb.TbPercentage50 title="In Progress" />
+              {getPercentageIcon(progress.num_questions_solved / progress.num_questions_available)}
             </Text>
           )}
           <Skeleton loading={!progress}>
             <Text size="2" color={color}>
-              {progress?.total_points_scored || '000'}
+              {progress?.total_points_scored ?? '000'}
               /
-              {progress?.total_points_available || '000'}
+              {progress?.total_points_available ?? '000'}
             </Text>
           </Skeleton>
         </Flex>

--- a/frontend/src/routes/events/challenge/ChallengeQuestion.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeQuestion.tsx
@@ -97,6 +97,7 @@ export default function ChallengeQuestion({
                 color={color || COLOR_QUESTION}
                 placeholder={placeholder}
                 required
+                autoComplete="off"
                 disabled={status === 'correct' || attemptsRemaining <= 0}
               >
                 <TextField.Slot>


### PR DESCRIPTION
- Progress indicator on challenge cards, some display fixes
- Show "Teams of 2" instead of "Teams of 2-2" on team size 2 event headers
- Don't show the team tab if the URL tab parameter is changed to `team` in an individual event
- Disable browser autocompletion for answer fields
- Refactor user dashboard page for better loading/error states and reduced prop-drilling