### PR TITLE
Reorganize hooks

### DIFF
--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -62,15 +62,6 @@ export function redeemHint(
   });
 }
 
-export function createChallenge(eventId: number, yaml: string) {
-  return apiMutation(`/admin/events/${eventId}/challenges`, { yaml : btoa(yaml) }, {
-    method : 'POST',
-  }).then(() => {
-    // refresh the challenges list when a new challenge is created
-    mutate(`/events/${eventId}/challenges`);
-  });
-}
-
 export function submitFlag(
   eventId: number,
   challengeId: number,
@@ -84,5 +75,16 @@ export function submitFlag(
   }).then(() => {
     // refresh the challenge data after submitting a flag
     mutate(`/events/${eventId}/challenges/${challengeId}`);
+  });
+}
+
+/* ADMIN ENDPOINTS */
+
+export function createChallenge(eventId: number, yaml: string) {
+  return apiMutation(`/admin/events/${eventId}/challenges`, { yaml : btoa(yaml) }, {
+    method : 'POST',
+  }).then(() => {
+    // refresh the challenges list when a new challenge is created
+    mutate(`/events/${eventId}/challenges`);
   });
 }

--- a/frontend/src/hooks/container.ts
+++ b/frontend/src/hooks/container.ts
@@ -2,6 +2,21 @@ import { apiMutation } from '@/fetchers';
 import type { ContainerInstance, ContainerStatus, Deployment } from '@/types';
 import useSWR, { mutate } from 'swr';
 
+export function useCurrentChallengeId() {
+  return useSWR<number | null>('/container/me/current_challenge');
+}
+
+export function connectWorkspace(eventId: number, challengeId: number) {
+  return apiMutation(`/events/${eventId}/challenge/${challengeId}/containers`, undefined, {
+    method : 'GET',
+  }).then(() => {
+    // refresh the current challenge ID after connecting workspace
+    mutate('/container/me/current_challenge');
+  });
+}
+
+/* ADMIN ENDPOINTS */
+
 export function useAllDeployments() {
   return useSWR<Deployment[], Error>('/admin/container');
 }
@@ -27,19 +42,6 @@ export function useProvisionerStats() {
     '/admin/container/stats',
     { refreshInterval : 30000 }, // Refresh metrics every 30 sec while they are on the page
   );
-}
-
-export function useCurrentChallengeId() {
-  return useSWR<number | null>('/container/me/current_challenge');
-}
-
-export function connectWorkspace(eventId: number, challengeId: number) {
-  return apiMutation(`/events/${eventId}/challenge/${challengeId}/containers`, undefined, {
-    method : 'GET',
-  }).then(() => {
-    // refresh the current challenge ID after connecting workspace
-    mutate('/container/me/current_challenge');
-  });
 }
 
 export function restartContainer(containerId: number) {

--- a/frontend/src/hooks/events.ts
+++ b/frontend/src/hooks/events.ts
@@ -35,18 +35,6 @@ export function useAdminEvent(eventId: number | null) {
 }
 
 /**
- * Gets the events a user is registered for.
- * This is an admin-only endpoint.
- * @param userId The ID of the user to fetch events for, or null if this should not be fetched.
- * @returns
- */
-export function useUserEvents(userId: number | null) {
-  return useSWR<Event[], Error>(
-    userId ? `/admin/users/${userId}/events` : null,
-  );
-}
-
-/**
  * Registeres user for a specific event
  * @param event_id The event id
  * @param team_name The leaderboard name for solo events or team name for team creation

--- a/frontend/src/hooks/scoring.ts
+++ b/frontend/src/hooks/scoring.ts
@@ -1,0 +1,42 @@
+import { apiMutation } from '@/fetchers';
+import type {
+  Attempt,
+  HintRedemption,
+  ManualPointAward,
+  ScoreEvent,
+} from '@/types';
+import useSWR, { mutate } from 'swr';
+
+/* ADMIN ENDPOINTS */
+export function useTeamScoreHistory(eventId: number| null, teamId: number | null) {
+  return useSWR<{score_events: ScoreEvent[]}, Error>(
+    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/history` : null,
+  );
+}
+
+export function useTeamAttempts(eventId: number | null, teamId: number | null) {
+  return useSWR<Attempt[], Error>(
+    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/attempts` : null,
+  );
+}
+
+export function useTeamHintRedemptions(eventId: number | null, teamId: number | null) {
+  return useSWR<HintRedemption[], Error>(
+    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/hint_redemptions` : null,
+  );
+}
+
+export function useTeamManualAwards(eventId: number | null, teamId: number | null) {
+  return useSWR<ManualPointAward[], Error>(
+    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/manual_awards` : null,
+  );
+}
+
+export function adjustPoints(eventId: number, teamId: number, points: number, reason: string) {
+  return apiMutation(`/admin/scoring/events/${eventId}/teams/${teamId}/award-points`, { points, reason }, {
+    method : 'POST',
+  }).then(() => {
+    mutate(`/admin/scoring/events/${eventId}/teams/${teamId}/history`);
+    mutate(`/admin/scoring/events/${eventId}/teams/${teamId}/manual_awards`);
+  });
+}

--- a/frontend/src/hooks/team.ts
+++ b/frontend/src/hooks/team.ts
@@ -1,11 +1,5 @@
-import type { Score, Team, TeamMember } from '@/types';
+import type { Team, TeamMember } from '@/types';
 import useSWR from 'swr';
-
-export function useMyTeamScore(eventId: number | null) {
-  return useSWR<Score, Error>(
-    eventId ? `/events/${eventId}/me/team/score` : null,
-  );
-}
 
 /* ADMIN ENDPOINTS */
 

--- a/frontend/src/hooks/team.ts
+++ b/frontend/src/hooks/team.ts
@@ -1,14 +1,13 @@
-import { apiMutation } from '@/fetchers';
-import type {
-  Attempt,
-  HintRedemption,
-  ManualPointAward,
-  Score,
-  ScoreEvent,
-  Team,
-  TeamMember,
-} from '@/types';
-import useSWR, { mutate } from 'swr';
+import type { Score, Team, TeamMember } from '@/types';
+import useSWR from 'swr';
+
+export function useMyTeamScore(eventId: number | null) {
+  return useSWR<Score, Error>(
+    eventId ? `/events/${eventId}/me/team/score` : null,
+  );
+}
+
+/* ADMIN ENDPOINTS */
 
 /**
  * Get a list of all teams across the system.
@@ -17,26 +16,6 @@ import useSWR, { mutate } from 'swr';
 export function useAllTeams() {
   return useSWR<Team[], Error>(
     '/admin/teams',
-  );
-}
-
-/**
- * Get a list of teams the given user is part of.
- * This is an admin-only endpoint.
- * @param userId The ID of the user to fetch teams for, or null if this should not be fetched.
- */
-export function useUserTeams(userId: number | null) {
-  return useSWR<Team[], Error>(
-    userId ? `/admin/users/${userId}/teams` : null,
-  );
-}
-
-/**
- * Get a list of teams the currently signed in user is part of.
- */
-export function useMyTeams() {
-  return useSWR<Team[], Error>(
-    '/users/me/teams',
   );
 }
 
@@ -60,43 +39,4 @@ export function useTeamMembers(teamId: number | null) {
   return useSWR<TeamMember[], Error>(
     teamId ? `/admin/teams/${teamId}/members` : null,
   );
-}
-
-export function useMyTeamScore(eventId: number | null) {
-  return useSWR<Score, Error>(
-    eventId ? `/events/${eventId}/me/team/score` : null,
-  );
-}
-
-export function useTeamScoreHistory(eventId: number| null, teamId: number | null) {
-  return useSWR<{score_events: ScoreEvent[]}, Error>(
-    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/history` : null,
-  );
-}
-
-export function useTeamAttempts(eventId: number | null, teamId: number | null) {
-  return useSWR<Attempt[], Error>(
-    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/attempts` : null,
-  );
-}
-
-export function useTeamHintRedemptions(eventId: number | null, teamId: number | null) {
-  return useSWR<HintRedemption[], Error>(
-    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/hint_redemptions` : null,
-  );
-}
-
-export function useTeamManualAwards(eventId: number | null, teamId: number | null) {
-  return useSWR<ManualPointAward[], Error>(
-    (eventId && teamId) ? `/admin/scoring/events/${eventId}/teams/${teamId}/manual_awards` : null,
-  );
-}
-
-export function adjustPoints(eventId: number, teamId: number, points: number, reason: string) {
-  return apiMutation(`/admin/scoring/events/${eventId}/teams/${teamId}/award-points`, { points, reason }, {
-    method : 'POST',
-  }).then(() => {
-    mutate(`/admin/scoring/events/${eventId}/teams/${teamId}/history`);
-    mutate(`/admin/scoring/events/${eventId}/teams/${teamId}/manual_awards`);
-  });
 }

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -1,5 +1,34 @@
-import type { Event, User } from '@/types';
+import type { Event, Team, User } from '@/types';
 import useSWR from 'swr';
+
+/**
+ * Get the currently signed in user.
+ */
+export function useCurrentUser() {
+  return useSWR<User>('/users/me');
+}
+
+/**
+ * Get a list of teams the currently signed in user is part of.
+ */
+export function useMyTeams() {
+  return useSWR<Team[], Error>(
+    '/users/me/teams',
+  );
+}
+
+/* ADMIN ENDPOINTS */
+
+/**
+ * Get a list of teams the given user is part of.
+ * This is an admin-only endpoint.
+ * @param userId The ID of the user to fetch teams for, or null if this should not be fetched.
+ */
+export function useUserTeams(userId: number | null) {
+  return useSWR<Team[], Error>(
+    userId ? `/admin/users/${userId}/teams` : null,
+  );
+}
 
 /**
  * Get a list of all users.
@@ -20,13 +49,6 @@ export function useUser(userId: number | null) {
   return useSWR<User, Error>(
     userId ? `/admin/users/${userId}` : null,
   );
-}
-
-/**
- * Get the currently signed in user.
- */
-export function useCurrentUser() {
-  return useSWR<User>('/users/me');
 }
 
 /**

--- a/frontend/src/routes/admin/teams/ScoreAdjustModal.tsx
+++ b/frontend/src/routes/admin/teams/ScoreAdjustModal.tsx
@@ -1,5 +1,5 @@
 import { COLOR_WARNING } from '@/constants';
-import { adjustPoints } from '@/hooks/team';
+import { adjustPoints } from '@/hooks/scoring';
 import type { Team } from '@/types';
 import { Button, TextField } from '@radix-ui/themes';
 import Modal from 'components/Modal';

--- a/frontend/src/routes/admin/teams/TeamActivity.tsx
+++ b/frontend/src/routes/admin/teams/TeamActivity.tsx
@@ -7,7 +7,7 @@ import {
   UserIcon,
 } from '@/constants';
 import { radixTheme } from '@/grid';
-import { useTeamAttempts, useTeamHintRedemptions, useTeamManualAwards } from '@/hooks/team';
+import { useTeamAttempts, useTeamHintRedemptions, useTeamManualAwards } from '@/hooks/scoring';
 import type { Attempt, HintRedemption, ManualPointAward } from '@/types';
 import { Badge } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -1,6 +1,6 @@
 import { COLOR_POSITIVE, EventIcon, TeamIcon } from '@/constants';
-import { useUserEvents } from '@/hooks/events';
-import { useTeamMembers, useUserTeams } from '@/hooks/team';
+import { useTeamMembers } from '@/hooks/team';
+import { useUserEvents, useUserTeams } from '@/hooks/users';
 import type { Event, Team, User } from '@/types';
 import { Button, Table } from '@radix-ui/themes';
 import AdminDataList from 'components/AdminDataList';


### PR DESCRIPTION
- `events/${eventId}/me/team/score`
    - does not have documentation or uses
    - Removed until it is actually used
- Challenge.ts
    - Left alone because we were talking about removing eventId from these since challenges are unique to events.
- `/events/${eventId}/challenge/${challengeId}/containers`
    - Is going to keep living in containers.ts