### PR TITLE
Set stopCellSelection columns for existing admin grids

### DIFF
--- a/frontend/src/routes/admin/deployments/index.tsx
+++ b/frontend/src/routes/admin/deployments/index.tsx
@@ -71,6 +71,7 @@ export default function AdminDeployments() {
         loading={isLoading}
         getRowId={(params) => params.data.id.toString()}
         sidebarComponent={DeploymentSidebar}
+        stopCellSelection={[ 'challenge_name', 'team_name', 'event_name' ]}
       />
     </Flex>
   );

--- a/frontend/src/routes/admin/teams/index.tsx
+++ b/frontend/src/routes/admin/teams/index.tsx
@@ -77,6 +77,7 @@ export default function AdminTeams() {
       loading={isLoading}
       getRowId={(params) => params.data.id.toString()}
       sidebarComponent={TeamSidebar}
+      stopCellSelection={[ 'event_name' ]}
     />
   );
 }


### PR DESCRIPTION
Allow entity links in deployment/team grids to work without selecting the row beforehand.