### PR TITLE
Admin panel layout updates

### DIFF
--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -81,7 +81,7 @@ function Routes() {
   ]);
 
   return (
-    <div className="p-4 min-h-[calc(100vh-var(--NavBarHeight)-var(--FooterBarHeight))] relative mb-[var(--FooterBarHeight)]">
+    <div className="p-3 min-h-[calc(100vh-var(--NavBarHeight)-var(--FooterBarHeight))] relative mb-[var(--FooterBarHeight)]">
       {routes}
     </div>
   );

--- a/frontend/src/components/AdminGrid.tsx
+++ b/frontend/src/components/AdminGrid.tsx
@@ -2,7 +2,12 @@ import { radixTheme } from '@/grid';
 import { Flex, Spinner } from '@radix-ui/themes';
 import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
-import { useCallback, useEffect, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
 import { useSearchParams } from 'react-router';
 
 /**
@@ -13,6 +18,7 @@ export default function AdminGrid<T>({
   columnDefs,
   loading = false,
   sidebarComponent : Sidebar,
+  toolbar,
   getRowId,
   gridOptions,
   stopCellSelection,
@@ -21,6 +27,7 @@ export default function AdminGrid<T>({
   columnDefs: ColDef<T>[];
   loading?: boolean;
   sidebarComponent?: React.ComponentType<{entity: T}>;
+  toolbar?: ReactNode;
   getRowId: (params: { data: T }) => string;
   gridOptions?: GridOptions;
   stopCellSelection?: string[]; // colIds of cells
@@ -84,73 +91,76 @@ export default function AdminGrid<T>({
   };
 
   return (
-    <Flex direction="row" gap="4" className="w-full h-full">
-      <AgGridReact
-        key="admin-grid"
-        theme={radixTheme}
-        rowData={rowData}
-        columnDefs={columnDefs}
-        rowSelection={{
-          mode : 'singleRow',
-          checkboxes : true,
-        }}
-        loading={loading}
-        loadingOverlayComponent={Spinner}
-        getRowId={getRowId}
-        onCellClicked={(e) => {
-          if (!stopCellSelection?.includes(e.column.getColId())) {
-            e.node.setSelected(true);
-          }
-        }}
-        onRowDoubleClicked={(event) => {
-          if (event.node.isSelected()) {
-            event.node.setSelected(false);
-          }
-        }}
-        onRowSelected={(event) => {
-          if (event.node.isSelected() && event.node.id && event.node.id !== selectedId) {
-            setSearchParams((prev) => {
-              prev.set('id', event.node.id!);
-              return prev;
-            });
-          }
-          if (event.api.getSelectedNodes().length === 0 && selectedId) {
-            setSearchParams((prev) => {
-              prev.delete('id');
-              return prev;
-            });
-          }
-        }}
-        onRowDataUpdated={updateSelection} // ensure selection is accurate when grid rows load
-        onGridReady={(params) => {
-          setGridApi(params.api);
-        }}
-        onFilterChanged={(params) => {
+    <Flex direction="row" gap="3" className="w-full h-full">
+      <Flex direction="column" gap="3" className="grow">
+        {toolbar}
+        <AgGridReact
+          key="admin-grid"
+          theme={radixTheme}
+          rowData={rowData}
+          columnDefs={columnDefs}
+          rowSelection={{
+            mode : 'singleRow',
+            checkboxes : true,
+          }}
+          loading={loading}
+          loadingOverlayComponent={Spinner}
+          getRowId={getRowId}
+          onCellClicked={(e) => {
+            if (!stopCellSelection?.includes(e.column.getColId())) {
+              e.node.setSelected(true);
+            }
+          }}
+          onRowDoubleClicked={(event) => {
+            if (event.node.isSelected()) {
+              event.node.setSelected(false);
+            }
+          }}
+          onRowSelected={(event) => {
+            if (event.node.isSelected() && event.node.id && event.node.id !== selectedId) {
+              setSearchParams((prev) => {
+                prev.set('id', event.node.id!);
+                return prev;
+              });
+            }
+            if (event.api.getSelectedNodes().length === 0 && selectedId) {
+              setSearchParams((prev) => {
+                prev.delete('id');
+                return prev;
+              });
+            }
+          }}
+          onRowDataUpdated={updateSelection} // ensure selection is accurate when grid rows load
+          onGridReady={(params) => {
+            setGridApi(params.api);
+          }}
+          onFilterChanged={(params) => {
           // Update the URL when grid filter model changes
-          const filterModel = params.api.getFilterModel();
-          if (Object.keys(filterModel).length > 0) {
-            const filterString = btoa(JSON.stringify(filterModel));
+            const filterModel = params.api.getFilterModel();
+            if (Object.keys(filterModel).length > 0) {
+              const filterString = btoa(JSON.stringify(filterModel));
 
-            // don't double nav if the filter won't change
-            if (searchParams.get('filter') === filterString) return;
+              // don't double nav if the filter won't change
+              if (searchParams.get('filter') === filterString) return;
 
-            setSearchParams((prev) => {
-              prev.set('filter', filterString);
-              return prev;
-            });
-          } else {
-            if (!searchParams.has('filter')) return;
+              setSearchParams((prev) => {
+                prev.set('filter', filterString);
+                return prev;
+              });
+            } else {
+              if (!searchParams.has('filter')) return;
 
-            setSearchParams((prev) => {
-              prev.delete('filter');
-              return prev;
-            });
-          }
-        }}
-        initialState={initialState}
-        className="w-full h-full grow"
-        gridOptions={gridOptions}
-      />
+              setSearchParams((prev) => {
+                prev.delete('filter');
+                return prev;
+              });
+            }
+          }}
+          initialState={initialState}
+          className="w-full h-full grow"
+          gridOptions={gridOptions}
+        />
+      </Flex>
       {Sidebar && selectedData && (
         <Sidebar entity={selectedData} key={selectedId} />
       )}

--- a/frontend/src/components/AdminSidebar.tsx
+++ b/frontend/src/components/AdminSidebar.tsx
@@ -1,7 +1,7 @@
 import { Flex } from '@radix-ui/themes';
 import { useEffect, useRef, type ReactNode } from 'react';
 
-export default function AdminSidebar({ children }: {children: ReactNode}) {
+export default function AdminSidebar({ basis, children }: {basis?: string, children: ReactNode}) {
   const headerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -11,7 +11,14 @@ export default function AdminSidebar({ children }: {children: ReactNode}) {
   }, []);
 
   return (
-    <Flex direction="column" gap="4" className="basis-1/2 min-w-128 grow-0 shrink-0 overflow-y-auto outline-0" ref={headerRef} tabIndex={-1}>
+    <Flex
+      direction="column"
+      gap="3"
+      className="min-w-128 overflow-y-auto outline-0 -m-3 p-3"
+      ref={headerRef}
+      tabIndex={-1}
+      flexBasis={basis || '50%'}
+    >
       {children}
     </Flex>
   );

--- a/frontend/src/components/AdminSidebarHeader.tsx
+++ b/frontend/src/components/AdminSidebarHeader.tsx
@@ -2,14 +2,19 @@ import { Flex, Heading } from '@radix-ui/themes';
 
 export default function AdminSidebarHeader({
   title,
+  icon,
   children,
 } : {
   title: string;
+  icon?: React.ReactNode;
   children?: React.ReactNode
 }) {
   return (
-    <Flex direction="row" align="center" justify="between" gap="4">
-      <Heading>{title}</Heading>
+    <Flex direction="row" align="center" justify="between" gap="2">
+      <Flex direction="row" align="center" gap="2">
+        {icon && <Heading>{icon}</Heading>}
+        <Heading>{title}</Heading>
+      </Flex>
       <Flex direction="row" align="center" gap="2">
         {children}
       </Flex>

--- a/frontend/src/components/HeaderContainer.tsx
+++ b/frontend/src/components/HeaderContainer.tsx
@@ -8,11 +8,11 @@ export default function HeaderContainer({ children = undefined }: {
     children && (
       <Container
         size="2"
-        px="4"
+        px="3"
         py="9"
-        mx="-4"
-        mt="-4"
-        mb="4"
+        mx="-3"
+        mt="-3"
+        mb="3"
         className="bg-dots-2"
       >
         {children}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -4,6 +4,7 @@ import {
   TbCalendarEvent,
   TbCube,
   TbLifebuoy,
+  TbPackages,
   TbStarFilled,
   TbTools,
   TbUser,
@@ -20,6 +21,7 @@ export const EventIcon = TbCalendarEvent;
 export const UserIcon = TbUser;
 export const TeamIcon = TbUsersGroup;
 export const ChallengeIcon = TbCube;
+export const DeploymentIcon = TbPackages;
 
 // Semantic colors for UI.
 // Use instead of default accent for things that carry semantic meaning.

--- a/frontend/src/grid.ts
+++ b/frontend/src/grid.ts
@@ -13,5 +13,6 @@ export const radixTheme = themeQuartz
       foregroundColor : 'var(--gray-12)',
       accentColor : 'var(--accent-9)',
       fontFamily : 'var(--default-font-family)',
+      browserColorScheme : 'light dark',
     },
   );

--- a/frontend/src/routes/admin/deployments/DeploymentSidebar.tsx
+++ b/frontend/src/routes/admin/deployments/DeploymentSidebar.tsx
@@ -1,5 +1,6 @@
 import {
   COLOR_INFO,
+  DeploymentIcon,
   EventIcon,
   TeamIcon,
   UserIcon,
@@ -12,7 +13,6 @@ import {
   Skeleton,
   Table,
 } from '@radix-ui/themes';
-import AdminDataList from 'components/AdminDataList';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout, WarningCallout } from 'components/Callouts';
@@ -25,7 +25,7 @@ export default function DeploymentSidebar({ entity }: {entity: Deployment}) {
 
   return (
     <AdminSidebar>
-      <AdminSidebarHeader title="Deployment Details">
+      <AdminSidebarHeader title={`${entity.challenge_name} - ${entity.team_name}`} icon={<DeploymentIcon />}>
         <Button variant="soft" color={COLOR_INFO} asChild>
           <Link to={`/admin/teams?id=${entity.team}`}>
             <TeamIcon />
@@ -39,12 +39,6 @@ export default function DeploymentSidebar({ entity }: {entity: Deployment}) {
           </Link>
         </Button>
       </AdminSidebarHeader>
-      <AdminDataList
-        data={{
-          team : entity.team_name,
-          challenge : entity.challenge_name,
-        }}
-      />
 
       <AdminSidebarHeader title="Services" />
       {error && <ErrorCallout>{error.message}</ErrorCallout>}

--- a/frontend/src/routes/admin/events/AdminChallengeCard.tsx
+++ b/frontend/src/routes/admin/events/AdminChallengeCard.tsx
@@ -9,7 +9,6 @@ import {
   Text,
 } from '@radix-ui/themes';
 import ChallengeIcon from 'components/ChallengeIcon';
-import { TbPackages } from 'react-icons/tb';
 import { Link } from 'react-router';
 
 export default function AdminChallengeCard({ challenge }: { challenge: Challenge }) {

--- a/frontend/src/routes/admin/events/AdminChallengeCard.tsx
+++ b/frontend/src/routes/admin/events/AdminChallengeCard.tsx
@@ -1,4 +1,4 @@
-import { COLOR_INFO } from '@/constants';
+import { COLOR_INFO, DeploymentIcon } from '@/constants';
 import type { Challenge } from '@/types';
 import {
   Box,
@@ -32,7 +32,7 @@ export default function AdminChallengeCard({ challenge }: { challenge: Challenge
             <Link
               to={`/admin/deployments/?filter=${btoa(JSON.stringify({ challenge_name : { filterType : 'text', type : 'equals', filter : challenge.name } }))}`}
             >
-              <TbPackages />
+              <DeploymentIcon />
               Deployments
             </Link>
           </Button>

--- a/frontend/src/routes/admin/events/EventSidebar.tsx
+++ b/frontend/src/routes/admin/events/EventSidebar.tsx
@@ -10,7 +10,6 @@ import { Button } from '@radix-ui/themes';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import EventHeader from 'components/EventHeader';
-import { TbPackages } from 'react-icons/tb';
 import { Link } from 'react-router';
 import AdminChallengeCard from './AdminChallengeCard';
 import ChallengeUploadModal from './ChallengeUploadModal';

--- a/frontend/src/routes/admin/events/EventSidebar.tsx
+++ b/frontend/src/routes/admin/events/EventSidebar.tsx
@@ -1,4 +1,9 @@
-import { COLOR_INFO, TeamIcon } from '@/constants';
+import {
+  COLOR_INFO,
+  DeploymentIcon,
+  EventIcon,
+  TeamIcon,
+} from '@/constants';
 import { useEventChallenges } from '@/hooks/challenge';
 import type { Event } from '@/types';
 import { Button } from '@radix-ui/themes';
@@ -16,10 +21,10 @@ export default function EventSidebar({ entity }: { entity: Event }) {
 
   return (
     <AdminSidebar>
-      <AdminSidebarHeader title="Event Details">
+      <AdminSidebarHeader title={entity.name} icon={<EventIcon />}>
         <Button variant="soft" color={COLOR_INFO} asChild>
           <Link to={`/admin/deployments?filter=${btoa(JSON.stringify({ event_name : { filterType : 'text', type : 'equals', filter : entity.name } }))}`}>
-            <TbPackages />
+            <DeploymentIcon />
             Deployments
           </Link>
         </Button>

--- a/frontend/src/routes/admin/events/index.tsx
+++ b/frontend/src/routes/admin/events/index.tsx
@@ -95,19 +95,17 @@ export default function AdminEvents() {
   }
 
   return (
-    <Flex direction="column" gap="4" className="h-full w-full">
-      <Flex direction="row" gap="4" className="shrink-0">
-        <EventModal />
-      </Flex>
-      <Flex direction="row" gap="4" className="grow">
-        <AdminGrid
-          rowData={rowData}
-          columnDefs={colDefs}
-          loading={isLoading}
-          getRowId={(params) => params.data.id.toString()}
-          sidebarComponent={EventSidebar}
-        />
-      </Flex>
-    </Flex>
+    <AdminGrid
+      rowData={rowData}
+      columnDefs={colDefs}
+      loading={isLoading}
+      getRowId={(params) => params.data.id.toString()}
+      sidebarComponent={EventSidebar}
+      toolbar={(
+        <Flex direction="row" justify="start">
+          <EventModal />
+        </Flex>
+      )}
+    />
   );
 }

--- a/frontend/src/routes/admin/layout.tsx
+++ b/frontend/src/routes/admin/layout.tsx
@@ -58,7 +58,7 @@ function NavItem({
  */
 export default function AdminLayout() {
   return (
-    <Flex direction="row" className="absolute inset-0">
+    <Flex direction="row" className="absolute inset-0 overflow-hidden">
       <div className="flex-shrink-0 h-full p-3 pr-0">
         <Card className="h-full w-48">
           <NavigationMenu.Root orientation="vertical" aria-label="Sidebar" className="h-full overflow-y-auto">

--- a/frontend/src/routes/admin/layout.tsx
+++ b/frontend/src/routes/admin/layout.tsx
@@ -1,4 +1,9 @@
-import { EventIcon, TeamIcon, UserIcon } from '@/constants';
+import {
+  DeploymentIcon,
+  EventIcon,
+  TeamIcon,
+  UserIcon,
+} from '@/constants';
 import { Card, Flex } from '@radix-ui/themes';
 import { NavigationMenu } from 'radix-ui';
 import type { IconType } from 'react-icons';
@@ -8,7 +13,6 @@ import {
   TbChartPie,
   TbLayoutDashboard,
   TbMessage,
-  TbPackages,
   TbSettings,
   TbTags,
 } from 'react-icons/tb';
@@ -54,17 +58,17 @@ function NavItem({
  */
 export default function AdminLayout() {
   return (
-    <Flex direction="row" className="absolute top-0 bottom-0 left-0 right-0">
-      <div className="flex-shrink-0 h-full p-4 pr-0">
-        <Card asChild className="h-full w-48 overflow-hidden">
-          <NavigationMenu.Root orientation="vertical" aria-label="Sidebar">
+    <Flex direction="row" className="absolute inset-0">
+      <div className="flex-shrink-0 h-full p-3 pr-0">
+        <Card className="h-full w-48">
+          <NavigationMenu.Root orientation="vertical" aria-label="Sidebar" className="h-full overflow-y-auto">
             <NavigationMenu.List>
               <NavItem to="/admin" label="Dashboard" icon={TbLayoutDashboard} />
               <NavItem to="/admin/reports" label="Reports" icon={TbChartPie} />
               <NavItem to="/admin/events" label="Events" icon={EventIcon} />
               <NavItem to="/admin/users" label="Users" icon={UserIcon} />
               <NavItem to="/admin/teams" label="Teams" icon={TeamIcon} />
-              <NavItem to="/admin/deployments" label="Deployments" icon={TbPackages} />
+              <NavItem to="/admin/deployments" label="Deployments" icon={DeploymentIcon} />
               <NavItem to="/admin/notifications" label="Notifications" icon={TbBell} />
               <NavItem to="/admin/tickets" label="Tickets" icon={TbMessage} />
               <NavItem to="/admin/tags" label="Tags" icon={TbTags} />
@@ -74,7 +78,7 @@ export default function AdminLayout() {
           </NavigationMenu.Root>
         </Card>
       </div>
-      <main className="flex-grow overflow-y-auto p-4">
+      <main className="flex-grow overflow-y-auto p-3">
         <Outlet />
       </main>
     </Flex>

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -1,8 +1,8 @@
 import {
   COLOR_INFO,
-  COLOR_NEGATIVE,
-  COLOR_WARNING,
+  DeploymentIcon,
   EventIcon,
+  TeamIcon,
   UserIcon,
 } from '@/constants';
 import { useTeamMembers } from '@/hooks/team';
@@ -24,7 +24,7 @@ export default function TeamSidebar({ entity }: { entity: Team }) {
 
   return (
     <AdminSidebar>
-      <AdminSidebarHeader title="Team Details">
+      <AdminSidebarHeader title={entity.name} icon={<TeamIcon />}>
         <Button variant="soft" color={COLOR_INFO} asChild>
           <Link to={`/admin/deployments?filter=${btoa(JSON.stringify(
             {
@@ -33,7 +33,7 @@ export default function TeamSidebar({ entity }: { entity: Team }) {
             },
           ))}`}
           >
-            <TbPackages />
+            <DeploymentIcon />
             Deployments
           </Link>
         </Button>

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -1,5 +1,7 @@
 import {
   COLOR_INFO,
+  COLOR_NEGATIVE,
+  COLOR_WARNING,
   DeploymentIcon,
   EventIcon,
   TeamIcon,
@@ -14,7 +16,7 @@ import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout } from 'components/Callouts';
 import Entity from 'components/Entity';
 import RoleBadge from 'components/RoleBadge';
-import { TbDoorExit, TbPackages, TbStar } from 'react-icons/tb';
+import { TbDoorExit, TbStar } from 'react-icons/tb';
 import { Link } from 'react-router';
 import ScoreAdjustModal from './ScoreAdjustModal';
 import TeamActivity from './TeamActivity';

--- a/frontend/src/routes/admin/tickets/MessagesSidebar.tsx
+++ b/frontend/src/routes/admin/tickets/MessagesSidebar.tsx
@@ -1,4 +1,28 @@
 import {
+  ChallengeIcon,
+  EventIcon,
+  TeamIcon,
+  UserIcon,
+} from '@/constants';
+import { useEventChallenges } from '@/hooks/challenge';
+import { useSupportRoles } from '@/hooks/permissions';
+import {
+  addNewAdminTicketMessage,
+  assignTicket,
+  closeTicket,
+  muteTicket,
+  putTicketChallenge,
+  putTicketEventTeam,
+  removeTicketChallenge,
+  removeTicketEventTeam,
+  replaceTicketTags,
+  unassignTicket,
+  useAdminTicketMessages,
+  useSupportTags,
+} from '@/hooks/support';
+import { useCurrentUser, useUserEvents } from '@/hooks/users';
+import type { AdminTicket } from '@/types';
+import {
   Badge,
   Box,
   Button,
@@ -8,21 +32,11 @@ import {
 } from '@radix-ui/themes';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
-import {
-  unassignTicket,
-  assignTicket,
-  closeTicket,
-  muteTicket,
-  putTicketEventTeam,
-  removeTicketEventTeam,
-  putTicketChallenge,
-  removeTicketChallenge,
-  useAdminTicketMessages,
-  addNewAdminTicketMessage,
-  useSupportTags,
-  replaceTicketTags,
-} from '@/hooks/support';
-import type { AdminTicket } from '@/types';
+import { ErrorCallout } from 'components/Callouts';
+import Entity from 'components/Entity';
+import RichTextEditor from 'components/RichTextEditor';
+import { StatusBadge } from 'components/StatusBadge';
+import TicketMessagesCard from 'components/TicketMessagesCard';
 import {
   includes,
   isNil,
@@ -31,21 +45,7 @@ import {
   without,
 } from 'lodash';
 import { useState } from 'react';
-import RichTextEditor from 'components/RichTextEditor';
-import { ErrorCallout } from 'components/Callouts';
-import TicketMessagesCard from 'components/TicketMessagesCard';
-import { useCurrentUser, useUserEvents } from '@/hooks/users';
-import { useEventChallenges } from '@/hooks/challenge';
-import { StatusBadge } from 'components/StatusBadge';
-import {
-  ChallengeIcon,
-  EventIcon,
-  TeamIcon,
-  UserIcon,
-} from '@/constants';
-import Entity from 'components/Entity';
-import { useSupportRoles } from '@/hooks/permissions';
-import { TbX } from 'react-icons/tb';
+import { TbMessage, TbX } from 'react-icons/tb';
 
 export default function MessagesSidebar({ entity : selectedRow }: { entity: AdminTicket }) {
   // Dropdowns
@@ -214,7 +214,7 @@ export default function MessagesSidebar({ entity : selectedRow }: { entity: Admi
 
   return (
     <AdminSidebar>
-      <AdminSidebarHeader title="Ticket Details" />
+      <AdminSidebarHeader title={ticket.subject} icon={<TbMessage />} />
       {actionError && <ErrorCallout>{actionError}</ErrorCallout>}
       <DataList.Root>
         <DataList.Item>

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -1,4 +1,9 @@
-import { COLOR_POSITIVE, EventIcon, TeamIcon } from '@/constants';
+import { 
+  COLOR_POSITIVE,
+  EventIcon,
+  TeamIcon,
+  UserIcon,
+} from '@/constants';
 import { useTeamMembers } from '@/hooks/team';
 import { useUserEvents, useUserTeams } from '@/hooks/users';
 import type { Event, Team, User } from '@/types';
@@ -53,7 +58,7 @@ export default function UserSidebar({ entity }: { entity: User }) {
 
   return (
     <AdminSidebar>
-      <AdminSidebarHeader title="User Details" />
+      <AdminSidebarHeader title={entity.name} icon={<UserIcon />} />
 
       <AdminDataList data={{ ...entity }} />
 

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -1,4 +1,4 @@
-import { 
+import {
   COLOR_POSITIVE,
   EventIcon,
   TeamIcon,


### PR DESCRIPTION
- Standardize on 3 for spacing for consistency with radix
- Admin sidebar top header uses entity name instead of generic text, and can include an icon
- Clean up admin sidebar scrollbar display (scrollbar goes against the right edge of the screen, and overflowing content runs to the bottom of the screen instead of being arbitrarily cut off)
- Admin nav sidebar now scrolls at small viewport heights so all items can be accessed
- Admin sizebar basis value can now be adjusted as a prop
- AdminGrid takes toolbar prop for action buttons displayed above the grid
- ag-grid scollbars now correctly go into dark theme on chromium
- Various other scrollbar/layout fixes

<img width="2357" height="853" alt="image" src="https://github.com/user-attachments/assets/75117583-e49d-4d5c-8d8f-664db3c372e0" />
