### PR TITLE
Admin event challenges route

### DIFF
--- a/backend/ng/event/routes/admin_routes.py
+++ b/backend/ng/event/routes/admin_routes.py
@@ -217,6 +217,24 @@ class EventRegister(Resource):
 @events_admin_namespace.route("/<int:event_id>/challenges")
 class EventChallenges(Resource):
     @events_admin_namespace.doc(
+        description="Get all challenges for a specific event",
+        responses={
+            200: "Success - Returns list of challenges for the event",
+            404: "Not found - Event does not exist",
+            403: "Forbidden - Admin access required",
+            500: "Internal Server Error",
+        },
+    )
+    @admin_endpoint()
+    @load_event(source=LoaderType.PARAM)
+    def get(self, event: Event, **kwargs):
+        """
+        Get all challenges for an event
+        """
+        challenges = event.get_all_challenges()
+        return success_response(challenges)
+
+    @events_admin_namespace.doc(
         description="Create a challenge for an event using YAML configuration",
         params={
             "name": {

--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -79,6 +79,11 @@ export function submitFlag(
 }
 
 /* ADMIN ENDPOINTS */
+export function useAdminEventChallenges(eventId: number | null) {
+  return useSWR<Challenge[], Error>(
+    eventId ? `/admin/events/${eventId}/challenges` : null,
+  );
+}
 
 export function createChallenge(eventId: number, yaml: string) {
   return apiMutation(`/admin/events/${eventId}/challenges`, { yaml : btoa(yaml) }, {

--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -90,6 +90,6 @@ export function createChallenge(eventId: number, yaml: string) {
     method : 'POST',
   }).then(() => {
     // refresh the challenges list when a new challenge is created
-    mutate(`/events/${eventId}/challenges`);
+    mutate(`/admin/events/${eventId}/challenges`);
   });
 }

--- a/frontend/src/routes/admin/events/EventSidebar.tsx
+++ b/frontend/src/routes/admin/events/EventSidebar.tsx
@@ -4,11 +4,12 @@ import {
   EventIcon,
   TeamIcon,
 } from '@/constants';
-import { useEventChallenges } from '@/hooks/challenge';
+import { useAdminEventChallenges } from '@/hooks/challenge';
 import type { Event } from '@/types';
 import { Button } from '@radix-ui/themes';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
+import { ErrorCallout } from 'components/Callouts';
 import EventHeader from 'components/EventHeader';
 import { Link } from 'react-router';
 import AdminChallengeCard from './AdminChallengeCard';
@@ -16,7 +17,7 @@ import ChallengeUploadModal from './ChallengeUploadModal';
 import EventModal from './EventModal';
 
 export default function EventSidebar({ entity }: { entity: Event }) {
-  const { data : challenges } = useEventChallenges(entity.id);
+  const { data : challenges, error } = useAdminEventChallenges(entity.id);
 
   return (
     <AdminSidebar>
@@ -43,6 +44,8 @@ export default function EventSidebar({ entity }: { entity: Event }) {
       <AdminSidebarHeader title="Challenges">
         <ChallengeUploadModal eventId={entity.id} />
       </AdminSidebarHeader>
+
+      {error && <ErrorCallout>{error.message}</ErrorCallout>}
 
       {challenges && challenges.length > 0 && (
         challenges.map((challenge) => (


### PR DESCRIPTION
The admin page challenges list previously used the user-facing event challenges endpoint, which now has stricter access control that prevents admins from managing challenges unless they're registered for and have started an event.

This creates a separate admin endpoint to get event challenge lists which is not subject to user-facing permission controls so that admins can view challenges associated with any event through the admin panel.