### PR TITLE
Initial working event start button

### DIFF
--- a/frontend/src/hooks/events.ts
+++ b/frontend/src/hooks/events.ts
@@ -114,6 +114,20 @@ export function useMyTeamMembers(eventId: number | undefined) {
 }
 
 /**
+ * Starts the user's team for a specific event. User must be captain.
+ * @param eventId The id of the event
+ */
+export function startMyTeam(eventId: number) {
+  return apiMutation(`/events/${eventId}/me/team/start`, undefined, {
+    method : 'POST',
+  }).then(() => {
+    mutate(`/events/${eventId}/me/team`);
+    mutate(`/events/${eventId}/challenges`);
+    mutate(`/events/${eventId}/me/challenges`);
+  });
+}
+
+/**
  * @param eventId The id of the event
  * @param teamName The new name for the team
  * @returns a new team object

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -10,6 +10,7 @@ import HeaderContainer from 'components/HeaderContainer';
 import ChallengesTab from './OverviewTabs/ChallengesTab';
 import LeaderboardTab from './OverviewTabs/LeaderboardTab';
 import TeamTab from './OverviewTabs/TeamTab';
+import StartModal from './StartModal';
 
 export default function Overview() {
   const [ searchParams, setSearchParams ] = useSearchParams();
@@ -24,14 +25,16 @@ export default function Overview() {
         {data && (
           <EventHeader
             event={data}
-          />
+          >
+            {data && <StartModal eventId={data.id} />}
+          </EventHeader>
         )}
       </HeaderContainer>
 
       <Tabs.Root
         value={currentTab}
         onValueChange={(tab) => {
-          if (tab === searchParams.get('tab')) {
+          if (tab === currentTab) {
             return;
           }
           setSearchParams((prev) => {
@@ -39,6 +42,7 @@ export default function Overview() {
             return prev;
           });
         }}
+        activationMode="manual"
       >
         <Container size="2" mb="4">
           <Tabs.List className="*:!basis-0 *:!grow" loop={false}>

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/index.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/index.tsx
@@ -1,10 +1,12 @@
 import { useEventChallenges, useMyChallenges } from '@/hooks/challenge';
+import { useMyTeam } from '@/hooks/events';
 import {
   Container,
   Grid,
   Text,
   TextField,
 } from '@radix-ui/themes';
+import { ErrorCallout } from 'components/Callouts';
 import { keyBy } from 'lodash';
 import { useMemo, useState } from 'react';
 import { TbCancel, TbSearch } from 'react-icons/tb';
@@ -13,8 +15,8 @@ import ChallengeCard from './ChallengeCard';
 
 export default function ChallengesTab() {
   const { idEvent } = useParams<{idEvent: string}>();
-  const { data } = useEventChallenges(Number(idEvent));
-  const { data : myChallenges } = useMyChallenges(Number(idEvent));
+  const { data, error } = useEventChallenges(Number(idEvent));
+  const { data : myChallenges, error : myError } = useMyChallenges(Number(idEvent));
 
   const challengeProgressMap = useMemo(() => keyBy(myChallenges, (progress) => progress.challenge_id), [ myChallenges ]);
 
@@ -26,8 +28,10 @@ export default function ChallengesTab() {
       || challenge.summary.toLowerCase().includes(searchQuery.toLowerCase()));
   }, [ data, searchQuery ]);
 
-  // Are we in the event window/team start time?
-  const challengesAvailable = true;
+  // NAIVE PERMISSION CHECK - SHOULD BE BASED ON CAN_VIEW_CHALLENGES
+  // For now, just check if the user's team has a start timestamp
+  const { data : myTeam } = useMyTeam(Number(idEvent));
+  const challengesAvailable = myTeam?.start_timestamp;
 
   if (!challengesAvailable) {
     return (
@@ -41,9 +45,17 @@ export default function ChallengesTab() {
     );
   }
 
+  if (error) {
+    return (
+      <Container size="4">
+        <ErrorCallout>{error.message}</ErrorCallout>
+      </Container>
+    );
+  }
+
   return (
     <>
-      <Container size="2" mb="4">
+      <Container size="2" mb="3">
         <TextField.Root placeholder="Search challenges..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)}>
           <TextField.Slot>
             <TbSearch height="16" width="16" />
@@ -51,7 +63,8 @@ export default function ChallengesTab() {
         </TextField.Root>
       </Container>
       <Container size="4">
-        <Grid columns={{ xs : '1', sm : '2', md : '3' }} gap="4">
+        {myError && (<ErrorCallout className="mb-3">Failed to load your progress.</ErrorCallout>)}
+        <Grid columns={{ xs : '1', sm : '2', md : '3' }} gap="3">
           {filteredChallenges.map((challenge) => (
             <ChallengeCard
               challenge={challenge}

--- a/frontend/src/routes/events/StartModal.tsx
+++ b/frontend/src/routes/events/StartModal.tsx
@@ -1,0 +1,38 @@
+import { COLOR_POSITIVE } from '@/constants';
+import { startMyTeam, useMyTeam } from '@/hooks/events';
+import type { Event } from '@/types';
+import { Button } from '@radix-ui/themes';
+import Modal from 'components/Modal';
+import { TbPlayerPlay } from 'react-icons/tb';
+
+export default function StartModal({ event }: {event: Event}) {
+  const { data : myTeam } = useMyTeam(event.id);
+  const handleStart = async () => startMyTeam(event.id);
+
+  if (!myTeam) return null;
+
+  if (myTeam?.start_timestamp) {
+    return (
+      <Button disabled>
+        <TbPlayerPlay />
+        Started
+      </Button>
+    );
+  }
+
+  return (
+    <Modal
+      trigger={(
+        <Button color={COLOR_POSITIVE} className="pulsate">
+          <TbPlayerPlay />
+          Start
+        </Button>
+      )}
+      title="Start Event"
+      description="Are you sure you want to start playing this event?"
+      submitVerb="Start"
+      submitColor={COLOR_POSITIVE}
+      onSubmit={handleStart}
+    />
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -29,6 +29,8 @@ export interface Team {
   ranked: boolean;
   locked: boolean;
   invite_code?: string;
+  start_timestamp: Date | null;
+  end_time: Date | null;
 }
 
 export interface TeamMember {


### PR DESCRIPTION
Start button for event pages. Currently missing a lot of permission checking logic, since the necessary permission data is not available to the frontend currently, but having the button in place is important for being able to test event/challenge functionality going forwards.