### PR TITLE
Frontend websocket integration

### DIFF
--- a/backend/ng/notifications/services/notification_service.py
+++ b/backend/ng/notifications/services/notification_service.py
@@ -176,7 +176,7 @@ class NotificationService:
         )
 
         NotificationService._emit_refetch(
-            path = f"/ng/events/{event_id}/leaderboard",
+            path = f"/ng/scoring/events/{event_id}/leaderboard",
             event_id = event_id
         )
 

--- a/conf/ctfd/serve_debug.py
+++ b/conf/ctfd/serve_debug.py
@@ -42,4 +42,4 @@ if args.profile:
     toolbar.init_app(app)
     print(f" * Flask profiling running at http://0.0.0.0:${args.port}/flask-profiler/")
 
-app.run(debug=True, threaded=True, host="0.0.0.0", port=args.port)
+app.extensions["socketio"].run(app, host="0.0.0.0", port=args.port, debug=True)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "react-router": "^7.6.3",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
+    "socket.io-client": "^4.8.1",
     "swr": "^2.3.3",
     "tailwind-merge": "^3.3.1"
   },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { Theme } from '@radix-ui/themes';
-import { ThemeProvider } from 'next-themes';
 import FooterBar from 'components/Footer';
 import NavBar from 'components/NavBar';
+import { ThemeProvider } from 'next-themes';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router';
@@ -12,6 +12,7 @@ import { apiFetcher } from '@/fetchers';
 import Routes from './Routes';
 import './grid';
 import './index.css';
+import './socket';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -1,0 +1,14 @@
+import { io } from 'socket.io-client';
+import { mutate } from 'swr';
+import { APIPREFIX } from './constants';
+
+const socket = io({ transports : [ 'websocket' ], upgrade : false });
+
+// Trigger SWR revalidation when a "refetch" event is received from the server.
+socket.on('refetch', (msg: {path: string}) => {
+  // server refetch events use /ng prefix, we need to remove it here to match SWR keys
+  const resourcePath = msg.path.replace(APIPREFIX, '');
+  mutate(resourcePath);
+});
+
+export default socket;

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -11,4 +11,15 @@ socket.on('refetch', (msg: {path: string}) => {
   mutate(resourcePath);
 });
 
+// Update notification hooks when a notification is received.
+socket.on('notification', () => {
+  mutate('/notifications/me');
+  mutate('/notifications/unread_count');
+});
+
+// Update announcements hook when an announcement is received.
+socket.on('system_announcement', () => {
+  mutate('/notifications/announcements');
+});
+
 export default socket;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
 import path from 'path';
+import { defineConfig } from 'vite';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -16,7 +16,22 @@ export default defineConfig({
     },
   },
   base : '/static/',
-  plugins : [ react(), tailwindcss() ],
+  plugins : [
+    react(),
+    tailwindcss(),
+    {
+      // Force full page reload when socket implementation changes.
+      // Ensures that old sockets and event listeners are cleaned up.
+      name : 'full-reload-socket',
+      handleHotUpdate({ file, server }) {
+        if (file.endsWith('socket.ts')) {
+          server.ws.send({ type : 'full-reload' });
+          return [];
+        }
+        return undefined;
+      },
+    },
+  ],
   resolve : {
     alias : {
       assets : path.resolve(__dirname, './src/assets'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      socket.io-client:
+        specifier: ^4.8.1
+        version: 4.8.1
       swr:
         specifier: ^2.3.3
         version: 2.3.6(react@19.1.1)
@@ -1525,6 +1528,9 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@tailwindcss/node@4.1.12':
     resolution: {integrity: sha512-3hm9brwvQkZFe++SBt+oLjo4OLDtkvlE8q2WalaD/7QWaeM7KEJbAiY/LJZUaCs7Xa8aUu4xy3uoyX4q54UVdQ==}
 
@@ -2104,6 +2110,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
@@ -2161,6 +2176,13 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  engine.io-client@6.6.3:
+    resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
@@ -3437,6 +3459,14 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  socket.io-client@4.8.1:
+    resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.4:
+    resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
+    engines: {node: '>=10.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3740,6 +3770,22 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -5563,6 +5609,8 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@socket.io/component-emitter@3.1.2': {}
+
   '@tailwindcss/node@4.1.12':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6178,6 +6226,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -6231,6 +6283,20 @@ snapshots:
   electron-to-chromium@1.5.213: {}
 
   emoji-regex@9.2.2: {}
+
+  engine.io-client@6.6.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+      engine.io-parser: 5.2.3
+      ws: 8.17.1
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
 
   enhanced-resolve@5.18.3:
     dependencies:
@@ -8053,6 +8119,24 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  socket.io-client@4.8.1:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+      engine.io-client: 6.6.3
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.4:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+    transitivePeerDependencies:
+      - supports-color
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
@@ -8428,6 +8512,10 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  ws@8.17.1: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
The backend can now trigger SWR refetches on the frontend via websocket. SWR hooks that use affected endpoints will automatically reload their data from the server and re-render the components they are used by.

Had to update `serve_debug.py` to use `socketio.run` as described in the flask-socket.io documentation, as `app.run` is not compatible with websockets (and results in a 500 error when connecting.)

I also configured Vite to do a full refresh of the page when `socket.ts` is modified, as the default hot-reload behavior caused issues with multiple sockets/listeners being created unnecessarily.