### PR TITLE
Support for public pages and other things

### DIFF
--- a/backend/ng/admin/tests/test_admin_integration.py
+++ b/backend/ng/admin/tests/test_admin_integration.py
@@ -172,7 +172,7 @@ class TestAdminImpersonation:
         assert response.status_code == 200
 
         response = admin_client.get("/ng/admin/health")
-        assert response.status_code == 302
+        assert response.status_code == 403
 
     def test_cannot_impersonate_nonexistent_user(self, admin_client):
         """Test that admin cannot impersonate a nonexistent user."""

--- a/backend/ng/conftest.py
+++ b/backend/ng/conftest.py
@@ -262,6 +262,12 @@ def logged_in_client(app, db_session, user):
         sess.permanent = False
     return client
 
+@pytest.fixture(scope="function")
+def public_client(app, db_session):
+    """A test client for making public requests."""
+    cache.clear()
+    return app.test_client()
+
 
 @pytest.fixture(scope="function")
 def admin_client(app, db_session, admin):

--- a/backend/ng/core/exceptions.py
+++ b/backend/ng/core/exceptions.py
@@ -62,6 +62,13 @@ class PermissionError(APIException):
     message = "You do not have permission to perform this action."
     error_field = "permission"
 
+class AuthenticationError(APIException):
+    """Raised when authentication fails or is required."""
+
+    status_code = 401
+    message = "Authentication is required to access this resource."
+    error_field = "authentication"
+
 
 class ConflictError(APIException):
     """Raised when a request conflicts with the current state of the resource"""

--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -64,7 +64,7 @@ def _auth_handler(f, auth_required, json_required, validation_func):
         if auth_required:
             current_user = get_current_user()
             if not current_user:
-                abort(401)
+                raise PermissionError("Authentication is required to access this endpoint.")
             kwargs["current_user"] = User.find_or_create_by_ctfd_id(current_user.id)
         if json_required:
             if not request.is_json:

--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -106,7 +106,7 @@ def admins_only(f):
 
 
 # Convenience decorators for common patterns
-def user_endpoint(auth_required=True, json_required=False, validation_func=None):
+def user_endpoint(json_required=False, validation_func=None):
     """Shorthand for authenticated user endpoints"""
     return api_endpoint(
         auth_required=True,

--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -5,7 +5,6 @@ Resource loading and permissions are handled by separate decorators.
 
 from functools import wraps
 
-from CTFd.utils.decorators import authed_only
 from CTFd.utils.user import get_current_user
 from flask import request, redirect, url_for, abort
 

--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -6,10 +6,10 @@ Resource loading and permissions are handled by separate decorators.
 from functools import wraps
 
 from CTFd.utils.user import get_current_user
-from flask import request, redirect, url_for, abort
+from flask import request, abort
 
 from ...user.models.User import User
-from ..exceptions import PermissionError, ValidationError, AuthenticationError
+from ..exceptions import ValidationError, AuthenticationError
 from ...permissions.models.enums import RoleEnum
 from ...permissions.controllers.get_user_roles import get_user_roles
 from .error_handler import handle_exceptions

--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -47,8 +47,6 @@ def api_endpoint(auth_required=True, admin_required=False, json_required=False, 
         def decorated_function(*args, **kwargs):
             if admin_required:
                 return admins_only(_auth_handler(f, auth_required, json_required, validation_func))(*args, **kwargs)
-            elif auth_required:
-                return authed_only(_auth_handler(f, auth_required, json_required, validation_func))(*args, **kwargs)
             else:
                 return _auth_handler(f, auth_required, json_required, validation_func)(*args, **kwargs)
 
@@ -66,7 +64,7 @@ def _auth_handler(f, auth_required, json_required, validation_func):
         if auth_required:
             current_user = get_current_user()
             if not current_user:
-                raise PermissionError("Authentication is required to access this resource.")
+                abort(401)
             kwargs["current_user"] = User.find_or_create_by_ctfd_id(current_user.id)
         if json_required:
             if not request.is_json:
@@ -108,7 +106,7 @@ def admins_only(f):
 
 
 # Convenience decorators for common patterns
-def user_endpoint(json_required=False, validation_func=None):
+def user_endpoint(auth_required=True, json_required=False, validation_func=None):
     """Shorthand for authenticated user endpoints"""
     return api_endpoint(
         auth_required=True,

--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -64,7 +64,7 @@ def _auth_handler(f, auth_required, json_required, validation_func):
         if auth_required:
             current_user = get_current_user()
             if not current_user:
-                raise PermissionError("Authentication is required to access this endpoint.")
+                raise PermissionError("Authentication is required to access this resource.")
             kwargs["current_user"] = User.find_or_create_by_ctfd_id(current_user.id)
         if json_required:
             if not request.is_json:

--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -9,7 +9,7 @@ from CTFd.utils.user import get_current_user
 from flask import request, redirect, url_for, abort
 
 from ...user.models.User import User
-from ..exceptions import PermissionError, ValidationError
+from ..exceptions import PermissionError, ValidationError, AuthenticationError
 from ...permissions.models.enums import RoleEnum
 from ...permissions.controllers.get_user_roles import get_user_roles
 from .error_handler import handle_exceptions
@@ -63,7 +63,7 @@ def _auth_handler(f, auth_required, json_required, validation_func):
         if auth_required:
             current_user = get_current_user()
             if not current_user:
-                raise PermissionError("Authentication is required to access this resource.")
+                raise AuthenticationError("Authentication is required to access this resource.")
             kwargs["current_user"] = User.find_or_create_by_ctfd_id(current_user.id)
         if json_required:
             if not request.is_json:
@@ -96,10 +96,7 @@ def admins_only(f):
         if RoleEnum.ADMIN in get_user_roles():
             return f(*args, **kwargs)
         else:
-            if request.content_type == "application/json":
-                abort(403)
-            else:
-                return redirect(url_for("auth.login", next=request.full_path))
+            abort(403)
 
     return admins_only_wrapper
 

--- a/backend/ng/core/middleware/permission_middleware.py
+++ b/backend/ng/core/middleware/permission_middleware.py
@@ -32,7 +32,7 @@ def check_permissions(permission: PermissionEnum, error_message: str):
                 kwargs['permissions'] = permissions
             else:
                 kwargs['permissions'].extend(permissions)
-            if permission.name not in permissions:
+            if permission is not None and permission.name not in permissions:
                 return _deny(permission, trace, error_message)
             return f(*args, **kwargs)
         return wrapped

--- a/backend/ng/core/middleware/permission_middleware.py
+++ b/backend/ng/core/middleware/permission_middleware.py
@@ -52,7 +52,8 @@ def event_only_public(f):
     def wrapped(*args, **kwargs):
         event = kwargs.get('event')
         current_user = kwargs.get('current_user')
-        if Demographic.find_by_user_and_event(current_user.id, event.id) is None:
+        id = current_user.id if current_user else None
+        if Demographic.find_by_user_and_event(id, event.id) is None:
             if not event.public:
                 return error_response("Event not found", "not_found", 404)
         return f(*args, **kwargs)

--- a/backend/ng/core/routes/__init__.py
+++ b/backend/ng/core/routes/__init__.py
@@ -10,6 +10,7 @@ from flask_restx import Api
 from ...challenge.routes import challenge_admin_namespace
 from ...event.routes import events_admin_namespace, events_user_namespace
 from ...permissions.routes import permissions_admin_namespace
+from ...permissions.routes.user_routes import permissions_user_namespace
 from ...team.routes import teams_admin_namespace
 from ...user.routes import users_admin_namespace, users_user_namespace
 from ...user.routes.authenticate import oauth_namespace
@@ -57,6 +58,7 @@ api_v1.add_namespace(scoring_user_namespace, path="/events")
 # api_v1.add_namespace(challenge_namespace, path="/challenge")
 api_v1.add_namespace(support_user_namespace, path="/support")
 api_v1.add_namespace(container_namespace, path="/container")
+api_v1.add_namespace(permissions_user_namespace, path="/permissions")
 api_v1.add_namespace(notifications_user_namespace, path="/notifications")
 
 # Admin namespaces

--- a/backend/ng/event/routes/user_routes.py
+++ b/backend/ng/event/routes/user_routes.py
@@ -9,6 +9,7 @@ from CTFd.models import db
 from ...core.utils import utc_now
 from ...core.middleware import (
     user_endpoint,
+    public_endpoint,
 )
 from ...core.middleware.loaders import (
     load_user,
@@ -55,7 +56,7 @@ events_user_namespace = Namespace(
 
 @events_user_namespace.route("")
 class EventList(Resource):
-    @user_endpoint()
+    @public_endpoint()
     @events_user_namespace.doc(
         description="Get all public events",
         responses={
@@ -75,7 +76,7 @@ class EventList(Resource):
 @events_user_namespace.route("/<int:event_id>")
 class EventDetail(Resource):
 
-    @user_endpoint()
+    @public_endpoint()
     @load_event(source = LoaderType.PARAM)
     @event_only_public
     @events_user_namespace.doc(

--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -989,7 +989,7 @@ class Test_Event_Admin_Get:
 
         response = logged_in_client.get(self.get_endpoint(event.id))
 
-        assert response.status_code == 302
+        assert response.status_code == 403
 
 
 class Test_Event_Admin_Put:

--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -45,6 +45,19 @@ class Test_Public_Event_Listing:
         assert len(data["data"]) == 1
         assert data["data"][0] == event2.serialize()
 
+    def test_public_can_list_events(self, public_client, event_factory):
+        event1 = event_factory(name = "Public Event 1", public = True)
+        event2 = event_factory(name = "Public Event 2", public = True)
+
+        response = public_client.get(self.endpoint)
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is True
+        assert len(data["data"]) == 2
+        assert data["data"][0] == event1.serialize()
+        assert data["data"][1] == event2.serialize()
+
 
 class Test_Public_Event_Detail:
     def get_endpoint(self, event_id: int) -> str:
@@ -79,6 +92,21 @@ class Test_Public_Event_Detail:
         assert response.status_code == 404
         data = response.get_json()
         assert data["success"] is False
+
+    def test_public_can_get_public_event_details(
+        self,
+        public_client,
+        event_factory
+    ):
+        event = event_factory(name = "Public Event for Detail Test", public = True)
+
+        response = public_client.get(self.get_endpoint(event.id))
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert data["success"] is True
+        assert data["data"] == event.serialize()
 
 
 class Test_Event_Eligibility:

--- a/backend/ng/permissions/routes/__init__.py
+++ b/backend/ng/permissions/routes/__init__.py
@@ -1,5 +1,7 @@
 from .admin_routes import permissions_admin_namespace
+from .user_routes import permissions_user_namespace
 
 __all__ = [
     "permissions_admin_namespace",
+    "permissions_user_namespace"
 ]

--- a/backend/ng/permissions/routes/user_routes.py
+++ b/backend/ng/permissions/routes/user_routes.py
@@ -1,12 +1,7 @@
-from flask import request
 from flask_restx import Namespace, Resource
 from ...core.utils.logger import get_logger
-from ...core.utils.api import error_response, success_response
+from ...core.utils.api import success_response
 from ...core.middleware.auth import user_endpoint
-from ...core.exceptions import ValidationError
-from ..models.Role import Role
-from ..models.UserRole import UserRole
-from ..controllers import get_users_with_roles, get_support_role_users
 from ...core.middleware.loaders.load_event import load_event
 from ...core.middleware.loaders.load_team_by_user_and_event import load_team_by_user_and_event
 from ...core.middleware.loaders._util import LoaderType

--- a/backend/ng/permissions/routes/user_routes.py
+++ b/backend/ng/permissions/routes/user_routes.py
@@ -4,6 +4,7 @@ from ...core.utils.api import success_response
 from ...core.middleware.auth import user_endpoint
 from ...core.middleware.loaders.load_event import load_event
 from ...core.middleware.loaders.load_team_by_user_and_event import load_team_by_user_and_event
+from ...permissions.controllers.get_user_roles import get_user_roles
 from ...core.middleware.loaders._util import LoaderType
 from ...core.middleware.permission_middleware import (
     check_permissions,
@@ -37,4 +38,50 @@ class UserPermissions(Resource):
         return success_response({
             "user_id": current_user.id,
             "permissions": permissions
+        })
+
+@permissions_user_namespace.route("/me")
+class UserGlobalPermissions(Resource):
+    """
+    Resource to get the current user's global permissions.
+    """
+    @user_endpoint()
+    @check_permissions(None, "")
+    @permissions_user_namespace.doc(
+        description="Get the current user's global permissions",
+        responses={200: "Success", 401: "Unauthorized"},
+    )
+    def get(self, **kwargs):
+        """
+        Get the current user's global permissions.
+        """
+        current_user = kwargs.get("current_user")
+        permissions = kwargs.get("permissions", [])
+
+        return success_response({
+            "user_id": current_user.id,
+            "permissions": permissions
+        })
+
+@permissions_user_namespace.route("/me/roles")
+class UserRoles(Resource):
+    """
+    Resource to get the current user's roles.
+    """
+    @user_endpoint()
+    @permissions_user_namespace.doc(
+        description="Get the current user's roles",
+        responses={200: "Success", 401: "Unauthorized"},
+    )
+    def get(self, **kwargs):
+        """
+        Get the current user's roles.
+        """
+        current_user = kwargs.get("current_user")
+
+        roles = get_user_roles(current_user.id)
+
+        return success_response({
+            "user_id": current_user.id,
+            "roles": roles
         })

--- a/backend/ng/permissions/routes/user_routes.py
+++ b/backend/ng/permissions/routes/user_routes.py
@@ -1,0 +1,45 @@
+from flask import request
+from flask_restx import Namespace, Resource
+from ...core.utils.logger import get_logger
+from ...core.utils.api import error_response, success_response
+from ...core.middleware.auth import user_endpoint
+from ...core.exceptions import ValidationError
+from ..models.Role import Role
+from ..models.UserRole import UserRole
+from ..controllers import get_users_with_roles, get_support_role_users
+from ...core.middleware.loaders.load_event import load_event
+from ...core.middleware.loaders.load_team_by_user_and_event import load_team_by_user_and_event
+from ...core.middleware.loaders._util import LoaderType
+from ...core.middleware.permission_middleware import (
+    check_permissions,
+)
+
+
+permissions_user_namespace = Namespace("/permissions", description="Permissions management endpoints for users")
+logger = get_logger(__name__)
+
+
+@permissions_user_namespace.route("/<int:event_id>/me")
+class UserPermissions(Resource):
+    """
+    Resource to get the current user's permissions.
+    """
+    @user_endpoint()
+    @load_event(source=LoaderType.PARAM, output_key="event")
+    @load_team_by_user_and_event(output_key="team")
+    @check_permissions(None, "")
+    @permissions_user_namespace.doc(
+        description="Get the current user's permissions",
+        responses={200: "Success", 401: "Unauthorized"},
+    )
+    def get(self, **kwargs):
+        """
+        Get the current user's permissions.
+        """
+        current_user = kwargs.get("current_user")
+        permissions = kwargs.get("permissions", [])
+
+        return success_response({
+            "user_id": current_user.id,
+            "permissions": permissions
+        })

--- a/backend/ng/permissions/tests/test_permission_api.py
+++ b/backend/ng/permissions/tests/test_permission_api.py
@@ -89,4 +89,14 @@ def test_update_user_roles_invalid_role(admin_client, user_with_roles):
     assert "errors" in data
     assert "validation" in data["errors"]
 
+def test_get_user_permissions(team_captain_client, user_with_roles):
+    """Check that a user can get their own permissions."""
+    response = team_captain_client.get("/ng/permissions/1/me")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"]
+    assert "permissions" in data["data"]
+    assert isinstance(data["data"]["permissions"], list)
+    assert len(data["data"]["permissions"]) > 0
+
 

--- a/backend/ng/permissions/tests/test_permission_api.py
+++ b/backend/ng/permissions/tests/test_permission_api.py
@@ -19,7 +19,7 @@ def test_role_endpoints_not_authenticated(logged_in_client, role_with_permission
     """Check that role endpoints are not accessible without authentication as an admin."""
     role = role_with_permissions
     response = logged_in_client.get(f"/ng/admin/permissions/{role.id}/details")
-    assert response.status_code == 302
+    assert response.status_code == 403
     response = logged_in_client.put(f"/ng/admin/permissions/{role.id}/details", json={
         "permissions": ["can_edit_team", "can_edit_user"]
     })
@@ -62,7 +62,7 @@ def test_get_user_roles(admin_client, user_with_roles):
 def test_user_endpoints_not_authenticated(logged_in_client, user_with_roles):
     """Check that user endpoints are not accessible without authentication as an admin."""
     response = logged_in_client.get(f"/ng/admin/permissions/{user_with_roles.id}/roles")
-    assert response.status_code == 302
+    assert response.status_code == 403
     response = logged_in_client.put(f"/ng/admin/permissions/{user_with_roles.id}/roles", json={
         "roles": ["Test Role"]
     })
@@ -98,5 +98,37 @@ def test_get_user_permissions(team_captain_client, user_with_roles):
     assert "permissions" in data["data"]
     assert isinstance(data["data"]["permissions"], list)
     assert len(data["data"]["permissions"]) > 0
+
+def test_get_user_global_permissions(admin_client, user_with_roles):
+    """Check that a user can get their own global permissions."""
+    response = admin_client.get("/ng/permissions/me")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"]
+    assert "permissions" in data["data"]
+    assert isinstance(data["data"]["permissions"], list)
+    assert len(data["data"]["permissions"]) > 0
+
+def test_get_user_roles_endpoint(team_captain_client, user_with_roles):
+    """Check that a user can get their own roles."""
+    response = team_captain_client.get("/ng/permissions/me/roles")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"]
+    assert "roles" in data["data"]
+    assert isinstance(data["data"]["roles"], list)
+    assert len(data["data"]["roles"]) == 0
+
+def test_get_user_roles_with_roles(admin_client):
+    """Check that we can get roles for a specific user with multiple roles."""
+
+    response = admin_client.get(f"/ng/permissions/me/roles")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"]
+    assert "roles" in data["data"]
+    assert isinstance(data["data"]["roles"], list)
+    assert len(data["data"]["roles"]) > 0
+    assert "admin" in data["data"]["roles"]
 
 

--- a/backend/ng/permissions/tests/test_permission_api.py
+++ b/backend/ng/permissions/tests/test_permission_api.py
@@ -122,7 +122,7 @@ def test_get_user_roles_endpoint(team_captain_client, user_with_roles):
 def test_get_user_roles_with_roles(admin_client):
     """Check that we can get roles for a specific user with multiple roles."""
 
-    response = admin_client.get(f"/ng/permissions/me/roles")
+    response = admin_client.get("/ng/permissions/me/roles")
     assert response.status_code == 200
     data = response.get_json()
     assert data["success"]

--- a/backend/ng/scoring/routes/user_routes.py
+++ b/backend/ng/scoring/routes/user_routes.py
@@ -5,7 +5,7 @@ User API routes for scoring
 from flask import request
 from flask_restx import Namespace, Resource
 
-from ...core.middleware import user_endpoint
+from ...core.middleware import user_endpoint, public_endpoint
 from ...core.middleware.loaders import (
     LoaderType,
     load_event,
@@ -35,7 +35,7 @@ scoring_user_namespace = Namespace("scoring", description="Scoring operations fo
 
 @scoring_user_namespace.route("/<int:event_id>/leaderboard")
 class EventLeaderboard(Resource):
-    @user_endpoint()
+    @public_endpoint()
     @load_event(LoaderType.PARAM)
     @scoring_user_namespace.doc(
         description="Get the event leaderboard showing team rankings and scores with optional limit",

--- a/backend/ng/scoring/routes/user_routes.py
+++ b/backend/ng/scoring/routes/user_routes.py
@@ -59,7 +59,6 @@ class EventLeaderboard(Resource):
         """
         Get event leaderboard
         """
-        current_user = kwargs.get("current_user", None)
         limit = request.args.get("limit", config.DEFAULT_LEADERBOARD_LIMIT, type=int)
         if limit < 1 or limit > config.MAX_LEADERBOARD_LIMIT:
             raise ValidationError(f"Limit must be between 1 and {config.MAX_LEADERBOARD_LIMIT}")

--- a/backend/ng/scoring/routes/user_routes.py
+++ b/backend/ng/scoring/routes/user_routes.py
@@ -55,10 +55,11 @@ class EventLeaderboard(Resource):
             500: "Internal Server Error",
         },
     )
-    def get(self, event_id: int, event, current_user: User, **kwargs):
+    def get(self, event_id: int, event, **kwargs):
         """
         Get event leaderboard
         """
+        current_user = kwargs.get("current_user", None)
         limit = request.args.get("limit", config.DEFAULT_LEADERBOARD_LIMIT, type=int)
         if limit < 1 or limit > config.MAX_LEADERBOARD_LIMIT:
             raise ValidationError(f"Limit must be between 1 and {config.MAX_LEADERBOARD_LIMIT}")

--- a/backend/ng/scoring/tests/test_scoring_api.py
+++ b/backend/ng/scoring/tests/test_scoring_api.py
@@ -72,6 +72,16 @@ class TestUserScoringEndpoints:
         data = response.get_json()
         assert data["success"] is False
 
+    def test_public_access_leaderboard(self, public_client, event, multiple_teams_with_scores):
+        """Test that public client can access leaderboard"""
+        response = public_client.get(f"/ng/events/{event.id}/leaderboard")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is True
+        assert len(data["data"]) == 5
+
+
     def test_get_my_team_score_basic(
         self,
         logged_in_client,
@@ -458,7 +468,6 @@ class TestUserScoringEndpoints:
     ):
         """Test that unauthenticated requests fail"""
         endpoints = [
-            f"/ng/events/{event.id}/leaderboard",
             f"/ng/events/{event.id}/me/team/score",
             f"/ng/events/{event.id}/challenges/{challenge.id}/questions/{question.id}/submit",
             f"/ng/events/{event.id}/challenges/{challenge.id}/hint/{hint.id}/redeem",

--- a/backend/ng/scoring/tests/test_scoring_api.py
+++ b/backend/ng/scoring/tests/test_scoring_api.py
@@ -479,7 +479,7 @@ class TestUserScoringEndpoints:
             else:
                 response = client.get(endpoint)
 
-            assert response.status_code in [302, 403]
+            assert response.status_code == 401
 
 
 class TestAdminScoringEndpoints:
@@ -907,7 +907,7 @@ class TestAdminScoringEndpoints:
         )
 
         # CTFd returns 302 redirect for non admin access to admin endpoints in test environment
-        assert response.status_code == 302
+        assert response.status_code == 403
 
     def test_get_score_history_empty(
         self,
@@ -1174,7 +1174,7 @@ class TestAdminScoringEndpoints:
 
         for endpoint in endpoints:
             response = logged_in_client.get(endpoint)
-            assert response.status_code == 302
+            assert response.status_code == 403
 
     def test_unauthenticated_admin_requests(
         self,

--- a/backend/ng/support/tests/test_support_api.py
+++ b/backend/ng/support/tests/test_support_api.py
@@ -221,7 +221,7 @@ class TestUserSupportEndpoints:
             else:
                 response = client.post(endpoint, json=json_data)
 
-            assert response.status_code in [302, 403]
+            assert response.status_code in [401,403]
 
 
 class TestAdminSupportEndpoints:

--- a/backend/ng/user/tests/test_user_api.py
+++ b/backend/ng/user/tests/test_user_api.py
@@ -93,9 +93,9 @@ def test_non_admin_endpoints(logged_in_client, user):
     Test that non-admins cannot access the admin users endpoint
     """
     response = logged_in_client.get("/ng/admin/users")
-    assert response.status_code == 302
+    assert response.status_code == 403
     response = logged_in_client.get(f"/ng/admin/users/{user.id}")
-    assert response.status_code == 302
+    assert response.status_code == 403
     response = logged_in_client.put(f"/ng/admin/users/{user.id}", json = {})
     assert response.status_code == 403
     response = logged_in_client.delete(
@@ -104,9 +104,9 @@ def test_non_admin_endpoints(logged_in_client, user):
     )
     assert response.status_code == 403
     response = logged_in_client.get(f"/ng/admin/users/{user.id}/events")
-    assert response.status_code == 302
+    assert response.status_code == 403
     response = logged_in_client.get(f"/ng/admin/users/{user.id}/teams")
-    assert response.status_code == 302
+    assert response.status_code == 403
 
 
 def test_admin_get_user_events(admin_client, user_factory, event_factory, team_factory):


### PR DESCRIPTION
Changes the behavior of several endpoints to be publicly accessible without authentication
Changes unauthed requests to 401 instead of redirect
adds an endpoint to get user permissions for an event

Fixes #177
