### PR TITLE
Time limit and Team update changes

### DIFF
--- a/backend/ng/event/models/Event.py
+++ b/backend/ng/event/models/Event.py
@@ -87,7 +87,7 @@ class Event(db.Model):
             "registration_start_date": self.registration_start_date.isoformat() + "Z" if self.registration_start_date else None,
             "registration_end_date": self.registration_end_date.isoformat() + "Z" if self.registration_end_date else None,
             "hints_enabled": self.hints_enabled,
-            "time_limit": self.time_limit_minutes,
+            "time_limit_minutes": self.time_limit_minutes,
         }
 
         return data
@@ -144,6 +144,18 @@ class Event(db.Model):
             data,
             "registration_open",
             friendly_name="Registration open status",
+        )
+        validator.validate_positive_integer(
+            data,
+            "time_limit_minutes",
+            required=False,
+            friendly_name="Time limit (minutes)",
+        )
+        validator.validate_boolean(
+            data,
+            "hints_enabled",
+            required=False,
+            friendly_name="Hints enabled",
         )
 
         return validator.validate()

--- a/backend/ng/event/routes/user_routes.py
+++ b/backend/ng/event/routes/user_routes.py
@@ -275,7 +275,7 @@ class EventTeamUpdateName(Resource):
                 400,
             )
 
-        team.update_name(new_name)
+        team.update_team(name = new_name)
         return success_response(team)
 
 

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -164,7 +164,7 @@ class Team(db.Model):
         try:
             Team.validate(data=cast(dict[str, Any], self.serialize(include_admin_fields=True)))
         except ValidationError as e:
-            raise ValidationError(f"Team validation failed: {e}")
+            raise ValidationError(f"Team validation failed: {e}") from e
 
     @classmethod
     def team_name_contains_member_name(cls, name, member_names) -> bool:
@@ -285,7 +285,7 @@ class Team(db.Model):
 
         # LAZY-IMPORT
         from ...scoring.models.Score import Score
-        
+
         if "name" in kwargs:
             Score.query.filter_by(team_id=self.id).update({"team_name": kwargs["name"]})
 

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -282,6 +282,9 @@ class Team(db.Model):
         """Update team attributes and persist to database."""
         for key, value in kwargs.items():
             setattr(self, key, value)
+        
+        if "name" in kwargs:
+            Score.query.filter_by(team_id=self.id).update({"team_name": kwargs["name"]})
 
         self.self_validate()
         db.session.commit()

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -282,6 +282,9 @@ class Team(db.Model):
         """Update team attributes and persist to database."""
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+        # LAZY-IMPORT
+        from ...scoring.models.Score import Score
         
         if "name" in kwargs:
             Score.query.filter_by(team_id=self.id).update({"team_name": kwargs["name"]})

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -142,8 +142,6 @@ class Team(db.Model):
                 required=False,
                 friendly_name="Invite code",
             )
-            if not Team.is_invite_code_unique(data["invite_code"]):
-                raise ValidationError(f"Invite code '{data['invite_code']}' already exists.")
 
         # Check if team name is unique within event
         if "name" in data and "event_id" in data:
@@ -166,7 +164,7 @@ class Team(db.Model):
         try:
             Team.validate(data=cast(dict[str, Any], self.serialize(include_admin_fields=True)))
         except ValidationError as e:
-            raise ValidationError(f"Team validation failed: {e.errors}") from e
+            raise ValidationError(f"Team validation failed: {e}")
 
     @classmethod
     def team_name_contains_member_name(cls, name, member_names) -> bool:
@@ -280,18 +278,14 @@ class Team(db.Model):
         if commit:
             db.session.commit()
 
-    def update_name(self, new_name: str, commit: bool = True) -> None:
-        """
-        Updates the team's name and synchronizes the cached name
-        """
-        # LAZY-IMPORT
-        from ...scoring.models.Score import Score
+    def update_team(self, **kwargs):
+        """Update team attributes and persist to database."""
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
-        self.name = new_name
-        Score.query.filter_by(team_id=self.id).update({"team_name": new_name})
-
-        if commit:
-            db.session.commit()
+        self.self_validate()
+        db.session.commit()
+        return self
 
     def add_member(self, user_id: int, role: TeamRole = TeamRole.MEMBER, commit=True):
         """Add a member to the team.

--- a/backend/ng/team/routes/admin_routes.py
+++ b/backend/ng/team/routes/admin_routes.py
@@ -93,17 +93,9 @@ class TeamDetail(Resource):
         """
         Update a team
         """
-        new_name = validated_data.get("name", team.name)
-        if Team.team_name_contains_member_name(
-                name = new_name,
-                member_names = [m.user.ctfd_user.name for m in team.members]):
-            return error_response(
-                "Team name cannot include a member's name.",
-                "validation",
-                400,
-            )
-
-        team.update_name(new_name)
+        if Team.team_name_contains_member_name(validated_data.get("name", team.name),[member.user.ctfd_user.name for member in team.members]):
+            return error_response("Team name cannot include a member's name.", "validation",400)
+        team.update_team(**validated_data)
         return success_response(team)
 
 

--- a/backend/ng/team/tests/test_admin_routes.py
+++ b/backend/ng/team/tests/test_admin_routes.py
@@ -43,6 +43,15 @@ def test_teamdetail_update_invalid_name(admin_client, event, team_factory, user)
     data = response.get_json()
     assert data['errors']['validation'] == "Team name cannot include a member's name."
 
+def test_update_team_ranked_status(admin_client, event, team_factory, user):
+    """Test that the team detail endpoint can update the ranked status of a team."""
+    team = team_factory(event=event, members=[user], ranked=False)
+    response = admin_client.put(f"/ng/admin/teams/{team.id}", json={"ranked": True})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['data']["ranked"] is True
+    assert data['success']
+
 def test_teammembers(admin_client, team_with_member):
     """Test that the team members endpoint returns the correct data."""
     team = team_with_member

--- a/backend/ng/team/tests/test_team_model.py
+++ b/backend/ng/team/tests/test_team_model.py
@@ -113,7 +113,7 @@ class Test_Update_Name:
         old_name = team.name
         new_name = "Updated Team Name"
 
-        team.update_name(new_name)
+        team.update_team(name=new_name)
 
         refreshed_team = Team.query.get(team.id)
 


### PR DESCRIPTION
Changes serialization to use time_limit_minutes
Updates the team update controller to support updating fields other than name
Adds time limit and hints enabled to `Event.validate`

Fixes #176