### PR TITLE
Pass None values through validator to allow clearing fields

### DIFF
--- a/backend/ng/challenge/tests/test_challenge_model.py
+++ b/backend/ng/challenge/tests/test_challenge_model.py
@@ -167,15 +167,15 @@ class TestChallengeValidation:
 
     def test_validate_optional_fields_missing_should_pass(self, event):
         """Test that validation passes when optional fields are missing."""
-        minimal_data = {"event_id": event.id, "name": "Minimal Challenge", "challenge_yaml": "Initial Fake Data"}
+        minimal_data = {"event_id": event.id, "name": "Minimal Challenge", "challenge_yaml": "Initial Fake Data", "description": None, "icon": None, "summary": None}
 
         validated_data = Challenge.validate(minimal_data)
 
         assert validated_data["event_id"] == event.id
         assert validated_data["name"] == "Minimal Challenge"
-        assert "description" not in validated_data
-        assert "icon" not in validated_data
-        assert "summary" not in validated_data
+        assert validated_data["description"] is None
+        assert validated_data["icon"] is None
+        assert validated_data["summary"] is None
 
     def test_validate_optional_fields_empty_should_pass(self, challenge_data):
         """Test that validation passes when optional fields are empty."""

--- a/backend/ng/core/tests/system/test_validate_model_id.py
+++ b/backend/ng/core/tests/system/test_validate_model_id.py
@@ -75,7 +75,7 @@ class TestValidateModelId:
         validator.validate_model_id(data, "challenge_id", "Challenge", required=False)
 
         assert "challenge_id" not in validator.errors
-        assert "challenge_id" not in validator.parsed_data
+        assert validator.parsed_data["challenge_id"] is None
 
     def test_validate_model_id_custom_friendly_name(self):
         """Test that custom friendly names are used in error messages."""

--- a/backend/ng/core/utils/validator.py
+++ b/backend/ng/core/utils/validator.py
@@ -43,6 +43,7 @@ def validation_field(func: Callable) -> Callable:
 
         # Early return for None values on non-required fields
         if value is None and not required:
+            self._add_parsed_data(field, None)
             return None
 
         # Call the original function with the processed parameters
@@ -388,8 +389,8 @@ class BaseValidator:
         Validates a start/end time window, ensuring both or neither are present
         and that start is before end.
         """
-        start_time = self.validate_datetime(data, start_field, required=False, allow_past=False)
-        end_time = self.validate_datetime(data, end_field, required=False, allow_past=False)
+        start_time = self.validate_datetime(data, start_field, required=False)
+        end_time = self.validate_datetime(data, end_field, required=False)
 
         has_start = start_field in data and data.get(start_field) is not None
         has_end = end_field in data and data.get(end_field) is not None

--- a/backend/ng/core/utils/validator.py
+++ b/backend/ng/core/utils/validator.py
@@ -43,7 +43,9 @@ def validation_field(func: Callable) -> Callable:
 
         # Early return for None values on non-required fields
         if value is None and not required:
-            self._add_parsed_data(field, None)
+            if field in data:
+                # if none is explicitly provided, pass it through
+                self._add_parsed_data(field, None)
             return None
 
         # Call the original function with the processed parameters


### PR DESCRIPTION
Resolves #179. `None` values passed for optional fields will be passed through the validator, allowing optional model fields to be cleared.

For this to happen, JSON input must include the fields with a value of `null` - fields omitted entirely won't be passed through as `None` due to how the update/validation logic is used in existing code. This kind of blurs the lines between `PUT` and `PATCH` semantics which feels a little weird, but with the way existing update/validation code works there's not much that can be done about that without significant refactoring.