### PR TITLE
Container management and challenge import fixes

### DIFF
--- a/backend/ng/challenge/models/Question.py
+++ b/backend/ng/challenge/models/Question.py
@@ -90,6 +90,7 @@ class Question(db.Model):
             validator.validate_model_id(
                 data,
                 "answer_variable_id",
+                "ChallengeVariable",
                 required=templated,
                 friendly_name="Answer Variable ID",
             )

--- a/backend/ng/containers/controllers/start_containers.py
+++ b/backend/ng/containers/controllers/start_containers.py
@@ -1,9 +1,10 @@
 from ...team.models.Team import Team
+from ...user.models.User import User
 from ..models.ContainerInstance import ContainerInstance
 from ..models.IndvidualContainer import IndvidualContainer
 from ...challenge.models.ContainerBlueprint import ContainerBlueprint
 
-def start_containers(challenge_id: int, team_id: int, current_user: int) -> bool:
+def start_containers(challenge_id: int, team_id: int, current_user: User) -> bool:
     blueprints = ContainerBlueprint.query.filter_by(challenge_id=challenge_id).all()
     team = Team.query.filter_by(id=team_id).first()
 

--- a/backend/ng/containers/models/ContainerInstance.py
+++ b/backend/ng/containers/models/ContainerInstance.py
@@ -186,7 +186,7 @@ class ContainerInstance(db.Model):
 
         instances = db.session.scalars(
             select(cls)
-            .where(cls.blueprint.in_(blueprint_ids), cls.team == team_id)
+            .where(cls.blueprint.in_(blueprint_ids), cls.team_id == team_id)
         ).all()
         return instances
 

--- a/backend/ng/containers/models/IndvidualContainer.py
+++ b/backend/ng/containers/models/IndvidualContainer.py
@@ -113,23 +113,27 @@ class IndvidualContainer(db.Model):
 
         return host_port
 
-    def get_current_challenge(self) -> int:
+    def get_current_challenge(self) -> int | None:
         client = get_client(self.hostip)
-        ctr_info = client.api.inspect_container(self.dockerid)
+        try:
+            ctr_info = client.api.inspect_container(self.dockerid)
+            current_challenge_network = None
 
-        current_challenge_network = None
+            networks = ctr_info["NetworkSettings"]["Networks"]
+            for network in networks:
+                if network != DOCKER_BRIDGE:
+                    current_challenge_network = network
 
-        networks = ctr_info["NetworkSettings"]["Networks"]
-        for network in networks:
-            if network != DOCKER_BRIDGE:
-                current_challenge_network = network
+            if not current_challenge_network:
+                return None
 
-        if not current_challenge_network:
+            parsed_network = ContainerInstance.parse_network_name(current_challenge_network)
+
+            return parsed_network["challenge_id"]
+
+        except docker.errors.NotFound:
+            # If the user workspace container doesn't exist, there is no current challenge
             return None
-
-        parsed_network = ContainerInstance.parse_network_name(current_challenge_network)
-
-        return parsed_network["challenge_id"]
 
     def restart(self):
         client = get_client(self.hostip)

--- a/backend/ng/containers/routes/admin_routes.py
+++ b/backend/ng/containers/routes/admin_routes.py
@@ -99,7 +99,7 @@ class InstanceRestart(Resource):
     )
     @admin_endpoint()
     @load_container_instance(source=LoaderType.PARAM)
-    def get(self, container_instance, container_instance_id, **kwargs):
+    def post(self, container_instance, **kwargs):
         container_instance.restart()
         return success_response(True)
 
@@ -117,7 +117,7 @@ class InstanceRecycle(Resource):
     )
     @admin_endpoint()
     @load_container_instance(source=LoaderType.PARAM)
-    def get(self, container_instance, **kwargs):
+    def post(self, container_instance, **kwargs):
         container_instance.recycle()
         return success_response(True)
 

--- a/frontend/src/hooks/container.ts
+++ b/frontend/src/hooks/container.ts
@@ -8,7 +8,7 @@ export function useCurrentChallengeId() {
 
 export function connectWorkspace(eventId: number, challengeId: number) {
   return apiMutation(`/events/${eventId}/challenge/${challengeId}/containers`, undefined, {
-    method : 'GET',
+    method : 'POST',
   }).then(() => {
     // refresh the current challenge ID after connecting workspace
     mutate('/container/me/current_challenge');
@@ -46,7 +46,7 @@ export function useProvisionerStats() {
 
 export function restartContainer(containerId: number) {
   return apiMutation(`/admin/container/${containerId}/restart`, undefined, {
-    method : 'GET',
+    method : 'POST',
   }).then(() => {
     mutate(`/admin/container/${containerId}/status`);
   });
@@ -54,7 +54,7 @@ export function restartContainer(containerId: number) {
 
 export function recycleContainer(containerId: number) {
   return apiMutation(`/admin/container/${containerId}/recycle`, undefined, {
-    method : 'GET',
+    method : 'POST',
   }).then(() => {
     mutate(`/admin/container/${containerId}/status`);
   });


### PR DESCRIPTION
- Add missing ChallengeVariable type string during question validation, resolves failing YAML imports
- Update admin-facing restart/recycle endpoints to POST for consistency with user-facing ones
- Update frontend container management hooks to use POST
- Fix missed refactor in `get_instance_group` that was causing exceptions
- Fix `start_containers` type signature
- Catch exception thrown when user workspace does not exist in `get_current_challenge`