### PR TITLE
fix notification reply/assigment logic

### DIFF
--- a/backend/ng/notifications/services/notification_service.py
+++ b/backend/ng/notifications/services/notification_service.py
@@ -134,25 +134,8 @@ class NotificationService:
         subject: str,
     ) -> None:
         """
-        Notify all support staff about a new support ticket with DB notifications
+        Notify all support staff about a new support ticket via refetch only
         """
-        support_users = get_support_role_users()
-
-        for support_user in support_users:
-            notification = Notification.create_notification(
-                notification_type = NotificationType.TICKET_CREATE,
-                title = "New Support Ticket",
-                message = f"New ticket created: {subject}",
-                recipient_id = support_user.ctfd_user.id,
-                sender_id = author_id,
-                ticket_id = ticket_id,
-                commit = False,
-            )
-
-            NotificationService._emit_notification(notification)
-
-        db.session.commit()
-
         NotificationService._emit_refetch(
             path = "/ng/support/tickets",
         )

--- a/backend/ng/notifications/services/notification_service.py
+++ b/backend/ng/notifications/services/notification_service.py
@@ -155,7 +155,6 @@ class NotificationService:
 
         NotificationService._emit_refetch(
             path = "/ng/support/tickets",
-            user_ids = None
         )
 
     @staticmethod
@@ -185,7 +184,6 @@ class NotificationService:
 
         NotificationService._emit_refetch(
             path = f"/ng/support/tickets/{ticket_id}",
-            user_ids = None
         )
 
     @staticmethod

--- a/backend/ng/notifications/services/notification_service.py
+++ b/backend/ng/notifications/services/notification_service.py
@@ -22,6 +22,7 @@ from ..models import (
     AnnouncementType,
 )
 from ...team.models import TeamMember
+from ...permissions.controllers import get_support_role_users
 
 
 class WebSocketEvent(str, Enum):
@@ -133,11 +134,58 @@ class NotificationService:
         subject: str,
     ) -> None:
         """
-        Notify admins about a new support ticket
+        Notify all support staff about a new support ticket with DB notifications
         """
+        support_users = get_support_role_users()
+
+        for support_user in support_users:
+            notification = Notification.create_notification(
+                notification_type = NotificationType.TICKET_CREATE,
+                title = "New Support Ticket",
+                message = f"New ticket created: {subject}",
+                recipient_id = support_user.ctfd_user.id,
+                sender_id = author_id,
+                ticket_id = ticket_id,
+                commit = False,
+            )
+
+            NotificationService._emit_notification(notification)
+
+        db.session.commit()
+
         NotificationService._emit_refetch(
             path = "/ng/support/tickets",
-            user_ids = None  # Via _emit_refetch fallback
+            user_ids = None
+        )
+
+    @staticmethod
+    def notify_unassigned_ticket_reply(
+        ticket_id: int,
+        author_id: int,
+    ) -> None:
+        """
+        Notify all support staff when user replies to unassigned ticket
+        """
+        support_users = get_support_role_users()
+
+        for support_user in support_users:
+            notification = Notification.create_notification(
+                notification_type = NotificationType.TICKET_MESSAGE,
+                title = "Support Ticket Update",
+                message = "User replied to unassigned ticket",
+                recipient_id = support_user.ctfd_user.id,
+                sender_id = author_id,
+                ticket_id = ticket_id,
+                commit = False,
+            )
+
+            NotificationService._emit_notification(notification)
+
+        db.session.commit()
+
+        NotificationService._emit_refetch(
+            path = f"/ng/support/tickets/{ticket_id}",
+            user_ids = None
         )
 
     @staticmethod

--- a/backend/ng/support/controllers/admin_actions/update_ticket_assignment.py
+++ b/backend/ng/support/controllers/admin_actions/update_ticket_assignment.py
@@ -5,6 +5,8 @@ Ticket assignment management (admin only).
 from ...models.Ticket import Ticket
 from ....user.models.User import User
 from ....notifications.services import NotificationService
+from ....permissions.controllers import get_support_role_users
+from ....core.exceptions import ValidationError
 
 
 def assign_ticket(
@@ -12,8 +14,17 @@ def assign_ticket(
     ticket: Ticket,
 ) -> Ticket:
     """
-    Assign a ticket to a user
+    Assign a ticket to a user (must have ADMIN or SUPPORT role)
     """
+    # Validate user has support role
+    support_users = get_support_role_users()
+    support_user_ids = [su.ctfd_user.id for su in support_users]
+
+    if user.id not in support_user_ids:
+        raise ValidationError(
+            "Tickets can only be assigned to users with ADMIN or SUPPORT roles"
+        )
+
     ticket.assign_to_user(user_id=user.id, commit=True)
 
     NotificationService.notify_ticket_assigned(

--- a/backend/ng/support/controllers/all_actions/create_ticket_message.py
+++ b/backend/ng/support/controllers/all_actions/create_ticket_message.py
@@ -4,7 +4,6 @@ Creates a new message in a support ticket thread.
 
 from ...models.Ticket import Ticket
 from ...models.TicketMessage import TicketMessage
-
 from ....notifications.services import NotificationService
 
 
@@ -30,19 +29,31 @@ def create_ticket_message(
     messages = ticket.get_messages()
     message = messages[-1]
 
-    if is_admin and ticket.author_id != author_id:
-        NotificationService.notify_ticket_reply(
-            ticket_id=ticket.id,
-            author_id=author_id,
-            recipient_id=ticket.author_id,
-            is_admin_reply=True,
-        )
-    elif not is_admin and ticket.assigned_to:
-        NotificationService.notify_ticket_reply(
-            ticket_id=ticket.id,
-            author_id=author_id,
-            recipient_id=ticket.assigned_to,
-            is_admin_reply=False,
-        )
+    if is_admin:
+        # Admin replying to user's ticket
+        if ticket.author_id != author_id:
+            # Notify the ticket author (user)
+            NotificationService.notify_ticket_reply(
+                ticket_id=ticket.id,
+                author_id=author_id,
+                recipient_id=ticket.author_id,
+                is_admin_reply=True,
+            )
+    else:
+        # User replying to ticket
+        if ticket.assigned_to:
+            # Ticket is assigned - notify only the assigned admin
+            NotificationService.notify_ticket_reply(
+                ticket_id=ticket.id,
+                author_id=author_id,
+                recipient_id=ticket.assigned_to,
+                is_admin_reply=False,
+            )
+        else:
+            # Ticket is unassigned - notify all support staff
+            NotificationService.notify_unassigned_ticket_reply(
+                ticket_id=ticket.id,
+                author_id=author_id,
+            )
 
     return message

--- a/backend/ng/support/controllers/all_actions/create_ticket_message.py
+++ b/backend/ng/support/controllers/all_actions/create_ticket_message.py
@@ -29,31 +29,33 @@ def create_ticket_message(
     messages = ticket.get_messages()
     message = messages[-1]
 
-    if is_admin:
-        # Admin replying to user's ticket
-        if ticket.author_id != author_id:
-            # Notify the ticket author (user)
-            NotificationService.notify_ticket_reply(
-                ticket_id=ticket.id,
-                author_id=author_id,
-                recipient_id=ticket.author_id,
-                is_admin_reply=True,
-            )
-    else:
-        # User replying to ticket
-        if ticket.assigned_to:
-            # Ticket is assigned - notify only the assigned admin
-            NotificationService.notify_ticket_reply(
-                ticket_id=ticket.id,
-                author_id=author_id,
-                recipient_id=ticket.assigned_to,
-                is_admin_reply=False,
-            )
+    # Skip notifications if ticket is muted
+    if not ticket.muted:
+        if is_admin:
+            # Admin replying to user's ticket
+            if ticket.author_id != author_id:
+                # Notify the ticket author (user)
+                NotificationService.notify_ticket_reply(
+                    ticket_id=ticket.id,
+                    author_id=author_id,
+                    recipient_id=ticket.author_id,
+                    is_admin_reply=True,
+                )
         else:
-            # Ticket is unassigned - notify all support staff
-            NotificationService.notify_unassigned_ticket_reply(
-                ticket_id=ticket.id,
-                author_id=author_id,
-            )
+            # User replying to ticket
+            if ticket.assigned_to:
+                # Ticket is assigned - notify only the assigned admin
+                NotificationService.notify_ticket_reply(
+                    ticket_id=ticket.id,
+                    author_id=author_id,
+                    recipient_id=ticket.assigned_to,
+                    is_admin_reply=False,
+                )
+            else:
+                # Ticket is unassigned - notify all support staff
+                NotificationService.notify_unassigned_ticket_reply(
+                    ticket_id=ticket.id,
+                    author_id=author_id,
+                )
 
     return message

--- a/backend/ng/support/tests/test_support_api.py
+++ b/backend/ng/support/tests/test_support_api.py
@@ -425,6 +425,23 @@ class TestAdminSupportEndpoints:
         assert data["success"] is True
         assert data["data"]["assigned_to"] == admin.id
 
+    def test_assign_ticket_to_non_support_user_fails(self, admin_client, ticket, user, db_session):
+        """
+        Test that assigning a ticket to a non-support user fails with validation error
+        """
+        # Try to assign ticket to regular user (not admin/support)
+        response = admin_client.put(
+            f"/ng/admin/support/tickets/{ticket.id}/assign",
+            json={"user_id": user.id},
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["success"] is False
+        # Check error message in response
+        response_str = str(data)
+        assert "ADMIN" in response_str or "SUPPORT" in response_str or "role" in response_str.lower()
+
     def test_unassign_ticket(self, admin_client, assigned_ticket):
         """Test unassigning ticket"""
         response = admin_client.put(
@@ -715,6 +732,7 @@ class TestAdminSupportEndpoints:
         assert response.status_code == 201
 
         # Check that assigned admin got notification
+        # NOTE: ONLY SUPPORT admins can be assigned in the first place
         admin_notifications = Notification.query.filter_by(
             recipient_id=admin.id,
             ticket_id=assigned_ticket.id,
@@ -797,8 +815,6 @@ class TestAdminSupportEndpoints:
         Test that when a ticket IS assigned, user replies only notify
         the ASSIGNED admin, NOT all admins
         """
-        from CTFd.models import Users
-
         # Create second admin
         admin2_ctfd = Users(name="admin2", email="admin2@example.com", password="password", type="admin")
         admin2_ctfd.verified = True
@@ -838,6 +854,39 @@ class TestAdminSupportEndpoints:
             Notification.type == "ticket_message"
         ).all()
         assert len(admin2_notifications) == 0  # Should be ZERO!
+
+    def test_muted_ticket_does_not_send_notifications(
+        self,
+        logged_in_client,
+        user,
+        admin,
+        ticket,
+        db_session,
+    ):
+        """
+        Test that muted tickets do NOT send notifications when users reply
+        """
+        # Mute the ticket
+        ticket.toggle_mute(True)
+        db_session.commit()
+
+        # User replies to muted ticket
+        response = logged_in_client.post(
+            f"/ng/support/me/tickets/{ticket.id}/add_message",
+            json={"text": "Hello? Anyone there?"},
+        )
+
+        assert response.status_code == 201
+
+        # Check that NO notifications were created
+        admin_notifications = Notification.query.filter_by(
+            recipient_id=admin.id,
+            ticket_id=ticket.id,
+        ).filter(
+            Notification.type == "ticket_message"
+        ).all()
+
+        assert len(admin_notifications) == 0  # No notifications
 
     def test_admin_assigns_self_then_replies_user_gets_notification(
         self,

--- a/backend/ng/support/tests/test_support_api.py
+++ b/backend/ng/support/tests/test_support_api.py
@@ -734,65 +734,6 @@ class TestAdminSupportEndpoints:
         assert notification.type.value == "ticket_message"
         assert notification.sender_id == user.id
 
-    def test_user_replies_to_unassigned_ticket_all_support_staff_get_notification(
-        self,
-        logged_in_client,
-        user,
-        admin,
-        ticket,
-        db_session,
-    ):
-        """
-        Test that when a user replies to an UNASSIGNED ticket,
-        ALL support staff (ADMIN + SUPPORT roles) receive notifications
-        """
-        Role.create_role(RoleEnum.SUPPORT)
-
-        support_user_ctfd = Users(name="supportuser2", email="support2@example.com", password="password")
-        support_user_ctfd.verified = True
-        db_session.add(support_user_ctfd)
-        db_session.flush()
-
-        NgUser.create_user(user_id=support_user_ctfd.id, commit=False)
-        assign_role_to_user(support_user_ctfd.id, RoleEnum.SUPPORT)
-        db_session.flush()
-
-        # Ensure ticket is not assigned
-        assert ticket.assigned_to is None
-
-        # User replies to unassigned ticket
-        response = logged_in_client.post(
-            f"/ng/support/me/tickets/{ticket.id}/add_message",
-            json={"text": "Is anyone there?"},
-        )
-
-        assert response.status_code == 201
-
-        # Check that ADMIN got notification
-        admin_notifications = Notification.query.filter_by(
-            recipient_id=admin.id,
-            ticket_id=ticket.id,
-            sender_id=user.id
-        ).all()
-
-        assert len(admin_notifications) >= 1
-        notification = admin_notifications[-1]
-        assert notification.type.value == "ticket_message"
-        assert notification.title == "Support Ticket Update"
-        assert "unassigned" in notification.message.lower()
-
-        # Check that SUPPORT role user also got notification
-        support_notifications = Notification.query.filter_by(
-            recipient_id=support_user_ctfd.id,
-            ticket_id=ticket.id,
-            sender_id=user.id
-        ).all()
-
-        assert len(support_notifications) >= 1
-        support_notification = support_notifications[-1]
-        assert support_notification.type.value == "ticket_message"
-        assert support_notification.title == "Support Ticket Update"
-
     def test_assigned_ticket_only_notifies_assigned_admin_not_all(
         self,
         logged_in_client,

--- a/backend/ng/support/tests/test_support_api.py
+++ b/backend/ng/support/tests/test_support_api.py
@@ -6,6 +6,14 @@ import json
 import pytest
 from datetime import datetime
 
+from CTFd.models import Users
+
+from ...permissions.models.Role import Role
+from ...user.models.User import User as NgUser
+from ...notifications.models import Notification
+from ...permissions.models.enums import RoleEnum
+from ...permissions.controllers import assign_role_to_user
+
 
 class TestUserSupportEndpoints:
     """Tests for user support API endpoints"""
@@ -594,6 +602,322 @@ class TestAdminSupportEndpoints:
         assert ticket["event_name"] == event.name
         assert ticket["team_id"] == team.id
         assert ticket["team_name"] == team.name
+
+    def test_user_creates_ticket_support_staff_get_notification(
+        self,
+        logged_in_client,
+        user,
+        admin,
+        db_session,
+    ):
+        """
+        Test that when a user creates a ticket, ALL support staff (ADMIN + SUPPORT roles) receive DB notifications
+        """
+        Role.create_role(RoleEnum.SUPPORT)
+
+        # Create a SUPPORT role user to test both roles get notifications
+        support_user_ctfd = Users(name="supportuser", email="support@example.com", password="password")
+        support_user_ctfd.verified = True
+        db_session.add(support_user_ctfd)
+        db_session.flush()
+
+        NgUser.create_user(user_id=support_user_ctfd.id, commit=False)
+        assign_role_to_user(support_user_ctfd.id, RoleEnum.SUPPORT)
+        db_session.flush()
+
+        # Create ticket
+        response = logged_in_client.post(
+            "/ng/support/tickets/create",
+            json={
+                "subject": "Need help with login",
+                "text": "I can't log in",
+            },
+        )
+
+        assert response.status_code == 201
+        ticket_id = response.get_json()["data"]["id"]
+
+        # Check that ADMIN got notification
+        admin_notifications = Notification.query.filter_by(
+            recipient_id=admin.id,
+            ticket_id=ticket_id
+        ).all()
+
+        assert len(admin_notifications) == 1
+        notification = admin_notifications[0]
+        assert notification.type.value == "ticket_create"
+        assert notification.title == "New Support Ticket"
+        assert "Need help with login" in notification.message
+        assert notification.sender_id == user.id
+
+        # Check that SUPPORT role user also got notification
+        support_notifications = Notification.query.filter_by(
+            recipient_id=support_user_ctfd.id,
+            ticket_id=ticket_id
+        ).all()
+
+        assert len(support_notifications) == 1
+        support_notification = support_notifications[0]
+        assert support_notification.type.value == "ticket_create"
+        assert support_notification.title == "New Support Ticket"
+
+    def test_admin_replies_without_assignment_user_gets_notification(
+        self,
+        admin_client,
+        user,
+        admin,
+        ticket,
+        db_session,
+    ):
+        """
+        Test that when an admin replies to a ticket WITHOUT being assigned,
+        the user still receives a notification
+        """
+        # Admin replies without being assigned
+        response = admin_client.post(
+            f"/ng/admin/support/tickets/{ticket.id}/add_message",
+            json={"text": "I can help you with this"},
+        )
+
+        assert response.status_code == 201
+
+        # Check that user got notification
+        user_notifications = Notification.query.filter_by(
+            recipient_id=user.id,
+            ticket_id=ticket.id,
+            sender_id=admin.id
+        ).all()
+
+        assert len(user_notifications) >= 1
+        notification = user_notifications[-1]  # Get most recent
+        assert notification.type.value == "ticket_message"
+        assert notification.title == "Support Ticket Update"
+        assert "replied" in notification.message.lower()
+
+    def test_user_replies_to_assigned_ticket_admin_gets_notification(
+        self,
+        logged_in_client,
+        user,
+        admin,
+        assigned_ticket,
+        db_session,
+    ):
+        """
+        Test that when a user replies to an assigned ticket,
+        the assigned admin receives a notification
+        """
+        # User replies to assigned ticket
+        response = logged_in_client.post(
+            f"/ng/support/me/tickets/{assigned_ticket.id}/add_message",
+            json={"text": "Thanks for the help!"},
+        )
+
+        assert response.status_code == 201
+
+        # Check that assigned admin got notification
+        admin_notifications = Notification.query.filter_by(
+            recipient_id=admin.id,
+            ticket_id=assigned_ticket.id,
+            sender_id=user.id
+        ).all()
+
+        assert len(admin_notifications) >= 1
+        notification = admin_notifications[-1]
+        assert notification.type.value == "ticket_message"
+        assert notification.sender_id == user.id
+
+    def test_user_replies_to_unassigned_ticket_all_support_staff_get_notification(
+        self,
+        logged_in_client,
+        user,
+        admin,
+        ticket,
+        db_session,
+    ):
+        """
+        Test that when a user replies to an UNASSIGNED ticket,
+        ALL support staff (ADMIN + SUPPORT roles) receive notifications
+        """
+        Role.create_role(RoleEnum.SUPPORT)
+
+        support_user_ctfd = Users(name="supportuser2", email="support2@example.com", password="password")
+        support_user_ctfd.verified = True
+        db_session.add(support_user_ctfd)
+        db_session.flush()
+
+        NgUser.create_user(user_id=support_user_ctfd.id, commit=False)
+        assign_role_to_user(support_user_ctfd.id, RoleEnum.SUPPORT)
+        db_session.flush()
+
+        # Ensure ticket is not assigned
+        assert ticket.assigned_to is None
+
+        # User replies to unassigned ticket
+        response = logged_in_client.post(
+            f"/ng/support/me/tickets/{ticket.id}/add_message",
+            json={"text": "Is anyone there?"},
+        )
+
+        assert response.status_code == 201
+
+        # Check that ADMIN got notification
+        admin_notifications = Notification.query.filter_by(
+            recipient_id=admin.id,
+            ticket_id=ticket.id,
+            sender_id=user.id
+        ).all()
+
+        assert len(admin_notifications) >= 1
+        notification = admin_notifications[-1]
+        assert notification.type.value == "ticket_message"
+        assert notification.title == "Support Ticket Update"
+        assert "unassigned" in notification.message.lower()
+
+        # Check that SUPPORT role user also got notification
+        support_notifications = Notification.query.filter_by(
+            recipient_id=support_user_ctfd.id,
+            ticket_id=ticket.id,
+            sender_id=user.id
+        ).all()
+
+        assert len(support_notifications) >= 1
+        support_notification = support_notifications[-1]
+        assert support_notification.type.value == "ticket_message"
+        assert support_notification.title == "Support Ticket Update"
+
+    def test_assigned_ticket_only_notifies_assigned_admin_not_all(
+        self,
+        logged_in_client,
+        user,
+        admin,
+        ticket,
+        db_session,
+    ):
+        """
+        Test that when a ticket IS assigned, user replies only notify
+        the ASSIGNED admin, NOT all admins
+        """
+        from CTFd.models import Users
+
+        # Create second admin
+        admin2_ctfd = Users(name="admin2", email="admin2@example.com", password="password", type="admin")
+        admin2_ctfd.verified = True
+        db_session.add(admin2_ctfd)
+        db_session.flush()
+
+        NgUser.create_user(user_id=admin2_ctfd.id, commit=False)
+        assign_role_to_user(admin2_ctfd.id, RoleEnum.ADMIN)
+        db_session.flush()
+
+        # Assign ticket to admin (not admin2)
+        ticket.assign_to_user(admin.id)
+        db_session.commit()
+
+        # User replies to assigned ticket
+        response = logged_in_client.post(
+            f"/ng/support/me/tickets/{ticket.id}/add_message",
+            json={"text": "Thanks for helping!"},
+        )
+
+        assert response.status_code == 201
+
+        # Check that ASSIGNED admin got notification
+        admin_notifications = Notification.query.filter_by(
+            recipient_id=admin.id,
+            ticket_id=ticket.id,
+        ).filter(
+            Notification.type == "ticket_message"
+        ).all()
+        assert len(admin_notifications) >= 1
+
+        # Check that OTHER admin did NOT get notification
+        admin2_notifications = Notification.query.filter_by(
+            recipient_id=admin2_ctfd.id,
+            ticket_id=ticket.id,
+        ).filter(
+            Notification.type == "ticket_message"
+        ).all()
+        assert len(admin2_notifications) == 0  # Should be ZERO!
+
+    def test_admin_assigns_self_then_replies_user_gets_notification(
+        self,
+        admin_client,
+        user,
+        admin,
+        ticket,
+        db_session,
+    ):
+        """
+        Test the full flow: admin assigns ticket to themselves, then replies
+        """
+        # Admin assigns ticket to themselves
+        assign_response = admin_client.put(
+            f"/ng/admin/support/tickets/{ticket.id}/assign",
+            json={"user_id": admin.id},
+        )
+        assert assign_response.status_code == 200
+
+        # Check admin got assignment notification
+        assignment_notifications = Notification.query.filter_by(
+            recipient_id=admin.id,
+            ticket_id=ticket.id,
+        ).filter(
+            Notification.type == "ticket_assigned"
+        ).all()
+        assert len(assignment_notifications) == 1
+
+        # Admin replies to ticket
+        reply_response = admin_client.post(
+            f"/ng/admin/support/tickets/{ticket.id}/add_message",
+            json={"text": "I've been assigned and I'm here to help"},
+        )
+        assert reply_response.status_code == 201
+
+        # Check that user got reply notification
+        reply_notifications = Notification.query.filter_by(
+            recipient_id=user.id,
+            ticket_id=ticket.id,
+            sender_id=admin.id
+        ).filter(
+            Notification.type == "ticket_message"
+        ).all()
+
+        assert len(reply_notifications) >= 1
+        notification = reply_notifications[-1]
+        assert "replied" in notification.message.lower()
+
+    def test_admin_closes_ticket_user_gets_notification(
+        self,
+        admin_client,
+        user,
+        admin,
+        ticket,
+        db_session,
+    ):
+        """
+        Test that when an admin closes a ticket, the user receives a notification
+        """
+        # Admin closes ticket
+        response = admin_client.put(
+            f"/ng/admin/support/tickets/{ticket.id}/close",
+            json={"closed": True},
+        )
+
+        assert response.status_code == 200
+
+        # Check that user got notification
+        user_notifications = Notification.query.filter_by(
+            recipient_id=user.id,
+            ticket_id=ticket.id,
+        ).filter(
+            Notification.type == "ticket_status_change"
+        ).all()
+
+        assert len(user_notifications) >= 1
+        notification = user_notifications[-1]
+        assert notification.title == "Ticket Status Changed"
+        assert "closed" in notification.message.lower()
+        assert notification.sender_id == admin.id
 
     def test_ticket_list_without_challenge(self, logged_in_client, user, event, team_factory):
         """

--- a/backend/ng/support/tests/test_support_api.py
+++ b/backend/ng/support/tests/test_support_api.py
@@ -620,7 +620,7 @@ class TestAdminSupportEndpoints:
         assert ticket["team_id"] == team.id
         assert ticket["team_name"] == team.name
 
-    def test_user_creates_ticket_support_staff_get_notification(
+    def test_user_creates_ticket_support_staff_do_not_get_notification(
         self,
         logged_in_client,
         user,
@@ -628,11 +628,11 @@ class TestAdminSupportEndpoints:
         db_session,
     ):
         """
-        Test that when a user creates a ticket, ALL support staff (ADMIN + SUPPORT roles) receive DB notifications
+        Test that when a user creates a ticket, support staff do not receive DB notifications
+        (only WebSocket refetch events are sent)
         """
         Role.create_role(RoleEnum.SUPPORT)
 
-        # Create a SUPPORT role user to test both roles get notifications
         support_user_ctfd = Users(name="supportuser", email="support@example.com", password="password")
         support_user_ctfd.verified = True
         db_session.add(support_user_ctfd)
@@ -654,29 +654,19 @@ class TestAdminSupportEndpoints:
         assert response.status_code == 201
         ticket_id = response.get_json()["data"]["id"]
 
-        # Check that ADMIN got notification
         admin_notifications = Notification.query.filter_by(
             recipient_id=admin.id,
             ticket_id=ticket_id
         ).all()
 
-        assert len(admin_notifications) == 1
-        notification = admin_notifications[0]
-        assert notification.type.value == "ticket_create"
-        assert notification.title == "New Support Ticket"
-        assert "Need help with login" in notification.message
-        assert notification.sender_id == user.id
+        assert len(admin_notifications) == 0
 
-        # Check that SUPPORT role user also got notification
         support_notifications = Notification.query.filter_by(
             recipient_id=support_user_ctfd.id,
             ticket_id=ticket_id
         ).all()
 
-        assert len(support_notifications) == 1
-        support_notification = support_notifications[0]
-        assert support_notification.type.value == "ticket_create"
-        assert support_notification.title == "New Support Ticket"
+        assert len(support_notifications) == 0
 
     def test_admin_replies_without_assignment_user_gets_notification(
         self,


### PR DESCRIPTION
- If user creates a ticket (which is always going to be unnasigned initially) - then notify all *support* admins there is a new ticket
- Admin replies to that ticket while being unnasigned - user still gets a notification
***(Or if admin is assigned and replies - user still also gets a notification)***
- User then replies to that same ticket with an unnasigned admin - all *support* admins get notification (because its still unassigned) - (OR if admin IS assigned then only THAT admin gets a notification of user reply)
***NOTE: (PR: https://github.com/CyberSkyline/ctf-ng/pull/208 adds the functionality to where when an admin replies to a ticket while being unnasigned - that admin automatically gets assigned to that ticket (for now thats not the case due to it being tied to the email service which is not on this branch - therefore - for now, all admins get notified until an admin is assigned)***


