### PR TITLE
Use react-hook-form in modals

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -29,6 +29,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars' : [ 'error' ], // Enable the TypeScript version of the rule
     'react/prop-types' : 'off', // Disable prop-types check since TypeScript already handles types
     'react/react-in-jsx-scope' : 'off', // React 17+ doesn't require `import React` in every file
+    'react/jsx-props-no-spreading' : 'off', // Allow prop spreading - react-hook-form relies on this (but make sure it's used responsibly elsewhere)
     'import/extensions' : [
       'error',
       'ignorePackages',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.3.8",
+    "react-hook-form": "^7.63.0",
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-router": "^7.6.3",

--- a/frontend/src/components/FormField.tsx
+++ b/frontend/src/components/FormField.tsx
@@ -1,0 +1,30 @@
+import { COLOR_NEGATIVE } from '@/constants';
+import { Flex, Text } from '@radix-ui/themes';
+import { useId } from 'react';
+import type { FieldError } from 'react-hook-form';
+
+export default function FormField({
+  children,
+  label,
+  error,
+}: {
+  children: (injected: { id: string; 'aria-describedby'?: string; 'aria-invalid': 'true' | 'false' }) => React.ReactNode,
+  label: string,
+  error?: FieldError,
+}) {
+  const id = useId(); // Unique ID for accessibility linking
+
+  const injected = {
+    id,
+    'aria-errormessage' : error ? `${id}-error` : undefined,
+    'aria-invalid' : (error ? 'true' : 'false') as 'true' | 'false',
+  };
+
+  return (
+    <Flex direction="column" gap="1">
+      <label htmlFor={id} data-invalid={error ? 'true' : 'false'}>{label}</label>
+      {children(injected)}
+      {error && <Text as="span" color={COLOR_NEGATIVE} id={`${id}-error`} aria-live="polite" aria-atomic>{error.message || 'Invalid input'}</Text>}
+    </Flex>
+  );
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -5,7 +5,6 @@ import {
   Dialog,
   Flex,
 } from '@radix-ui/themes';
-import { isEmpty } from 'lodash';
 import { useEffect, useState, type ReactNode } from 'react';
 import {
   useForm,
@@ -30,7 +29,6 @@ interface ModalProps<T extends FieldValues> {
   submitVerb?: string,
   submitColor?: AccentColor,
   submitDisabled?: boolean,
-  requireTouchingForm?: boolean,
 }
 
 export default function Modal<T extends FieldValues>({
@@ -137,9 +135,7 @@ export default function Modal<T extends FieldValues>({
               variant={onSubmit ? 'solid' : 'soft'}
               loading={loading}
               disabled={
-                loading
-                || submitDisabled
-                || (Object.keys(rhf.getValues()).length > 0 && isEmpty(rhf.formState.dirtyFields))
+                loading || submitDisabled
               }
             >
               {onSubmit ? submitVerb : 'Close'}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -5,19 +5,26 @@ import {
   Dialog,
   Flex,
 } from '@radix-ui/themes';
-import { Form } from 'radix-ui';
+import { isEmpty } from 'lodash';
 import { useEffect, useState, type ReactNode } from 'react';
+import {
+  useForm,
+  type DefaultValues,
+  type FieldValues,
+  type UseFormReturn,
+} from 'react-hook-form';
 import { TbX } from 'react-icons/tb';
 import { twMerge } from 'tailwind-merge';
 import { ErrorCallout } from './Callouts';
 
-interface ModalProps {
+interface ModalProps<T extends FieldValues> {
   title: string,
   description?: string,
-  children?: ReactNode,
+  children?: ReactNode | ((rhf: UseFormReturn<T>) => ReactNode),
   trigger: ReactNode,
   className?: string,
-  onSubmit?: (formData: FormData) => Promise<unknown>,
+  defaultValues?: DefaultValues<T>,
+  onSubmit?: (data: T) => Promise<unknown>,
   onOpenChange?: (open: boolean) => void,
   defaultOpen?: boolean,
   submitVerb?: string,
@@ -26,31 +33,37 @@ interface ModalProps {
   requireTouchingForm?: boolean,
 }
 
-export default function Modal({
+export default function Modal<T extends FieldValues>({
   title,
   description,
   children,
   trigger,
   className,
+  defaultValues,
   onSubmit,
   onOpenChange,
   defaultOpen = false,
   submitVerb = 'Submit',
   submitColor = COLOR_POSITIVE,
   submitDisabled = false,
-  requireTouchingForm = false,
-} : ModalProps) {
+} : ModalProps<T>) {
   const [ open, setOpen ] = useState<boolean>(defaultOpen);
   const [ error, setError ] = useState<string | null>(null);
   const [ loading, setLoading ] = useState<boolean>(false);
-  const [ formTouched, setFormTouched ] = useState<boolean>(false);
+
+  const rhf = useForm<T>({
+    mode : 'onBlur',
+    defaultValues,
+  });
 
   useEffect(() => {
-    if (!open) {
-      // reset state when modal closes
-      setFormTouched(false);
+    if (open) {
+      // reset state when modal opens
       setError(null);
+      setLoading(false);
+      rhf.reset(defaultValues);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ open ]);
 
   return (
@@ -94,19 +107,16 @@ export default function Modal({
             {error}
           </ErrorCallout>
         )}
-        <Form.Root
-          className="flex flex-col gap-3"
-          onSubmitCapture={(e) => {
-            e.preventDefault();
 
+        <form
+          className="flex flex-col gap-3"
+          onSubmit={rhf.handleSubmit((data) => {
             if (onSubmit) {
-              const formData = new FormData(e.currentTarget);
               setLoading(true);
-              onSubmit(formData)
-                .then(() => {
-                  // if promise resolves, close the modal
-                  setOpen(false);
-                })
+              onSubmit(data).then(() => {
+                // if promise resolves, close the modal
+                setOpen(false);
+              })
                 .catch((err) => {
                   // if promise rejects, set the error message
                   setError(err.message);
@@ -117,24 +127,23 @@ export default function Modal({
               // if no submit handler is defined, just close the modal
               setOpen(false);
             }
-          }}
-          onChange={() => {
-            setFormTouched(true);
-          }}
+          })}
         >
-          {children}
+          {typeof children === 'function' ? children(rhf) : children}
           <Flex direction="row-reverse" justify="start" align="center" gap="2">
-            <Form.Submit asChild>
-              <Button
-                type="submit"
-                color={onSubmit ? submitColor : 'gray'}
-                variant={onSubmit ? 'solid' : 'soft'}
-                loading={loading}
-                disabled={loading || submitDisabled || (requireTouchingForm && !formTouched)}
-              >
-                {onSubmit ? submitVerb : 'Close'}
-              </Button>
-            </Form.Submit>
+            <Button
+              type="submit"
+              color={onSubmit ? submitColor : 'gray'}
+              variant={onSubmit ? 'solid' : 'soft'}
+              loading={loading}
+              disabled={
+                loading
+                || submitDisabled
+                || (Object.keys(rhf.getValues()).length > 0 && isEmpty(rhf.formState.dirtyFields))
+              }
+            >
+              {onSubmit ? submitVerb : 'Close'}
+            </Button>
             {onSubmit && (
               <Dialog.Close>
                 <Button type="button" variant="soft" color="gray">
@@ -143,7 +152,7 @@ export default function Modal({
               </Dialog.Close>
             )}
           </Flex>
-        </Form.Root>
+        </form>
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -74,7 +74,6 @@ export default function Modal<T extends FieldValues>({
         className={twMerge('flex flex-col gap-3', className)}
         // aria-describedby should be set to undefined if no description is provided, otherwise it should not be set at all.
         // as far as i know, prop spreading is the only way to accomplish this.
-        // eslint-disable-next-line react/jsx-props-no-spreading
         {
           ...(!description ? { 'aria-describedby' : undefined } : {})
         }

--- a/frontend/src/components/RadixMarkdown.tsx
+++ b/frontend/src/components/RadixMarkdown.tsx
@@ -9,14 +9,13 @@ import {
   Text,
 } from '@radix-ui/themes';
 import ReactMarkdown, { type Components } from 'react-markdown';
-import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 
 /**
  * Mapping of html elements to their themed Radix UI counterparts to use when rendering markdown.
  */
 const Components: Components = {
-  p : ({ children }) => <Text as="p" color="gray" className="mb-2 last:mb-0">{children}</Text>,
+  p : ({ children }) => <Text as="p" color="gray" className="!mb-2 last:!mb-0">{children}</Text>,
   em : ({ children }) => <Em>{children}</Em>,
   strong : ({ children }) => <Strong>{children}</Strong>,
   code : ({ children }) => <Code color="gray">{children}</Code>,
@@ -31,7 +30,7 @@ const Components: Components = {
   h6 : ({ children }) => <Heading size="3" as="h6">{children}</Heading>,
   ul : ({ children }) => <ul className="list-disc list-inside mb-2 ms-2">{children}</ul>,
   ol : ({ children }) => <ol className="list-decimal list-inside mb-2 ms-2">{children}</ol>,
-  li : ({ children }) => <Text asChild color="gray" mb="1"><li>{children}</li></Text>,
+  li : ({ children }) => <Text asChild color="gray" mb="1"><li className="*:inline">{children}</li></Text>,
   table : ({ children }) => <Table.Root className="w-fit max-w-full mb-2">{children}</Table.Root>,
   thead : ({ children }) => <Table.Header>{children}</Table.Header>,
   tbody : ({ children }) => <Table.Body>{children}</Table.Body>,
@@ -47,7 +46,7 @@ export default function RadixMarkdown({ children }: {
   children: string;
 }) {
   return (
-    <ReactMarkdown components={Components} remarkPlugins={[ remarkGfm, remarkBreaks ]}>
+    <ReactMarkdown components={Components} remarkPlugins={[ remarkGfm ]}>
       {children}
     </ReactMarkdown>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,17 +31,12 @@ form label {
 }
 
 form label[data-invalid="true"] {
-  @apply text-(--accent-11);
-}
-
-/* Validation messages should be block so they stack vertically */
-form div span[id^=radix-] {
-  @apply text-(--accent-11) block;
+  @apply text-(--red-11);
 }
 
 /* Give invalid form elements a red accent color */
 /* Effectively sets their color prop to red. */
-[data-invalid="true"] {
+[aria-invalid="true"] {
   --accent-1: var(--red-1);
   --accent-2: var(--red-2);
   --accent-3: var(--red-3);
@@ -96,7 +91,7 @@ form div span[id^=radix-] {
   --focus-a12: var(--accent-a12);
 }
 
-[data-invalid="true"] .rt-TextFieldRoot {
+[aria-invalid="true"] {
   @apply !ring !ring-(--accent-7);
 }
 

--- a/frontend/src/routes/admin/events/ChallengeUploadModal.tsx
+++ b/frontend/src/routes/admin/events/ChallengeUploadModal.tsx
@@ -57,13 +57,11 @@ export default function ChallengeUploadModal({ eventId }: { eventId: number }) {
       >
         {({ getRootProps, getInputProps, isDragActive }) => (
           <Callout.Root
-            // eslint-disable-next-line react/jsx-props-no-spreading
             {...getRootProps()}
             variant={(isDragActive) ? 'surface' : 'outline'}
             className="cursor-pointer !p-8 !flex flex-col !items-center"
           >
             <input
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...getInputProps()}
               name="file"
             />

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -22,11 +22,9 @@ export default function EventDataForm({
         {(injected) => (
           <TextField.Root
             placeholder="Event Name"
-            // eslint-disable-next-line react/jsx-props-no-spreading
             {...register('name', {
               required : 'Event name is required',
             })}
-            // eslint-disable-next-line react/jsx-props-no-spreading
             {...injected}
           />
         )}
@@ -38,9 +36,7 @@ export default function EventDataForm({
             placeholder="Event Description"
             rows={4}
             resize="vertical"
-            // eslint-disable-next-line react/jsx-props-no-spreading
             {...register('description')}
-            // eslint-disable-next-line react/jsx-props-no-spreading
             {...injected}
           />
         )}
@@ -65,7 +61,6 @@ export default function EventDataForm({
                     name={field.name}
                     ref={field.ref}
                     size="3"
-                    // eslint-disable-next-line react/jsx-props-no-spreading
                     {...injected}
                   />
                 </Box>
@@ -91,7 +86,6 @@ export default function EventDataForm({
                     name={field.name}
                     ref={field.ref}
                     size="3"
-                    // eslint-disable-next-line react/jsx-props-no-spreading
                     {...injected}
                   />
                 </Box>
@@ -117,7 +111,6 @@ export default function EventDataForm({
                     name={field.name}
                     ref={field.ref}
                     size="3"
-                    // eslint-disable-next-line react/jsx-props-no-spreading
                     {...injected}
                   />
                 </Box>
@@ -133,7 +126,6 @@ export default function EventDataForm({
           {(injected) => (
             <TextField.Root
               type="number"
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...register('max_team_size', {
                 required : 'Max team size is required',
                 valueAsNumber : true,
@@ -146,7 +138,6 @@ export default function EventDataForm({
                   message : 'Max team size cannot exceed 8',
                 },
               })}
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...injected}
             />
           )}
@@ -158,7 +149,6 @@ export default function EventDataForm({
               type="number"
               placeholder="No time limit"
               step={1}
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...register('time_limit_minutes', {
                 valueAsNumber : true,
                 min : {
@@ -166,7 +156,6 @@ export default function EventDataForm({
                   message : 'Time limit must be at least 1 minute',
                 },
               })}
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...injected}
             />
           )}
@@ -178,11 +167,9 @@ export default function EventDataForm({
           {(injected) => (
             <TextField.Root
               type="datetime-local"
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...register('registration_start_date', {
                 valueAsDate : true,
               })}
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...injected}
             />
 
@@ -192,11 +179,9 @@ export default function EventDataForm({
           {(injected) => (
             <TextField.Root
               type="datetime-local"
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...register('registration_end_date', {
                 valueAsDate : true,
               })}
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...injected}
             />
           )}
@@ -208,11 +193,9 @@ export default function EventDataForm({
           {(injected) => (
             <TextField.Root
               type="datetime-local"
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...register('start_time', {
                 valueAsDate : true,
               })}
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...injected}
             />
           )}
@@ -221,11 +204,9 @@ export default function EventDataForm({
           {(injected) => (
             <TextField.Root
               type="datetime-local"
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...register('end_time', {
                 valueAsDate : true,
               })}
-              // eslint-disable-next-line react/jsx-props-no-spreading
               {...injected}
             />
           )}

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -12,7 +12,6 @@ import { Controller, type UseFormReturn } from 'react-hook-form';
 export default function EventDataForm({
   rhf,
 }: {
-  initial?: Omit<Event, 'id'>,
   rhf: UseFormReturn<Omit<Event, 'id'>>,
 }) {
   const { register, formState : { errors } } = rhf;
@@ -25,7 +24,7 @@ export default function EventDataForm({
             placeholder="Event Name"
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...register('name', {
-              required : 'Event name is required.',
+              required : 'Event name is required',
             })}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...injected}
@@ -54,6 +53,7 @@ export default function EventDataForm({
             <Controller
               control={rhf.control}
               name="public"
+              defaultValue
               rules={{}}
               render={({ field }) => (
                 <Box>
@@ -79,6 +79,7 @@ export default function EventDataForm({
             <Controller
               control={rhf.control}
               name="hints_enabled"
+              defaultValue={false}
               rules={{}}
               render={({ field }) => (
                 <Box>
@@ -104,6 +105,7 @@ export default function EventDataForm({
             <Controller
               control={rhf.control}
               name="locked"
+              defaultValue={false}
               rules={{}}
               render={({ field }) => (
                 <Box>

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -1,151 +1,233 @@
 import type { Event } from '@/types';
 import {
-  Checkbox,
+  Box,
   Flex,
+  Switch,
   TextArea,
   TextField,
 } from '@radix-ui/themes';
-import { Form } from 'radix-ui';
-
-function adjustDateForInput(date: Date | null): string {
-  // Adjust the date to be in the format required by datetime-local input
-  if (date === null) return '';
-  const dateObj = new Date(date);
-  const offset = dateObj.getTimezoneOffset();
-  const localDate = new Date(dateObj.getTime() - (offset * 60 * 1000));
-  return localDate.toISOString().slice(0, 16);
-}
+import FormField from 'components/FormField';
+import { Controller, type UseFormReturn } from 'react-hook-form';
 
 export default function EventDataForm({
-  initial,
+  rhf,
 }: {
   initial?: Omit<Event, 'id'>,
+  rhf: UseFormReturn<Omit<Event, 'id'>>,
 }) {
+  const { register, formState : { errors } } = rhf;
+
   return (
     <>
-      <Form.Field name="Name">
-        <Form.Label>Name</Form.Label>
-        <Form.Control asChild>
+      <FormField label="Name" error={errors.name}>
+        {(injected) => (
           <TextField.Root
-            name="name"
-            defaultValue={initial?.name || ''}
             placeholder="Event Name"
-            required
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...register('name', {
+              required : 'Event name is required.',
+            })}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...injected}
           />
-        </Form.Control>
-        <Form.Message match="valueMissing">
-          Event name is required.
-        </Form.Message>
-      </Form.Field>
+        )}
+      </FormField>
 
-      <Form.Field name="description">
-        <Form.Label>Description</Form.Label>
-        <Form.Control asChild>
+      <FormField label="Description" error={errors.description}>
+        {(injected) => (
           <TextArea
-            defaultValue={initial?.description || ''}
             placeholder="Event Description"
             rows={4}
             resize="vertical"
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...register('description')}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...injected}
           />
-        </Form.Control>
-      </Form.Field>
+        )}
+      </FormField>
 
       <Flex direction="row" gap="2" className="*:grow *:basis-0">
-        <Form.Field name="registration_start_date">
-          <Form.Label>Registration Opens</Form.Label>
-          <Form.Control asChild>
-            <TextField.Root
-              type="datetime-local"
-              onChange={(e) => { e.target.form?.reportValidity(); }}
-              defaultValue={adjustDateForInput(initial?.registration_start_date || null)}
+
+        <FormField label="Public" error={errors.public}>
+          {(injected) => (
+            <Controller
+              control={rhf.control}
+              name="public"
+              rules={{}}
+              render={({ field }) => (
+                <Box>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={(checked) => {
+                      field.onChange(checked);
+                    }}
+                    name={field.name}
+                    ref={field.ref}
+                    size="3"
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...injected}
+                  />
+                </Box>
+              )}
             />
-          </Form.Control>
-          <Form.Message match="badInput" />
-        </Form.Field>
-        <Form.Field name="registration_end_date">
-          <Form.Label>Registration Closes</Form.Label>
-          <Form.Control asChild>
-            <TextField.Root
-              type="datetime-local"
-              onChange={(e) => { e.target.form?.reportValidity(); }}
-              defaultValue={adjustDateForInput(initial?.registration_end_date || null)}
+          )}
+        </FormField>
+
+        <FormField label="Hints Enabled" error={errors.hints_enabled}>
+          {(injected) => (
+            <Controller
+              control={rhf.control}
+              name="hints_enabled"
+              rules={{}}
+              render={({ field }) => (
+                <Box>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={(checked) => {
+                      field.onChange(checked);
+                    }}
+                    name={field.name}
+                    ref={field.ref}
+                    size="3"
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...injected}
+                  />
+                </Box>
+              )}
             />
-          </Form.Control>
-          <Form.Message match="badInput" />
-        </Form.Field>
+          )}
+        </FormField>
+
+        <FormField label="Teams Locked" error={errors.locked}>
+          {(injected) => (
+            <Controller
+              control={rhf.control}
+              name="locked"
+              rules={{}}
+              render={({ field }) => (
+                <Box>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={(checked) => {
+                      field.onChange(checked);
+                    }}
+                    name={field.name}
+                    ref={field.ref}
+                    size="3"
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...injected}
+                  />
+                </Box>
+              )}
+            />
+          )}
+        </FormField>
+
       </Flex>
 
       <Flex direction="row" gap="2" className="*:grow *:basis-0">
-        <Form.Field name="start_time">
-          <Form.Label>Event Starts</Form.Label>
-          <Form.Control asChild>
+        <FormField label="Max Team Size" error={errors.max_team_size}>
+          {(injected) => (
             <TextField.Root
-              type="datetime-local"
-              defaultValue={adjustDateForInput(initial?.start_time || null)}
-              required
+              type="number"
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...register('max_team_size', {
+                required : 'Max team size is required',
+                valueAsNumber : true,
+                min : {
+                  value : 1,
+                  message : 'Max team size must be at least 1',
+                },
+                max : {
+                  value : 8,
+                  message : 'Max team size cannot exceed 8',
+                },
+              })}
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...injected}
             />
-          </Form.Control>
-          <Form.Message match="valueMissing" />
-          <Form.Message match="badInput" />
-        </Form.Field>
+          )}
+        </FormField>
 
-        <Form.Field name="end_time">
-          <Form.Label>Event Ends</Form.Label>
-          <Form.Control asChild>
+        <FormField label="Time Limit (minutes)" error={errors.time_limit_minutes}>
+          {(injected) => (
             <TextField.Root
-              type="datetime-local"
-              name="end_time"
-              defaultValue={adjustDateForInput(initial?.end_time || null)}
-              required
+              type="number"
+              placeholder="No time limit"
+              step={1}
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...register('time_limit_minutes', {
+                valueAsNumber : true,
+                min : {
+                  value : 1,
+                  message : 'Time limit must be at least 1 minute',
+                },
+              })}
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...injected}
             />
-          </Form.Control>
-          <Form.Message match="valueMissing" />
-          <Form.Message match="badInput" />
-        </Form.Field>
+          )}
+        </FormField>
       </Flex>
 
-      <Form.Field name="max_team_size">
-        <Form.Label>Max Team Size</Form.Label>
-        <Form.Control asChild>
-          <TextField.Root
-            type="number"
-            defaultValue={initial?.max_team_size.toString() || '1'}
-            min={1}
-            max={8}
-            required
-          />
-        </Form.Control>
-        <Form.Message match="valueMissing" />
-        <Form.Message match="rangeOverflow" />
-        <Form.Message match="rangeUnderflow" />
-      </Form.Field>
-
-      <Flex direction="row" gap="2" className="*:grow *:basis-0 my-1" wrap="wrap">
-        <Form.Field name="public" className="flex gap-1">
-          <Form.Control asChild>
-            <Checkbox
-              defaultChecked={initial?.public}
-              size="3"
+      <Flex direction="row" gap="2" className="*:grow *:basis-0">
+        <FormField label="Registration Opens" error={errors.registration_start_date}>
+          {(injected) => (
+            <TextField.Root
+              type="datetime-local"
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...register('registration_start_date', {
+                valueAsDate : true,
+              })}
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...injected}
             />
-          </Form.Control>
-          <Form.Label>Public</Form.Label>
-        </Form.Field>
-        <Form.Field name="locked" className="flex gap-1">
-          <Form.Control asChild>
-            <Checkbox defaultChecked={initial?.locked} size="3" />
-          </Form.Control>
-          <Form.Label>Disable Team Management</Form.Label>
 
-        </Form.Field>
-        <Form.Field name="registration_open" className="flex gap-1">
-          <Form.Control asChild>
-            <Checkbox
-              defaultChecked={initial?.registration_open}
-              size="3"
+          )}
+        </FormField>
+        <FormField label="Registration Closes" error={errors.registration_end_date}>
+          {(injected) => (
+            <TextField.Root
+              type="datetime-local"
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...register('registration_end_date', {
+                valueAsDate : true,
+              })}
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...injected}
             />
-          </Form.Control>
-          <Form.Label>Registration Open</Form.Label>
-        </Form.Field>
+          )}
+        </FormField>
+      </Flex>
+
+      <Flex direction="row" gap="2" className="*:grow *:basis-0">
+        <FormField label="Event Starts" error={errors.start_time}>
+          {(injected) => (
+            <TextField.Root
+              type="datetime-local"
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...register('start_time', {
+                valueAsDate : true,
+              })}
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...injected}
+            />
+          )}
+        </FormField>
+        <FormField label="Event Ends" error={errors.end_time}>
+          {(injected) => (
+            <TextField.Root
+              type="datetime-local"
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...register('end_time', {
+                valueAsDate : true,
+              })}
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...injected}
+            />
+          )}
+        </FormField>
       </Flex>
     </>
   );

--- a/frontend/src/routes/admin/events/EventModal.tsx
+++ b/frontend/src/routes/admin/events/EventModal.tsx
@@ -62,7 +62,6 @@ export default function EventModal({
       onSubmit={handleSubmit}
       submitVerb={eventToUpdate ? 'Update' : 'Create'}
       submitColor={eventToUpdate ? COLOR_WARNING : COLOR_POSITIVE}
-      requireTouchingForm={!!eventToUpdate}
       defaultValues={defaultValues}
     >
       {(rhf) => <EventDataForm rhf={rhf} />}

--- a/frontend/src/routes/admin/events/EventModal.tsx
+++ b/frontend/src/routes/admin/events/EventModal.tsx
@@ -3,35 +3,42 @@ import { createEvent, updateEvent } from '@/hooks/events';
 import type { Event } from '@/types';
 import { Button } from '@radix-ui/themes';
 import Modal from 'components/Modal';
+import { omit } from 'lodash';
+import type { DefaultValues } from 'react-hook-form';
 import { TbPencil, TbPlus } from 'react-icons/tb';
 import EventDataForm from './EventDataForm';
+
+function adjustDateForInput(date: Date | null): string | undefined {
+  // Adjust the date to be in the format required by datetime-local input
+  if (date === null) return undefined;
+  const dateObj = new Date(date);
+  const offset = dateObj.getTimezoneOffset();
+  const localDate = new Date(dateObj.getTime() - (offset * 60 * 1000));
+  return localDate.toISOString().slice(0, 16);
+}
 
 export default function EventModal({
   eventToUpdate,
 }: {
   eventToUpdate?: Event;
 }) {
-  const handleSubmit = async (data: FormData) => {
-    const entries = Object.fromEntries(data.entries());
-    const event: Omit<Event, 'id'> = {
-      name : entries.name as string,
-      description : entries.description as string,
-      start_time : new Date(entries.start_time as string),
-      end_time : new Date(entries.end_time as string),
-      locked : entries.locked === 'on',
-      public : entries.public === 'on',
-      max_team_size : Number(entries.max_team_size),
-      registration_open : entries.registration_open === 'on',
-      registration_start_date : new Date(entries.registration_start_date as string),
-      registration_end_date : new Date(entries.registration_end_date as string),
-    };
-
+  const handleSubmit = async (data: Omit<Event, 'id'>) => {
     if (eventToUpdate) {
       // Update existing event
-      return updateEvent(eventToUpdate.id, event);
+      return updateEvent(eventToUpdate.id, data);
     }
 
-    return createEvent(event);
+    return createEvent(data);
+  };
+
+  // Default value Dates must be converted to datetime-local string format, even though the value is typed as Date.
+  // This is because valueAsDate only applies to entered values, not default values.
+  const defaultValues: DefaultValues<Omit<Event, 'id'>> = {
+    ...omit(eventToUpdate, 'id'),
+    registration_start_date : adjustDateForInput(eventToUpdate?.registration_start_date || null) as unknown as Date,
+    registration_end_date : adjustDateForInput(eventToUpdate?.registration_end_date || null) as unknown as Date,
+    start_time : adjustDateForInput(eventToUpdate?.start_time || null) as unknown as Date,
+    end_time : adjustDateForInput(eventToUpdate?.end_time || null) as unknown as Date,
   };
 
   return (
@@ -56,8 +63,9 @@ export default function EventModal({
       submitVerb={eventToUpdate ? 'Update' : 'Create'}
       submitColor={eventToUpdate ? COLOR_WARNING : COLOR_POSITIVE}
       requireTouchingForm={!!eventToUpdate}
+      defaultValues={defaultValues}
     >
-      <EventDataForm initial={eventToUpdate} />
+      {(rhf) => <EventDataForm rhf={rhf} />}
     </Modal>
   );
 }

--- a/frontend/src/routes/admin/tags/SupportTags/TagModal.tsx
+++ b/frontend/src/routes/admin/tags/SupportTags/TagModal.tsx
@@ -33,7 +33,6 @@ export default function CreateTagModal(
       onSubmit={handleSubmit}
       submitVerb={isCreating ? 'Create' : 'Update'}
       defaultValues={omit(defaultValues, 'id', 'ticket_count')}
-      requireTouchingForm
     >
       {({ register, formState : { errors } }) => (
         <>

--- a/frontend/src/routes/admin/tags/SupportTags/TagModal.tsx
+++ b/frontend/src/routes/admin/tags/SupportTags/TagModal.tsx
@@ -1,28 +1,21 @@
-import Modal from 'components/Modal';
-import { Button, TextField } from '@radix-ui/themes';
-import { Form } from 'radix-ui';
+import { COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
 import { createSupportTag, putSupportTag } from '@/hooks/support';
 import type { TicketTag } from '@/types';
-import { isUndefined } from 'lodash';
-import { COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
+import { Button, Flex, TextField } from '@radix-ui/themes';
+import FormField from 'components/FormField';
+import Modal from 'components/Modal';
+import { isUndefined, omit } from 'lodash';
 
 export default function CreateTagModal(
   { defaultValues }: {defaultValues?: TicketTag},
 ) {
   const isCreating = isUndefined(defaultValues);
 
-  const handleSubmit = async (data: FormData) => {
-    const entries = Object.fromEntries(data.entries());
-    const newTag: Omit<TicketTag, 'id' | 'ticket_count'> = {
-      name : entries.name as string,
-      color : entries.color as string,
-      description : entries.description as string,
-    };
-
+  const handleSubmit = async (data: Omit<TicketTag, 'id' | 'ticket_count'>) => {
     if (isCreating) {
-      return createSupportTag(newTag);
+      return createSupportTag(data);
     }
-    return putSupportTag(defaultValues?.id, newTag);
+    return putSupportTag(defaultValues?.id, data);
   };
 
   return (
@@ -39,45 +32,55 @@ export default function CreateTagModal(
       )}
       onSubmit={handleSubmit}
       submitVerb={isCreating ? 'Create' : 'Update'}
+      defaultValues={omit(defaultValues, 'id', 'ticket_count')}
       requireTouchingForm
     >
-      <Form.Field name="name">
-        <Form.Label>Name</Form.Label>
-        <Form.Control asChild>
-          <TextField.Root
-            defaultValue={defaultValues?.name}
-            placeholder="Enter a tag name"
-            required
-          />
-        </Form.Control>
-        <Form.Message match="valueMissing">
-          Please enter a name.
-        </Form.Message>
-      </Form.Field>
-      <Form.Field name="color">
-        <Form.Label>Hex Color</Form.Label>
-        <Form.Control asChild>
-          <TextField.Root
-            defaultValue={defaultValues?.color}
-            placeholder="Enter a hex color"
-          />
-        </Form.Control>
-        <Form.Message match="valueMissing">
-          Please enter a name.
-        </Form.Message>
-      </Form.Field>
-      <Form.Field name="description">
-        <Form.Label>Description</Form.Label>
-        <Form.Control asChild>
-          <TextField.Root
-            defaultValue={defaultValues?.description}
-            placeholder="Enter a description"
-          />
-        </Form.Control>
-        <Form.Message match="valueMissing">
-          Please enter a name.
-        </Form.Message>
-      </Form.Field>
+      {({ register, formState : { errors } }) => (
+        <>
+          <Flex direction="row" gap="2" className="*:first:grow">
+            <FormField label="Name" error={errors?.name}>
+              {(injected) => (
+                <TextField.Root
+                  placeholder="Enter a tag name"
+                  // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...register('name', {
+                    required : 'Please enter a name.',
+                  })}
+                  // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...injected}
+                />
+              )}
+            </FormField>
+            <FormField label="Color" error={errors?.color}>
+              {(injected) => (
+                <input
+                  type="color"
+                  className="rounded"
+                  // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...register('color', {
+                    required : 'Please enter a color.',
+                  })}
+                  // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...injected}
+                />
+              )}
+            </FormField>
+          </Flex>
+          <FormField label="Description" error={errors?.description}>
+            {(injected) => (
+              <TextField.Root
+                placeholder="Enter a description"
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...register('description', {
+                  required : 'Please enter a description.',
+                })}
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...injected}
+              />
+            )}
+          </FormField>
+        </>
+      )}
     </Modal>
   );
 }

--- a/frontend/src/routes/admin/tags/SupportTags/TagModal.tsx
+++ b/frontend/src/routes/admin/tags/SupportTags/TagModal.tsx
@@ -41,11 +41,9 @@ export default function CreateTagModal(
               {(injected) => (
                 <TextField.Root
                   placeholder="Enter a tag name"
-                  // eslint-disable-next-line react/jsx-props-no-spreading
                   {...register('name', {
                     required : 'Please enter a name.',
                   })}
-                  // eslint-disable-next-line react/jsx-props-no-spreading
                   {...injected}
                 />
               )}
@@ -55,11 +53,9 @@ export default function CreateTagModal(
                 <input
                   type="color"
                   className="rounded"
-                  // eslint-disable-next-line react/jsx-props-no-spreading
                   {...register('color', {
                     required : 'Please enter a color.',
                   })}
-                  // eslint-disable-next-line react/jsx-props-no-spreading
                   {...injected}
                 />
               )}
@@ -69,11 +65,9 @@ export default function CreateTagModal(
             {(injected) => (
               <TextField.Root
                 placeholder="Enter a description"
-                // eslint-disable-next-line react/jsx-props-no-spreading
                 {...register('description', {
                   required : 'Please enter a description.',
                 })}
-                // eslint-disable-next-line react/jsx-props-no-spreading
                 {...injected}
               />
             )}

--- a/frontend/src/routes/admin/teams/ScoreAdjustModal.tsx
+++ b/frontend/src/routes/admin/teams/ScoreAdjustModal.tsx
@@ -2,16 +2,18 @@ import { COLOR_WARNING } from '@/constants';
 import { adjustPoints } from '@/hooks/scoring';
 import type { Team } from '@/types';
 import { Button, TextField } from '@radix-ui/themes';
+import FormField from 'components/FormField';
 import Modal from 'components/Modal';
-import { Form } from 'radix-ui';
 import { TbPlusMinus } from 'react-icons/tb';
 
 export default function ScoreAdjustModal({ team }: { team: Team }) {
-  const handleSubmit = async (data: FormData) => {
-    const { points, reason } = Object.fromEntries(data.entries());
-
-    return adjustPoints(team.event_id, team.id, Number(points), reason as string);
-  };
+  const handleSubmit = async ({
+    adjustment,
+    reason,
+  }: {
+    adjustment: number;
+    reason: string;
+  }) => adjustPoints(team.event_id, team.id, adjustment, reason);
 
   return (
     <Modal
@@ -27,21 +29,39 @@ export default function ScoreAdjustModal({ team }: { team: Team }) {
       submitVerb="Adjust"
       submitColor={COLOR_WARNING}
     >
-      <Form.Field name="points">
-        <Form.Label>Adjustment</Form.Label>
-        <Form.Control asChild>
-          <TextField.Root type="number" placeholder="Number of points" required />
-        </Form.Control>
-        <Form.Message match="valueMissing" />
-        <Form.Message match="badInput" />
-      </Form.Field>
-      <Form.Field name="reason">
-        <Form.Label>Reason</Form.Label>
-        <Form.Control asChild>
-          <TextField.Root placeholder="Reason for adjustment" required />
-        </Form.Control>
-        <Form.Message match="valueMissing" />
-      </Form.Field>
+      {({ register, formState : { errors } }) => (
+
+        <>
+          <FormField label="Adjustment" error={errors?.adjustment}>
+            {(injected) => (
+              <TextField.Root
+                placeholder="Number of points"
+                type="number"
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...register('adjustment', {
+                  required : 'Point value is required',
+                  valueAsNumber : true,
+                })}
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...injected}
+              />
+            )}
+          </FormField>
+          <FormField label="Reason" error={errors?.reason}>
+            {(injected) => (
+              <TextField.Root
+                placeholder="Reason for adjustment"
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...register('reason', { required : 'Reason is required' })}
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...injected}
+              />
+            )}
+          </FormField>
+        </>
+
+      )}
+
     </Modal>
   );
 }

--- a/frontend/src/routes/admin/teams/ScoreAdjustModal.tsx
+++ b/frontend/src/routes/admin/teams/ScoreAdjustModal.tsx
@@ -37,12 +37,10 @@ export default function ScoreAdjustModal({ team }: { team: Team }) {
               <TextField.Root
                 placeholder="Number of points"
                 type="number"
-                // eslint-disable-next-line react/jsx-props-no-spreading
                 {...register('adjustment', {
                   required : 'Point value is required',
                   valueAsNumber : true,
                 })}
-                // eslint-disable-next-line react/jsx-props-no-spreading
                 {...injected}
               />
             )}
@@ -51,9 +49,7 @@ export default function ScoreAdjustModal({ team }: { team: Team }) {
             {(injected) => (
               <TextField.Root
                 placeholder="Reason for adjustment"
-                // eslint-disable-next-line react/jsx-props-no-spreading
                 {...register('reason', { required : 'Reason is required' })}
-                // eslint-disable-next-line react/jsx-props-no-spreading
                 {...injected}
               />
             )}

--- a/frontend/src/routes/events/RegistrationModal.tsx
+++ b/frontend/src/routes/events/RegistrationModal.tsx
@@ -1,111 +1,186 @@
+import { registerMyEvent, registerMyEventTeamJoin } from '@/hooks/events';
+import type { Event } from '@/types';
 import {
+  Box,
   Button,
   Checkbox,
-  TextField,
-  Text,
   Flex,
+  SegmentedControl,
+  Text,
+  TextField,
 } from '@radix-ui/themes';
+import { InfoCallout, WarningCallout } from 'components/Callouts';
+import FormField from 'components/FormField';
 import Modal from 'components/Modal';
-import { Form } from 'radix-ui';
-import { useNavigate, useParams } from 'react-router';
-import { useState } from 'react';
+import RadixMarkdown from 'components/RadixMarkdown';
 import { isUndefined } from 'lodash';
-import type { Event } from '@/types';
-import { registerMyEvent, registerMyEventTeamJoin } from '@/hooks/events';
+import { useState } from 'react';
+import { Controller } from 'react-hook-form';
+import { TbArrowRight, TbPlus } from 'react-icons/tb';
+import { useNavigate, useParams } from 'react-router';
 
 export default function RegistrationModal({ eventId, eventName, isTeamGame }: {eventId : Event['id'], eventName: string, isTeamGame: boolean}) {
-  const [ checked, setChecked ] = useState(false);
   const { inviteCode, idEvent } = useParams();
   const joinWithCode = !!(eventId === Number(idEvent) && !isUndefined(inviteCode));
 
+  const [ selectedOption, setSelectedOption ] = useState<'create-team' | 'join-team'>(joinWithCode ? 'join-team' : 'create-team');
+
   const navigate = useNavigate();
 
-  const register = async (data: FormData) => {
-    if (joinWithCode) {
-      return registerMyEventTeamJoin(eventId, inviteCode).then(() => {
+  const handleRegister = async (data: { leaderboardName: string; joinCode: string; termsConditions: boolean }) => {
+    if (selectedOption === 'join-team') {
+      return registerMyEventTeamJoin(eventId, data.joinCode).then(() => {
         navigate(`/events/${eventId}`);
       });
     }
 
-    const leaderboardName = data.get('leaderboard_name') as string;
+    const { leaderboardName } = data;
     return registerMyEvent(eventId, leaderboardName).then(() => {
       navigate(`/events/${eventId}`);
     });
   };
 
   function getDescription() {
-    if (joinWithCode) {
-      return undefined;
-    }
-    return isTeamGame ? 'Please do not use your real name or user name for your team name'
+    return isTeamGame ? 'Please do not use your real name or user name for your team name.'
       : 'Please do not use your real name for your leaderboard name.';
   }
 
   return (
     <Modal
-      title="Are you sure you want to register for this event?"
-      description={getDescription()}
+      title={`Register for ${eventName}`}
       trigger={(
         <Button variant="soft">Register</Button>
       )}
-      onSubmit={register}
+      onSubmit={handleRegister}
       submitVerb="Register"
-      onOpenChange={() => {
-        setChecked(false);
-      }}
       defaultOpen={joinWithCode}
+      defaultValues={{
+        leaderboardName : '',
+        joinCode : joinWithCode ? inviteCode : '',
+        termsConditions : false,
+      }}
+      onOpenChange={(open) => {
+        if (!open && joinWithCode) {
+          // If the user closes the modal while registering via an invite link, take them back to the event page
+          navigate('/events');
+        }
+
+        setSelectedOption('create-team');
+      }}
     >
-      {
-        joinWithCode ? (
-          <Flex gap="2">
-            <Text as="label" className="font-bold">Event Name: </Text>
-            <Text as="label">{eventName}</Text>
-          </Flex>
-        ) : (
-          <Form.Field name="leaderboard_name">
-            <Form.Label>
-              {isTeamGame ? 'Team Name' : 'Leaderboard Name'}
-            </Form.Label>
-            <Form.Control asChild>
-              <TextField.Root
-                placeholder={isTeamGame ? 'Enter your team name' : 'Enter your leaderboard name'}
-                required
-              />
-            </Form.Control>
-            <Form.Message match="valueMissing">
-              Please enter a name.
-            </Form.Message>
-          </Form.Field>
-        )
-      }
+      {({ register, control, formState : { errors } }) => (
+        <>
+          {isTeamGame && (
+            <SegmentedControl.Root
+              value={selectedOption}
+              onValueChange={(val) => setSelectedOption(val as 'create-team' | 'join-team')}
+              className="!h-16"
+            >
+              <SegmentedControl.Item value="create-team">
+                <TbPlus className="text-2xl mx-auto" />
+                Create New Team
+              </SegmentedControl.Item>
+              <SegmentedControl.Item value="join-team">
+                <TbArrowRight className="text-2xl mx-auto" />
+                Join Existing Team
+              </SegmentedControl.Item>
+            </SegmentedControl.Root>
+          )}
 
-      <Form.Field name="terms_conditions">
-        <Form.Label asChild>
-          <Text as="label" size="2">
-            <Flex as="span" gap="2">
-              <Checkbox
-                checked={checked}
-                onCheckedChange={(val) => setChecked(val === true)}
-              />
-              Agree to the Terms and Conditions
-            </Flex>
-          </Text>
-        </Form.Label>
-        {/* Hidden native checkbox for validation */}
-        <Form.Control asChild>
-          <input
-            type="checkbox"
-            checked={checked}
-            onChange={(e) => setChecked(e.target.checked)}
-            required
-            className="hidden"
+          { selectedOption === 'create-team' && (
+            <>
+              <WarningCallout>{getDescription()}</WarningCallout>
+              <FormField label={isTeamGame ? 'Team Name' : 'Leaderboard Name'} error={errors?.leaderboardName}>
+                {(injected) => (
+                  <TextField.Root
+                    placeholder={isTeamGame ? 'Enter your team name' : 'Enter your leaderboard name'}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...register('leaderboardName', {
+                      required : {
+                        value : true, message : 'This field is required',
+                      },
+                      maxLength : {
+                        value : 100, message : 'Name must be at most 100 characters',
+                      },
+                    })}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...injected}
+                  />
+                )}
+              </FormField>
+            </>
+          )}
+
+          { (selectedOption === 'join-team') && (
+            <>
+              {!joinWithCode && (
+                <InfoCallout>
+                  Open an invite link provided by your team captain or enter the invite code below to join the team.
+                </InfoCallout>
+              )}
+              <FormField label="Invite Code" error={errors?.joinCode}>
+                {(injected) => (
+                  <TextField.Root
+                    readOnly={joinWithCode}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...register('joinCode', {
+                      required : {
+                        value : true, message : 'An invite code is required to join an existing team',
+                      },
+                      minLength : {
+                        value : 32, message : 'Invite code should be 32 characters',
+                      },
+                      maxLength : {
+                        value : 32, message : 'Invite code should be 32 characters',
+                      },
+                    })}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...injected}
+                  />
+                )}
+              </FormField>
+            </>
+          )}
+
+          <Box className="text-sm">
+            <RadixMarkdown>
+              {`I acknowledge that I have read and understand the [eligibility criteria](/) and [contest rules](/)
+          for CISA's President's Cup Cybersecurity Competition. I agree to (1) comply with these criteria and rules and
+          (2) accept all decisions made by CISA and the contest administrators regarding the competition.
+          I will lodge all complaints or concerns I may have regarding the competition through my employer agency, which may submit them to CISA on my behalf.`}
+            </RadixMarkdown>
+          </Box>
+
+          <Controller
+            control={control}
+            name="termsConditions"
+            rules={{
+              required : {
+                value : true, message : 'You must accept the terms and conditions to register',
+              },
+            }}
+            defaultValue={false}
+            render={({ field }) => (
+              <Text as="label" size="2">
+                <Flex gap="2">
+                  <Checkbox
+                    id="termsConditions"
+                    checked={field.value}
+                    onCheckedChange={(checked) => field.onChange(checked)}
+                    onBlur={field.onBlur}
+                    ref={field.ref}
+                  />
+                  I agree to the Terms and Conditions
+                </Flex>
+              </Text>
+
+            )}
           />
-        </Form.Control>
 
-        <Form.Message match="valueMissing">
-          You must accept the terms and conditions.
-        </Form.Message>
-      </Form.Field>
+          {errors.termsConditions?.message && <WarningCallout>{errors.termsConditions.message.toString()}</WarningCallout>}
+        </>
+      )}
+
     </Modal>
   );
 }

--- a/frontend/src/routes/events/RegistrationModal.tsx
+++ b/frontend/src/routes/events/RegistrationModal.tsx
@@ -94,7 +94,6 @@ export default function RegistrationModal({ eventId, eventName, isTeamGame }: {e
                 {(injected) => (
                   <TextField.Root
                     placeholder={isTeamGame ? 'Enter your team name' : 'Enter your leaderboard name'}
-                    // eslint-disable-next-line react/jsx-props-no-spreading
                     {...register('leaderboardName', {
                       required : {
                         value : true, message : 'This field is required',
@@ -103,7 +102,6 @@ export default function RegistrationModal({ eventId, eventName, isTeamGame }: {e
                         value : 100, message : 'Name must be at most 100 characters',
                       },
                     })}
-                    // eslint-disable-next-line react/jsx-props-no-spreading
                     {...injected}
                   />
                 )}
@@ -122,7 +120,6 @@ export default function RegistrationModal({ eventId, eventName, isTeamGame }: {e
                 {(injected) => (
                   <TextField.Root
                     readOnly={joinWithCode}
-                    // eslint-disable-next-line react/jsx-props-no-spreading
                     {...register('joinCode', {
                       required : {
                         value : true, message : 'An invite code is required to join an existing team',
@@ -134,7 +131,6 @@ export default function RegistrationModal({ eventId, eventName, isTeamGame }: {e
                         value : 32, message : 'Invite code should be 32 characters',
                       },
                     })}
-                    // eslint-disable-next-line react/jsx-props-no-spreading
                     {...injected}
                   />
                 )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,6 +10,8 @@ export interface Event {
   registration_open: boolean;
   registration_start_date?: Date;
   registration_end_date?: Date;
+  hints_enabled: boolean;
+  time_limit_minutes: number | null;
 }
 
 export interface User {
@@ -165,6 +167,7 @@ export interface Deployment {
 
 export interface ContainerBlueprint {
   id: number;
+  name: string;
   image: string;
   hostname: string;
   stdin_open: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       react-dropzone:
         specifier: ^14.3.8
         version: 14.3.8(react@19.1.1)
+      react-hook-form:
+        specifier: ^7.63.0
+        version: 7.63.0(react@19.1.1)
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@19.1.1)
@@ -3243,6 +3246,12 @@ packages:
     engines: {node: '>= 10.13'}
     peerDependencies:
       react: '>= 16.8 || 18.0.0'
+
+  react-hook-form@7.63.0:
+    resolution: {integrity: sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-icons@5.5.0:
     resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
@@ -7766,6 +7775,10 @@ snapshots:
       attr-accept: 2.2.5
       file-selector: 2.1.2
       prop-types: 15.8.1
+      react: 19.1.1
+
+  react-hook-form@7.63.0(react@19.1.1):
+    dependencies:
       react: 19.1.1
 
   react-icons@5.5.0(react@19.1.1):


### PR DESCRIPTION
- Use react-hook-form to perform validation in Modal forms, and to allow cleaner use of checkboxes, selects, etc. without manually maintaining their state separate from the form values
  - Validation rules have been kept as-is, but we could adopt a library like yup or zod in the future to enforce more advanced validation schemas on the client-side
  - Form submit handler now consumes typed rhf form data as its parameter, instead of a `FormData` object that has to be unpacked.
- Updates the event registration modal form to include Terms/Conditions (as markdown, so they can be easily configurable in the future), as well as an option to manually enter/paste an invite code (good practice to provide an alternative to "magic links")
- Updates the tag create/edit modal to use a color picker input instead of manual hex code entry