### PR TITLE
Update event badge logic

### DIFF
--- a/frontend/src/components/EventBadge.tsx
+++ b/frontend/src/components/EventBadge.tsx
@@ -4,9 +4,18 @@ import {
   COLOR_WARNING,
   type AccentColor,
 } from '@/constants';
-import { Badge } from '@radix-ui/themes';
+import { useEventStatus } from '@/hooks/events';
+import { useEventPermission } from '@/hooks/permissions';
+import { useRegistration } from '@/hooks/users';
+import { Badge, Skeleton } from '@radix-ui/themes';
+import type { Responsive } from '@radix-ui/themes/props';
 import type { IconType } from 'react-icons';
-import { TbCheck, TbClock, TbPlayerPlayFilled } from 'react-icons/tb';
+import {
+  TbArrowRight,
+  TbCheck,
+  TbClock,
+  TbPlayerPlay,
+} from 'react-icons/tb';
 
 /** Maps an event state onto label, color, and icon to display in the UI. */
 const EVENT_STATES: {
@@ -16,20 +25,40 @@ const EVENT_STATES: {
         icon: IconType;
     };
 } = {
-  upcoming : {
+  registration_open : {
     color : COLOR_INFO,
-    label : 'Upcoming',
+    label : 'Registration Open',
+    icon : TbArrowRight,
+  },
+  registered : {
+    color : COLOR_POSITIVE,
+    label : 'Registered',
+    icon : TbCheck,
+  },
+  ready : {
+    color : COLOR_INFO,
+    label : 'Ready to Start',
     icon : TbClock,
   },
   waiting : {
     color : COLOR_WARNING,
-    label : 'Waiting for team',
+    label : 'Waiting for Captain',
     icon : TbClock,
+  },
+  playing : {
+    color : COLOR_POSITIVE,
+    label : 'Playing',
+    icon : TbPlayerPlay,
   },
   live : {
     color : COLOR_POSITIVE,
     label : 'Happening Now',
-    icon : TbPlayerPlayFilled,
+    icon : TbPlayerPlay,
+  },
+  participated : {
+    color : 'gray',
+    label : 'Participated',
+    icon : TbCheck,
   },
   ended : {
     color : 'gray',
@@ -38,10 +67,57 @@ const EVENT_STATES: {
   },
 };
 
-export default function EventBadge({ state }: { state: 'upcoming' | 'waiting' | 'live' | 'ended' }) {
+export default function EventBadge({ eventId, size, className }: { eventId: number; size?: Responsive<'1' | '2' | '3'>; className?: string }) {
+  const {
+    isRegistered, isStarted, team, isLoading,
+  } = useRegistration(eventId);
+  const {
+    isRegistrationOpen, isOngoing, isConcluded, isLoading : statusLoading,
+  } = useEventStatus(eventId);
+  const { granted, isLoading : permissionLoading } = useEventPermission('CAN_START_TEAM_TIMER', isRegistered ? eventId : null);
+
+  let state;
+
+  if (isLoading || statusLoading || permissionLoading) {
+    return <Skeleton><Badge size={size} className={className}>Loading...</Badge></Skeleton>;
+  }
+
+  if (isOngoing) {
+    state = 'live';
+  }
+
+  if (isRegistrationOpen) {
+    state = 'registration_open';
+  }
+
+  if (isRegistered) {
+    state = 'registered';
+
+    if (isOngoing) {
+      if (isStarted) {
+        state = 'playing';
+      } else {
+        state = granted ? 'ready' : 'waiting';
+      }
+    }
+
+    if (team?.end_time && team.end_time < new Date()) {
+      state = 'participated';
+    }
+  }
+
+  if (isConcluded) {
+    state = 'ended';
+  }
+
+  if (!state) {
+    return null;
+  }
+
   const { color, label, icon : Icon } = EVENT_STATES[state];
+
   return (
-    <Badge color={color} variant="soft" size="3">
+    <Badge color={color} variant="soft" size={size} className={className}>
       {Icon && <Icon className="inline" />}
       {label}
     </Badge>

--- a/frontend/src/components/EventHeader.tsx
+++ b/frontend/src/components/EventHeader.tsx
@@ -30,17 +30,6 @@ export default function EventHeader({
     max_team_size : maxTeamSize,
   } = event;
 
-  const now = new Date();
-
-  let state: 'upcoming' | 'live' | 'ended' | 'waiting' | null = null;
-  if (endTime && now > endTime) {
-    state = 'ended';
-  } else if (!startTime || now < startTime) {
-    state = 'upcoming';
-  } else if (startTime && endTime && now >= startTime && now <= endTime) {
-    state = 'live';
-  }
-
   const dateRange = (!isNull(startTime) && !isNull(endTime)) && `${startTime?.toLocaleString()} - ${endTime?.toLocaleString()}`;
 
   return (
@@ -52,9 +41,7 @@ export default function EventHeader({
         </AspectRatio>
       </Box>
       <Flex direction="column" flexGrow="1" align="start" gap="2">
-        {state && (
-          <EventBadge state={state} />
-        )}
+        <EventBadge eventId={id} size="3" />
         <Box>
           <Heading size="8">
             <LinkTheme asChild>

--- a/frontend/src/hooks/events.ts
+++ b/frontend/src/hooks/events.ts
@@ -30,6 +30,23 @@ export function useEvent(eventId: number | null) {
   return useSWR<Event, Error>(eventId ? `/events/${eventId}` : null);
 }
 
+export function useEventStatus(eventId: number | null) {
+  const { data, error, isLoading } = useEvent(eventId);
+
+  return {
+    isRegistrationOpen : !!(data && data.registration_open
+      && (!data.registration_start_date || data.registration_start_date <= new Date())
+      && (!data.registration_end_date || data.registration_end_date >= new Date())
+    ),
+    isOngoing : !!(data
+       && (!data.start_time || data.start_time <= new Date())
+       && (!data.end_time || data.end_time >= new Date())),
+    isConcluded : !!(data && data.end_time && data.end_time < new Date()),
+    isLoading,
+    error,
+  };
+}
+
 export function useMyEligibility(eventId: number | null) {
   return useSWR<boolean, Error>(eventId ? `/events/${eventId}/me/eligibility` : null);
 }
@@ -55,6 +72,8 @@ export function registerMyEvent(eventId: number, teamName: string) {
   }).then(() => {
     mutate('/users/me/events');
     mutate('/users/me/teams');
+    mutate(`/events/${eventId}/me/team`);
+    mutate(`/events/${eventId}/me/eligibility`);
     mutate(`/permissions/${eventId}/me`);
   });
 }
@@ -64,6 +83,8 @@ export function registerMyEventTeamJoin(eventId: number, inviteCode: string) {
   }).then(() => {
     mutate('/users/me/events');
     mutate('/users/me/teams');
+    mutate(`/events/${eventId}/me/team`);
+    mutate(`/events/${eventId}/me/eligibility`);
     mutate(`/permissions/${eventId}/me`);
   });
 }
@@ -142,6 +163,7 @@ export function startMyTeam(eventId: number) {
     mutate(`/events/${eventId}/challenges`);
     mutate(`/events/${eventId}/me/challenges`);
     mutate(`/permissions/${eventId}/me`);
+    mutate('/users/me/teams');
   });
 }
 

--- a/frontend/src/hooks/permissions.ts
+++ b/frontend/src/hooks/permissions.ts
@@ -4,11 +4,34 @@ import useSWR from 'swr';
 /*
   Gets users with Admin or Support roles
 */
-
-/* eslint-disable import/prefer-default-export */
-// ^ remove disable line after implementing more permission checks
 export function useSupportRoles() {
   return useSWR<User[], Error>(
     '/admin/permissions/support_role_users',
   );
+}
+
+export function useMyGlobalPermissions() {
+  return useSWR<{user_id: number, permissions: string[]}, Error>(
+    '/permissions/me',
+  );
+}
+
+export function useMyEventPermissions(eventId: number | null) {
+  return useSWR<{event_id: number, permissions: string[]}, Error>(
+    eventId ? `/permissions/${eventId}/me` : null,
+  );
+}
+
+/**
+ * Helper for performing an event-level permission check.
+ */
+export function useEventPermission(permission: string, eventId : number | null) {
+  const { data, error, isLoading } = useMyEventPermissions(eventId);
+
+  return {
+    granted : data ? data.permissions.includes(permission) : false,
+    denied : data ? !data.permissions.includes(permission) : false,
+    isLoading,
+    error,
+  };
 }

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -53,6 +53,8 @@ export function useRegistration(eventId: number | null) {
   return {
     isRegistered : !!myTeam,
     isUnregistered : !myTeam && !isLoading && !error,
+    isStarted : !!myTeam?.start_timestamp,
+    isFinished : !!(myTeam?.end_time && myTeam.end_time < new Date()),
     team : myTeam,
     error,
     isLoading,

--- a/frontend/src/routes/dashboard/EventCard.tsx
+++ b/frontend/src/routes/dashboard/EventCard.tsx
@@ -9,6 +9,7 @@ import {
   Inset,
   Text,
 } from '@radix-ui/themes';
+import EventBadge from 'components/EventBadge';
 import { TbCalendarEvent, TbClock } from 'react-icons/tb';
 import { Link } from 'react-router';
 
@@ -26,7 +27,10 @@ export default function EventCard({ event }: { event: Event }) {
             </AspectRatio>
           </Inset>
           <Flex direction="column" gap="2" className="flex-grow" justify="between">
-            <Heading size="4">{event.name}</Heading>
+            <Box>
+              <Heading size="4">{event.name}</Heading>
+              <EventBadge eventId={event.id} size="2" className="mt-2" />
+            </Box>
             <Flex direction="column">
               <Text size="2" color="gray">
                 {individual ? (


### PR DESCRIPTION
Closes #247. Updates event badges to more accurately reflect event states, and adds them to event cards shown on the dashboard and events page.