### PR TITLE
Event page polish and permission checks

### DIFF
--- a/frontend/src/components/EventBadge.tsx
+++ b/frontend/src/components/EventBadge.tsx
@@ -1,5 +1,6 @@
 import {
   COLOR_INFO,
+  COLOR_NEGATIVE,
   COLOR_POSITIVE,
   COLOR_WARNING,
   type AccentColor,
@@ -56,9 +57,9 @@ const EVENT_STATES: {
     icon : TbPlayerPlay,
   },
   participated : {
-    color : 'gray',
-    label : 'Participated',
-    icon : TbCheck,
+    color : COLOR_NEGATIVE,
+    label : 'Time Up',
+    icon : TbClock,
   },
   ended : {
     color : 'gray',

--- a/frontend/src/components/RequireEventPermission.tsx
+++ b/frontend/src/components/RequireEventPermission.tsx
@@ -1,0 +1,39 @@
+import { useEventPermission } from '@/hooks/permissions';
+import type { ReactNode } from 'react';
+import { ErrorCallout } from './Callouts';
+
+export default function RequireEventPermission(
+  {
+    children,
+    permission,
+    eventId,
+    permissionDeniedPlaceholder,
+    loadingPlaceholder,
+  } : {
+    children: ReactNode,
+    permission: string,
+    eventId: number,
+    permissionDeniedPlaceholder?: ReactNode
+    loadingPlaceholder?: ReactNode
+  },
+) {
+  const {
+    granted, denied, error,
+  } = useEventPermission(permission, eventId);
+
+  if (granted) {
+    return children;
+  }
+
+  if (denied) {
+    return permissionDeniedPlaceholder !== undefined
+      ? permissionDeniedPlaceholder
+      : <ErrorCallout>Permission Denied</ErrorCallout>;
+  }
+
+  if (error) {
+    return <ErrorCallout>{error.message}</ErrorCallout>;
+  }
+
+  return loadingPlaceholder;
+}

--- a/frontend/src/routes/dashboard/index.tsx
+++ b/frontend/src/routes/dashboard/index.tsx
@@ -6,17 +6,29 @@ import {
   Skeleton,
 } from '@radix-ui/themes';
 import { ErrorCallout, InfoCallout } from 'components/Callouts';
-import EventHeader from 'components/EventHeader';
 import HeaderContainer from 'components/HeaderContainer';
 import { isEmpty } from 'lodash';
 import PastEvents from 'routes/dashboard/PastEvents';
 import UpcomingEvents from 'routes/dashboard/UpcomingEvents';
+import EventCard from './EventCard';
 
 export default function Dashboard() {
   const { data, error, isLoading } = useMyEvents();
 
   const liveEvents = data?.filter(
-    (event) => event.start_time && event.end_time && new Date() >= event.start_time && new Date() <= event.end_time,
+    (event) => {
+      if (event.start_time && new Date() < event.start_time) {
+        // events that haven't started yet shouldn't be shown
+        return false;
+      }
+
+      if (event.end_time && new Date() > event.end_time) {
+        // events that have ended shouldn't be shown
+        return false;
+      }
+
+      return true;
+    },
   );
 
   if (error) {
@@ -33,12 +45,11 @@ export default function Dashboard() {
             </InfoCallout>
           </Skeleton>
         )}
-        {liveEvents?.map((event) => (
-          <EventHeader
-            key={event.id}
-            event={event}
-          />
-        ))}
+        <Flex direction="column" gap="3">
+          {liveEvents?.map((event) => (
+            <EventCard key={event.id} event={event} />
+          ))}
+        </Flex>
       </HeaderContainer>
 
       <Container size="4">

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -13,7 +13,6 @@ import ChallengesTab from './OverviewTabs/ChallengesTab';
 import LeaderboardTab from './OverviewTabs/LeaderboardTab';
 import TeamTab from './OverviewTabs/TeamTab';
 import RegistrationLine from './RegistrationLine';
-import StartModal from './StartModal';
 
 export default function Overview() {
   const [ searchParams, setSearchParams ] = useSearchParams();
@@ -53,8 +52,6 @@ export default function Overview() {
             {isAuthenticated && data && (
               <RegistrationLine event={data} />
             )}
-
-            {isAuthenticated && <StartModal eventId={data.id} />}
 
             {isUnauthenticated && (
               <InfoCallout>

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/EventChallenges.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/EventChallenges.tsx
@@ -1,0 +1,54 @@
+import { useEventChallenges, useMyChallenges } from '@/hooks/challenge';
+import { Container, Grid, TextField } from '@radix-ui/themes';
+import { ErrorCallout } from 'components/Callouts';
+import { keyBy } from 'lodash';
+import { useMemo, useState } from 'react';
+import { TbSearch } from 'react-icons/tb';
+import ChallengeCard from './ChallengeCard';
+
+export default function EventChallenges({ eventId }: {eventId: number}) {
+  const { data, error } = useEventChallenges(eventId);
+  const { data : myChallenges, error : myError } = useMyChallenges(eventId);
+
+  const challengeProgressMap = useMemo(() => keyBy(myChallenges, (progress) => progress.challenge_id), [ myChallenges ]);
+
+  const [ searchQuery, setSearchQuery ] = useState('');
+
+  const filteredChallenges = useMemo(() => {
+    if (!data) return [];
+    return data.filter((challenge) => challenge.name.toLowerCase().includes(searchQuery.toLowerCase())
+      || challenge.summary.toLowerCase().includes(searchQuery.toLowerCase()));
+  }, [ data, searchQuery ]);
+
+  if (error) {
+    return (
+      <Container size="4">
+        <ErrorCallout>{error.message}</ErrorCallout>
+      </Container>
+    );
+  }
+
+  return (
+    <>
+      <Container size="2" mb="3">
+        <TextField.Root placeholder="Search challenges..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)}>
+          <TextField.Slot>
+            <TbSearch height="16" width="16" />
+          </TextField.Slot>
+        </TextField.Root>
+      </Container>
+      <Container size="4">
+        {myError && (<ErrorCallout className="mb-3">Failed to load your progress.</ErrorCallout>)}
+        <Grid columns={{ xs : '1', sm : '2', md : '3' }} gap="3">
+          {filteredChallenges.map((challenge) => (
+            <ChallengeCard
+              challenge={challenge}
+              progress={challengeProgressMap[challenge.id]}
+              key={challenge.id}
+            />
+          ))}
+        </Grid>
+      </Container>
+    </>
+  );
+}

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/NotAvailable.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/NotAvailable.tsx
@@ -1,0 +1,40 @@
+import { useEvent, useEventStatus } from '@/hooks/events';
+import {
+  Container,
+  Flex,
+  Heading,
+  Text,
+} from '@radix-ui/themes';
+import { TbCancel } from 'react-icons/tb';
+import { useParams } from 'react-router';
+import StartModal from 'routes/events/StartModal';
+
+export default function NotAvailable() {
+  const { idEvent } = useParams();
+  const { data : event } = useEvent(Number(idEvent));
+  const { isOngoing, isConcluded } = useEventStatus(Number(idEvent));
+
+  return (
+    <Container size="2" className="text-center">
+      <Flex direction="column" gap="2" align="center">
+        <TbCancel className="inline text-9xl my-8" />
+        <Heading size="5">
+          Challenges are not available at this time.
+        </Heading>
+        {!isOngoing && !isConcluded && event?.start_time && (
+          <Text size="3" color="gray">
+            The event will start on
+            {' '}
+            {event.start_time.toLocaleDateString()}
+            {' at '}
+            {event.start_time.toLocaleTimeString()}
+            .
+          </Text>
+        )}
+        {isOngoing && (
+          <StartModal eventId={Number(idEvent)} />
+        )}
+      </Flex>
+    </Container>
+  );
+}

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/index.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/index.tsx
@@ -1,79 +1,19 @@
-import { useEventChallenges, useMyChallenges } from '@/hooks/challenge';
-import { useMyTeam } from '@/hooks/events';
-import {
-  Container,
-  Grid,
-  Text,
-  TextField,
-} from '@radix-ui/themes';
-import { ErrorCallout } from 'components/Callouts';
-import { keyBy } from 'lodash';
-import { useMemo, useState } from 'react';
-import { TbCancel, TbSearch } from 'react-icons/tb';
+import RequireEventPermission from 'components/RequireEventPermission';
 import { useParams } from 'react-router';
-import ChallengeCard from './ChallengeCard';
+import EventChallenges from './EventChallenges';
+import NotAvailable from './NotAvailable';
 
 export default function ChallengesTab() {
   const { idEvent } = useParams<{idEvent: string}>();
-  const { data, error } = useEventChallenges(Number(idEvent));
-  const { data : myChallenges, error : myError } = useMyChallenges(Number(idEvent));
-
-  const challengeProgressMap = useMemo(() => keyBy(myChallenges, (progress) => progress.challenge_id), [ myChallenges ]);
-
-  const [ searchQuery, setSearchQuery ] = useState('');
-
-  const filteredChallenges = useMemo(() => {
-    if (!data) return [];
-    return data.filter((challenge) => challenge.name.toLowerCase().includes(searchQuery.toLowerCase())
-      || challenge.summary.toLowerCase().includes(searchQuery.toLowerCase()));
-  }, [ data, searchQuery ]);
-
-  // NAIVE PERMISSION CHECK - SHOULD BE BASED ON CAN_VIEW_CHALLENGES
-  // For now, just check if the user's team has a start timestamp
-  const { data : myTeam } = useMyTeam(Number(idEvent));
-  const challengesAvailable = myTeam?.start_timestamp;
-
-  if (!challengesAvailable) {
-    return (
-      <Container size="2" className="text-center">
-        <TbCancel className="inline text-9xl my-8" />
-        <br />
-        <Text size="3" color="gray">
-          Challenges are not available until your team has started the event.
-        </Text>
-      </Container>
-    );
-  }
-
-  if (error) {
-    return (
-      <Container size="4">
-        <ErrorCallout>{error.message}</ErrorCallout>
-      </Container>
-    );
-  }
+  const eventId = Number(idEvent);
 
   return (
-    <>
-      <Container size="2" mb="3">
-        <TextField.Root placeholder="Search challenges..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)}>
-          <TextField.Slot>
-            <TbSearch height="16" width="16" />
-          </TextField.Slot>
-        </TextField.Root>
-      </Container>
-      <Container size="4">
-        {myError && (<ErrorCallout className="mb-3">Failed to load your progress.</ErrorCallout>)}
-        <Grid columns={{ xs : '1', sm : '2', md : '3' }} gap="3">
-          {filteredChallenges.map((challenge) => (
-            <ChallengeCard
-              challenge={challenge}
-              progress={challengeProgressMap[challenge.id]}
-              key={challenge.id}
-            />
-          ))}
-        </Grid>
-      </Container>
-    </>
+    <RequireEventPermission
+      permission="CAN_VIEW_CHALLENGES"
+      eventId={eventId}
+      permissionDeniedPlaceholder={<NotAvailable />}
+    >
+      <EventChallenges eventId={eventId} />
+    </RequireEventPermission>
   );
 }

--- a/frontend/src/routes/events/OverviewTabs/LeaderboardTab/TeamPerformance.tsx
+++ b/frontend/src/routes/events/OverviewTabs/LeaderboardTab/TeamPerformance.tsx
@@ -1,0 +1,27 @@
+import { useMyTeamScore } from '@/hooks/scoring';
+import { useRegistration } from '@/hooks/users';
+import { Flex } from '@radix-ui/themes';
+import { ErrorCallout } from 'components/Callouts';
+import Statistic from 'components/Statistic';
+
+export default function TeamPerformance({ eventId }: {eventId: number}) {
+  const { isRegistered, error } = useRegistration(eventId);
+
+  // don't fetch score if not registered since we know it will fail
+  const { data : score, error : scoreError } = useMyTeamScore(isRegistered ? eventId : null);
+
+  if (error) {
+    return <ErrorCallout>{error.message}</ErrorCallout>;
+  }
+
+  if (isRegistered) {
+    return (
+      <>
+        {scoreError && <ErrorCallout>{scoreError.message}</ErrorCallout>}
+        <Flex direction="row" gap="3">
+          <Statistic value={score?.points ?? ''} label="Your Score" description={`Last updated ${score?.last_update.toLocaleString()}`} />
+        </Flex>
+      </>
+    );
+  }
+}

--- a/frontend/src/routes/events/OverviewTabs/LeaderboardTab/index.tsx
+++ b/frontend/src/routes/events/OverviewTabs/LeaderboardTab/index.tsx
@@ -1,25 +1,20 @@
 import { radixTheme } from '@/grid';
 import { useLeaderboard } from '@/hooks/events';
-import { useMyTeamScore } from '@/hooks/scoring';
 import { Container, Flex } from '@radix-ui/themes';
 import { AgGridReact } from 'ag-grid-react';
 import { ErrorCallout } from 'components/Callouts';
-import Statistic from 'components/Statistic';
 import { useParams } from 'react-router';
+import TeamPerformance from './TeamPerformance';
 
 export default function LeaderboardTab() {
   const { idEvent } = useParams();
-  const { data : myTeamScore, error : myTeamScoreError } = useMyTeamScore(Number(idEvent));
   const { data : leaderboard, error : leaderboardError } = useLeaderboard(Number(idEvent));
 
   return (
     <Container size="4">
       <Flex direction="column" gap="3">
-        <Flex direction="row" gap="3">
-          <Statistic value={myTeamScore?.points ?? ''} label="Your Score" description={`Last updated ${myTeamScore?.last_update.toLocaleString()}`} />
-        </Flex>
+        <TeamPerformance eventId={Number(idEvent)} />
 
-        {myTeamScoreError && <ErrorCallout>{myTeamScoreError.message}</ErrorCallout>}
         {leaderboardError && <ErrorCallout>{leaderboardError.message}</ErrorCallout>}
 
         <AgGridReact
@@ -38,7 +33,6 @@ export default function LeaderboardTab() {
             {
               headerName : 'Score',
               field : 'points',
-              sort : 'desc',
               cellClass : 'tabular-nums',
             },
             {
@@ -48,6 +42,11 @@ export default function LeaderboardTab() {
             },
           ]}
           theme={radixTheme}
+          defaultColDef={{
+            sortable : false, // disable sorting for all columns - server side sort is the source of truth
+            lockPinned : true,
+            suppressMovable : true,
+          }}
           pagination
           paginationPageSize={20}
           domLayout="autoHeight"

--- a/frontend/src/routes/events/OverviewTabs/TeamTab/index.tsx
+++ b/frontend/src/routes/events/OverviewTabs/TeamTab/index.tsx
@@ -1,14 +1,17 @@
-import { useMemo } from 'react';
+import { useMyTeam, useMyTeamMembers } from '@/hooks/events';
+import { useCurrentUser } from '@/hooks/users';
 import {
   Container,
   Flex,
   Table,
   Text,
 } from '@radix-ui/themes';
+import { ErrorCallout } from 'components/Callouts';
+import RequireEventPermission from 'components/RequireEventPermission';
+import RoleBadge from 'components/RoleBadge';
 import { find, isUndefined, map } from 'lodash';
+import { useMemo } from 'react';
 import { useParams } from 'react-router';
-import { useCurrentUser } from '@/hooks/users';
-import { useMyTeam, useMyTeamMembers } from '@/hooks/events';
 import AddMemberModal from './AddMemberModal';
 import AssignCaptainModal from './AssignCaptainModal';
 import EditTeamName from './EditTeamName';
@@ -30,29 +33,36 @@ export default function TeamManagement() {
     return false;
   }), [ fullMembersList, currentUser ]);
 
-  if (isUndefined(team) || teamError || isUndefined(fullMembersList) || fullMembersError) {
+  if (teamError || fullMembersError) {
     return (
-      <>
-        <Text as="p">Oops, something went wrong.</Text>
-        <Text as="p">{String(teamError)}</Text>
-        <Text as="p">{String(fullMembersError)}</Text>
-      </>
+      <Container size="4">
+        {teamError && <ErrorCallout>{teamError.message}</ErrorCallout>}
+        {fullMembersError && <ErrorCallout>{fullMembersError.message}</ErrorCallout>}
+      </Container>
     );
+  }
+
+  if (!team) {
+    // if team is still loading, show nothing
+    return null;
   }
 
   const { event_id : eventId, name : teamName } = team;
 
   return (
     <Container size="4">
-      <Flex gap="4" direction="column">
-        {
-          (userIsCaptain && !team.locked)
-            ? <EditTeamName eventId={eventId} defaultTeamName={teamName} />
-            : <Text className="pr-4">{`Team Name: ${teamName}`}</Text>
-        }
-        {!isUndefined(team.invite_code) && userIsCaptain && !team.locked
-          && <AddMemberModal inviteCode={team.invite_code} eventId={eventId} />}
-      </Flex>
+
+      <RequireEventPermission
+        permission="CAN_EDIT_TEAM"
+        eventId={eventId}
+        permissionDeniedPlaceholder={<Text>{`Team Name: ${teamName}`}</Text>}
+      >
+        <Flex gap="3" direction="row" justify="between">
+          <EditTeamName eventId={eventId} defaultTeamName={teamName} />
+          {!isUndefined(team.invite_code) && <AddMemberModal inviteCode={team.invite_code} eventId={eventId} />}
+        </Flex>
+      </RequireEventPermission>
+
       <Table.Root>
         <Table.Header>
           <Table.Row>
@@ -74,26 +84,29 @@ export default function TeamManagement() {
                   id === currentUser?.id ? `${name} (you)` : name
                 }
               </Table.RowHeaderCell>
-              <Table.Cell>{role}</Table.Cell>
+              <Table.Cell><RoleBadge value={role} /></Table.Cell>
               <Table.Cell>
                 <Flex as="span" align="center" gap="2">
-                  {
-                    !team.locked && (
-                      userIsCaptain && id !== currentUser?.id && (
-                        <>
-                          <RemovePlayerModal
-                            eventId={eventId}
-                            userId={id}
-                            name={name}
-                          />
-                          <AssignCaptainModal
-                            eventId={eventId}
-                            userId={id}
-                            name={name}
-                          />
-                        </>
-                      ))
-                  }
+                  <RequireEventPermission
+                    permission="CAN_EDIT_TEAM"
+                    eventId={eventId}
+                    permissionDeniedPlaceholder={null}
+                  >
+                    {id !== currentUser?.id && (
+                      <>
+                        <RemovePlayerModal
+                          eventId={eventId}
+                          userId={id}
+                          name={name}
+                        />
+                        <AssignCaptainModal
+                          eventId={eventId}
+                          userId={id}
+                          name={name}
+                        />
+                      </>
+                    )}
+                  </RequireEventPermission>
                   { !team.locked && id === currentUser?.id && (
                     <LeaveTeamModal
                       eventId={eventId}

--- a/frontend/src/routes/events/RegistrationLine.tsx
+++ b/frontend/src/routes/events/RegistrationLine.tsx
@@ -1,5 +1,5 @@
 import { COLOR_POSITIVE } from '@/constants';
-import { useMyEligibility } from '@/hooks/events';
+import { useEventStatus, useMyEligibility } from '@/hooks/events';
 import { useRegistration } from '@/hooks/users';
 import type { Event } from '@/types';
 import { Text } from '@radix-ui/themes';
@@ -7,12 +7,37 @@ import { TbCheck } from 'react-icons/tb';
 import RegistrationModal from './RegistrationModal';
 
 export default function RegistrationLine({ event }: {event: Event}) {
-  const { isRegistered, isUnregistered, team } = useRegistration(event.id);
+  const {
+    isRegistered, isUnregistered, isStarted, isFinished, team,
+  } = useRegistration(event.id);
+  const { isConcluded } = useEventStatus(event.id);
 
   // don't check eligibility if already registered since we know it will fail
   const { data : eligibility, error : eligibilityError } = useMyEligibility(isUnregistered ? event.id : null);
 
   if (isRegistered) {
+    if (isFinished || isConcluded) {
+      return (
+        <Text color={COLOR_POSITIVE}>
+          <TbCheck className="inline me-1" />
+          You
+          {event.max_team_size === 1 ? ' have ' : 'r team has '}
+          completed this event.
+        </Text>
+      );
+    }
+
+    if (isStarted) {
+      return (
+        <Text color={COLOR_POSITIVE}>
+          <TbCheck className="inline me-1" />
+          You are currently playing.
+          {team!.end_time
+          && ` You${event.max_team_size > 1 ? 'r team' : ''} will finish at ${team!.end_time.toLocaleString()}.`}
+        </Text>
+      );
+    }
+
     return (
       <Text color={COLOR_POSITIVE}>
         <TbCheck className="inline me-1" />

--- a/frontend/src/routes/events/StartModal.tsx
+++ b/frontend/src/routes/events/StartModal.tsx
@@ -1,37 +1,66 @@
 import { COLOR_POSITIVE } from '@/constants';
-import { startMyTeam, useMyTeam } from '@/hooks/events';
-import { Button } from '@radix-ui/themes';
+import { startMyTeam, useEvent } from '@/hooks/events';
+import { useRegistration } from '@/hooks/users';
+import { Box, Button, Text } from '@radix-ui/themes';
 import Modal from 'components/Modal';
+import RequireEventPermission from 'components/RequireEventPermission';
 import { TbPlayerPlay } from 'react-icons/tb';
 
 export default function StartModal({ eventId }: {eventId: number}) {
-  const { data : myTeam } = useMyTeam(eventId);
+  const { isUnregistered, isFinished } = useRegistration(eventId);
+  const { data : event } = useEvent(eventId);
+  const isIndividual = (event?.max_team_size || 1) === 1;
+
   const handleStart = async () => startMyTeam(eventId);
 
-  if (!myTeam) return null;
-
-  if (myTeam?.start_timestamp) {
-    return (
-      <Button disabled>
-        <TbPlayerPlay />
-        Started
-      </Button>
-    );
-  }
+  if (isUnregistered) return null;
 
   return (
-    <Modal
-      trigger={(
-        <Button color={COLOR_POSITIVE} className="pulsate">
-          <TbPlayerPlay />
-          Start
-        </Button>
+    <RequireEventPermission
+      eventId={eventId}
+      permission="CAN_START_TEAM_TIMER"
+      permissionDeniedPlaceholder={(
+        <Text size="3" color="gray">
+          {isFinished
+            ? 'You have completed this event.'
+            : 'Waiting for your team captain to start the event.'}
+        </Text>
       )}
-      title="Start Event"
-      description="Are you sure you want to start playing this event?"
-      submitVerb="Start"
-      submitColor={COLOR_POSITIVE}
-      onSubmit={handleStart}
-    />
+    >
+      <Box>
+        <Text size="3" color="gray">
+          When
+          {' '}
+          {isIndividual ? 'you are' : 'your team is'}
+          {' '}
+          ready to start the event, press the start button below.
+        </Text>
+        {event?.time_limit_minutes && (
+          <>
+            <br />
+            <Text color="gray" size="3">
+              You will have
+              {' '}
+              {event?.time_limit_minutes || 'N/A'}
+              {' '}
+              minutes to complete as many challenges as possible.
+            </Text>
+          </>
+        ) }
+      </Box>
+      <Modal
+        trigger={(
+          <Button color={COLOR_POSITIVE} className="pulsate">
+            <TbPlayerPlay />
+            Start Event
+          </Button>
+      )}
+        title="Start Event"
+        description="Are you sure you want to start this event?"
+        submitVerb="Start"
+        submitColor={COLOR_POSITIVE}
+        onSubmit={handleStart}
+      />
+    </RequireEventPermission>
   );
 }

--- a/frontend/src/routes/events/challenge/ChallengeQuestion.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeQuestion.tsx
@@ -17,7 +17,9 @@ import {
   type AccentColor,
 } from '@/constants';
 import { submitFlag } from '@/hooks/challenge';
+import { useEventPermission } from '@/hooks/permissions';
 import type { Attempt, Question } from '@/types';
+import RequireEventPermission from 'components/RequireEventPermission';
 import { startCase } from 'lodash';
 import { useCallback } from 'react';
 
@@ -33,6 +35,8 @@ export default function ChallengeQuestion({
   const {
     id, name, points, body, max_attempts : maxAttempts, placeholder, challenge_id : challengeId,
   } = question;
+
+  const { denied } = useEventPermission('CAN_PLAY_CHALLENGES', eventId);
 
   const handleSubmit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -98,7 +102,7 @@ export default function ChallengeQuestion({
                 placeholder={placeholder}
                 required
                 autoComplete="off"
-                disabled={status === 'correct' || attemptsRemaining <= 0}
+                disabled={status === 'correct' || attemptsRemaining <= 0 || denied}
               >
                 <TextField.Slot>
                   <TbFlag2 className={twMerge(status !== 'unanswered' && 'text-(--accent-10)')} />
@@ -108,11 +112,13 @@ export default function ChallengeQuestion({
             <Form.Message match="valueMissing">Flag cannot be empty</Form.Message>
           </Form.Field>
 
-          {status !== 'correct' && attemptsRemaining > 0 && (
+          <RequireEventPermission eventId={eventId} permission="CAN_PLAY_CHALLENGES" permissionDeniedPlaceholder={null}>
+            {status !== 'correct' && attemptsRemaining > 0 && (
             <Button variant="soft" size="2" type="submit" color={color || COLOR_QUESTION}>
               Submit
             </Button>
-          )}
+            )}
+          </RequireEventPermission>
         </Flex>
       </Form.Root>
 

--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -1,5 +1,6 @@
 import { useChallenge } from '@/hooks/challenge';
 import { useEvent } from '@/hooks/events';
+import { useEventPermission } from '@/hooks/permissions';
 import {
   Box,
   Button,
@@ -34,6 +35,8 @@ export default function ChallengeSidebar() {
   const {
     challenge, questions, hints, attempts,
   } = data || {};
+
+  const { granted } = useEventPermission('CAN_PLAY_CHALLENGE', Number(idEvent));
 
   const groupedAttempts = groupBy(attempts || [], 'question_id');
 
@@ -83,7 +86,7 @@ export default function ChallengeSidebar() {
               </Box>
             )}
 
-            {challenge && event && (
+            {challenge && event && granted && (
               <Flex direction="row" gap="2" mt="3" align="center">
                 <ConnectModal eventId={event.id} challengeId={challenge.id} />
                 <Button variant="ghost" className="!m-0 !p-2" color="gray">


### PR DESCRIPTION
Improve loading and permission check behavior for event pages, as well as some logic improvements to the dashboard. More refinement to come.

Added a `RequireEventPermission` component to conditionally show its contents based on a permission, which is used when possible throughout the event page instead of replicating backend business logic.

The team start button has been moved to the challenges tab, and more descriptive text has been added for when challenges are not available. (i.e. to explain to team members that their captain needs to start.)

The leaderboard's "team performance" area is removed when unauthenticated or unregistered, since it will produce errors otherwise.

Cleaned up error handling and loading states for the team page to avoid layout shift/flicker, as well as moving to the CAN_EDIT_TEAM permission for showing team administration operations. Also now using role badges instead of raw text.

Challenge input fields are disabled and submit/start buttons are removed when the CAN_PLAY_CHALLENGES permission is not granted.

Dashboard shows events in its header for events that are active (ready to start, started, or team time up but event still in progress.) It now uses wider EventCards instead of the EventHeader component to differentiate it from event pages, since they were easily mixed up due to having identical header layouts.

Note that there is still no way to edit name or leave for individual events - see #235