### PR TITLE
Fix team invite url generation

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -13,7 +13,7 @@ import {
 
 export type AccentColor = (typeof accentColors)[number];
 
-export const ROUTEPREFIX: string = '/';
+export const ROUTEPREFIX: string = '';
 export const APIPREFIX: string = '/ng';
 export const SSOPATH: string = '/ng/authenticate/okta/login';
 


### PR DESCRIPTION
Invite URLs generated by the "Add Member" modal were getting an extra slash due to `ROUTEPREFIX` being set to `/` instead of empty (for no prefix), which caused invite URLs to not work properly.