### PR TITLE
Minor nav menu fixes

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -23,6 +23,7 @@ export default function NavBar() {
   const { theme } = useTheme(); // Drop Content wouldn't obey otherwise
 
   const defaultLinkClass = `
+    h-full
     p-2
     hover:bg-(--gray-3)
     dark:hover:bg-(--gray-3)
@@ -31,6 +32,7 @@ export default function NavBar() {
     dark:text-(--gray-a11)`;
 
   const activeLinkClass = `
+    h-full
     p-2
     hover:bg-(--gray-3)
     dark:hover:bg-(--gray-3)
@@ -106,10 +108,12 @@ export default function NavBar() {
             </NavigationMenu.Item>
           </NavLink>
 
-          <NotificationsPopover
-            triggerClassName={defaultLinkClass}
-            contentClassName={twMerge(contentBase, theme === 'dark' ? contentDark : contentLight)}
-          />
+          {isAuthenticated && (
+            <NotificationsPopover
+              triggerClassName={defaultLinkClass}
+              contentClassName={twMerge(contentBase, theme === 'dark' ? contentDark : contentLight)}
+            />
+          )}
 
           <NavigationMenu.Item>
             <NavigationMenu.Trigger


### PR DESCRIPTION
- Ensures nav items are `h-full` - fixes some alignment issues with icon-only nav items (i.e. user menu when not signed in)

Before:
<img width="168" height="56" alt="image" src="https://github.com/user-attachments/assets/5248a740-da3c-47fe-8595-d661b87ce5e3" />

After:
<img width="195" height="61" alt="image" src="https://github.com/user-attachments/assets/42d32254-0430-4829-bda5-6bc6021cd369" />

- Hides the notification bell if not logged in, since the associated notification endpoints won't work in that case:

<img width="179" height="65" alt="image" src="https://github.com/user-attachments/assets/4264dad2-143e-4f0a-a2e0-483fa4b08dc9" />
