### PR TITLE
Challenge update modal and YAML download

### DIFF
--- a/backend/ng/challenge/models/ContainerBlueprint.py
+++ b/backend/ng/challenge/models/ContainerBlueprint.py
@@ -44,6 +44,7 @@ class ContainerBlueprint(db.Model):
         """
         return {
             "id": self.id,
+            "name": self.name,
             "image": self.image,
             "hostname": self.hostname,
             "stdin_open": self.stdin_open,
@@ -117,6 +118,7 @@ class ContainerBlueprint(db.Model):
     @classmethod
     def create_container_blueprint(
         cls,
+        name: str,
         image: str,
         hostname: str,
         challenge_id: int,
@@ -136,6 +138,7 @@ class ContainerBlueprint(db.Model):
         try:
             ## Removed the validator as it currently does not support lists
             validated_data = {
+                    "name": name,
                     "image": image,
                     "hostname": hostname,
                     "challenge_id": challenge_id,

--- a/backend/ng/challenge/routes/admin_routes.py
+++ b/backend/ng/challenge/routes/admin_routes.py
@@ -1,6 +1,8 @@
 from flask_restx import Namespace, Resource
 import multiprocessing
 
+from ...event.controllers.admin.update_challenge_from_yaml import update_challenge_from_yaml
+
 from ...core.middleware.loaders.load_challenge import load_challenge
 from ...core.middleware.loaders._util import LoaderType
 from ...core.middleware.auth import admin_endpoint
@@ -33,6 +35,26 @@ class ChallengeDetail(Resource):
         Get detailed information about a specific challenge
         """
         return success_response(challenge)
+
+    @admin_endpoint(json_required=True)
+    @load_challenge(source = LoaderType.PARAM)
+    def put(self, challenge, json_data, **kwargs):
+        """
+        Update a specific challenge from YAML.
+        """
+        updated_challenge = update_challenge_from_yaml(challenge.id, json_data)
+        return success_response(updated_challenge)
+
+@challenge_admin_namespace.route("/<int:challenge_id>/yaml")
+class ChallengeYAML(Resource):
+    @admin_endpoint()
+    @load_challenge(source = LoaderType.PARAM)
+    def get(self, challenge: Challenge, **kwargs):
+        """
+        Get the YAML representation of a specific challenge
+        """
+        yaml_data = challenge.yaml.body
+        return success_response({"yaml": yaml_data})
 
 @challenge_admin_namespace.route("/<int:challenge_id>/questions")
 class ChallengeQuestions(Resource):

--- a/backend/ng/event/controllers/admin/import_challenge_from_yaml.py
+++ b/backend/ng/event/controllers/admin/import_challenge_from_yaml.py
@@ -121,8 +121,9 @@ def import_challenge_from_yaml(event: Event, json_data) -> Challenge:
             if isinstance(question.answer, ParserTemplate):
                 db_variable_questions[question.answer.parent_variable] = db_question
 
-        for service_data in services.values():
+        for (service_name, service_data) in services.items():
             ContainerBlueprint.create_container_blueprint(
+                name=service_name,
                 challenge_id=challenge.id,
                 image=service_data.image,
                 hostname=service_data.hostname,

--- a/backend/ng/event/controllers/admin/update_challenge_from_yaml.py
+++ b/backend/ng/event/controllers/admin/update_challenge_from_yaml.py
@@ -144,7 +144,7 @@ def update_challenge_from_yaml(challenge_id: int, json_data: dict[str, Any]) -> 
                 if isinstance(question.answer, ParserTemplate):
                     db_variable_questions[question.answer.parent_variable] = db_question
 
-        blueprints = {blueprint.hostname: blueprint for blueprint in challenge.blueprints}
+        blueprints = {blueprint.name: blueprint for blueprint in challenge.blueprints}
         if compose_file.services:
             for (service_name, service_data) in compose_file.services.items():
                 if service_name in blueprints:
@@ -165,6 +165,7 @@ def update_challenge_from_yaml(challenge_id: int, json_data: dict[str, Any]) -> 
                 else:
                     ContainerBlueprint.create_container_blueprint(
                         challenge_id=challenge.id,
+                        name=service_name,
                         image=service_data.image,
                         hostname=service_data.hostname,
                         stdin_open=service_data.stdin_open,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,12 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@codemirror/lang-yaml": "^6.1.2",
     "@milkdown/crepe": "^7.15.0",
     "@milkdown/plugin-automd": "^7.15.0",
     "@milkdown/plugin-listener": "^7.15.0",
     "@milkdown/react": "^7.15.0",
     "@milkdown/theme-nord": "^7.15.0",
     "@radix-ui/themes": "^3.2.1",
+    "@uiw/react-codemirror": "^4.25.2",
     "ag-grid-community": "^33.3.2",
     "ag-grid-react": "^33.3.2",
     "lodash": "^4.17.21",

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -72,6 +72,8 @@ export default function Modal<T extends FieldValues>({
 
       <Dialog.Content
         className={twMerge('flex flex-col gap-3', className)}
+        // clear tabIndex to ensure compatibility with CodeMirror's focus management
+        tabIndex={undefined}
         // aria-describedby should be set to undefined if no description is provided, otherwise it should not be set at all.
         // as far as i know, prop spreading is the only way to accomplish this.
         {

--- a/frontend/src/components/YamlEditor.tsx
+++ b/frontend/src/components/YamlEditor.tsx
@@ -1,0 +1,79 @@
+import { yaml } from '@codemirror/lang-yaml';
+import { Button } from '@radix-ui/themes';
+import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
+import { useTheme } from 'next-themes';
+import type { Ref } from 'react';
+import Dropzone from 'react-dropzone';
+import { TbUpload } from 'react-icons/tb';
+import { twMerge } from 'tailwind-merge';
+
+export default function YamlEditor({
+  value, onChange, ref, ...rest
+}: {value: string, onChange: (v: string) => void, ref?: Ref<ReactCodeMirrorRef>}) {
+  const theme = useTheme();
+
+  return (
+    <Dropzone
+      onDrop={(files) => {
+        if (files.length > 0) {
+          const file = files[0];
+          file.text().then((content) => {
+            onChange(content);
+          });
+        }
+      }}
+      accept={{
+        'application/yaml' : [ '.yaml', '.yml' ],
+      }}
+      multiple={false}
+      noClick
+    >
+      {({
+        getRootProps, getInputProps, isDragActive, open,
+      }) => (
+        <>
+          {/* {JSON.stringify(watch())} */}
+          <div
+            {...getRootProps()}
+            tabIndex={-1}
+            className={twMerge(
+              'relative rounded overflow-clip ',
+              isDragActive && '!ring-2 !ring-(--accent-8) relative after:absolute after:inset-0 after:bg-(--accent-a4)',
+            )}
+          >
+
+            <CodeMirror
+              value={value}
+              height="546px"
+              extensions={[ yaml() ]}
+              theme={theme.resolvedTheme === 'dark' ? 'dark' : 'light'}
+              basicSetup={{
+                dropCursor : false,
+              }}
+              onChange={onChange}
+              placeholder="Drop, paste, or type your YAML here..."
+              ref={ref}
+              {...rest}
+            />
+            <Button
+              color="gray"
+              variant="ghost"
+              className="!absolute !bottom-2 !right-2 !m-0"
+              onClick={open}
+              type="button"
+            >
+              <TbUpload />
+              Upload File
+            </Button>
+          </div>
+          <input
+            {...getInputProps()}
+            name="file"
+            aria-hidden
+          />
+        </>
+      )}
+    </Dropzone>
+
+  );
+}

--- a/frontend/src/components/YamlEditor.tsx
+++ b/frontend/src/components/YamlEditor.tsx
@@ -9,7 +9,9 @@ import { twMerge } from 'tailwind-merge';
 
 export default function YamlEditor({
   value, onChange, ref, ...rest
-}: {value: string, onChange: (v: string) => void, ref?: Ref<ReactCodeMirrorRef>}) {
+} : {
+  value: string, onChange: (v: string) => void, ref?: Ref<ReactCodeMirrorRef>
+}) {
   const theme = useTheme();
 
   return (
@@ -32,7 +34,6 @@ export default function YamlEditor({
         getRootProps, getInputProps, isDragActive, open,
       }) => (
         <>
-          {/* {JSON.stringify(watch())} */}
           <div
             {...getRootProps()}
             tabIndex={-1}
@@ -41,7 +42,6 @@ export default function YamlEditor({
               isDragActive && '!ring-2 !ring-(--accent-8) relative after:absolute after:inset-0 after:bg-(--accent-a4)',
             )}
           >
-
             <CodeMirror
               value={value}
               height="546px"

--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -91,6 +91,12 @@ export function useAdminEventChallenges(eventId: number | null) {
   );
 }
 
+export function useAdminChallengeYaml(challengeId: number | null) {
+  return useSWR<{ yaml: string }, Error>(
+    challengeId ? `/admin/challenges/${challengeId}/yaml` : null,
+  );
+}
+
 export function useAdminChallengeAttempts(challengeId: number | null) {
   return useSWR<Attempt[], Error>(
     challengeId ? `/admin/challenges/${challengeId}/attempts` : null,
@@ -121,5 +127,19 @@ export function createChallenge(eventId: number, yaml: string) {
   }).then(() => {
     // refresh the challenges list when a new challenge is created
     mutate(`/admin/events/${eventId}/challenges`);
+  });
+}
+
+export function updateChallenge(challengeId: number, yaml: string) {
+  return apiMutation(`/admin/challenges/${challengeId}`, { yaml : btoa(yaml) }, {
+    method : 'PUT',
+  }).then(() => {
+    // refresh the challenges list when a challenge is updated
+    mutate('/admin/challenges');
+    mutate(`/admin/challenges/${challengeId}/yaml`);
+    mutate(`/admin/challenges/${challengeId}/questions`);
+    mutate(`/admin/challenges/${challengeId}/hints`);
+    mutate(`/admin/challenges/${challengeId}/blueprints`);
+    if (reason) mutate('/notifications/me');
   });
 }

--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -140,6 +140,5 @@ export function updateChallenge(challengeId: number, yaml: string) {
     mutate(`/admin/challenges/${challengeId}/questions`);
     mutate(`/admin/challenges/${challengeId}/hints`);
     mutate(`/admin/challenges/${challengeId}/blueprints`);
-    if (reason) mutate('/notifications/me');
   });
 }

--- a/frontend/src/routes/admin/challenges/ChallengeDownloadButton.tsx
+++ b/frontend/src/routes/admin/challenges/ChallengeDownloadButton.tsx
@@ -1,0 +1,38 @@
+import { COLOR_POSITIVE } from '@/constants';
+import { useAdminChallengeYaml } from '@/hooks/challenge';
+import type { Challenge } from '@/types';
+import { Button } from '@radix-ui/themes';
+import { TbDownload } from 'react-icons/tb';
+
+export default function ChallengeDownloadButton({ challenge }: { challenge: Challenge }) {
+  const { data, error, isLoading } = useAdminChallengeYaml(challenge.id);
+
+  /**
+   * Download the YAML via Blob object URL.
+   */
+  const handleDownload = () => {
+    // if the yaml hasn't loaded yet, do nothing - the button should be disabled at that point
+    if (data?.yaml) {
+      const element = document.createElement('a');
+      const file = new Blob([ data.yaml ], { type : 'application/yaml' });
+      element.href = URL.createObjectURL(file);
+      element.download = `${challenge.name}.yaml`;
+      document.body.appendChild(element);
+      element.click();
+      document.body.removeChild(element);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="soft"
+      color={COLOR_POSITIVE}
+      disabled={isLoading || !!error}
+      onClick={handleDownload}
+    >
+      <TbDownload />
+      Download
+    </Button>
+  );
+}

--- a/frontend/src/routes/admin/challenges/ChallengeSidebar.tsx
+++ b/frontend/src/routes/admin/challenges/ChallengeSidebar.tsx
@@ -1,19 +1,15 @@
-import {
-  COLOR_INFO,
-  COLOR_POSITIVE,
-  COLOR_WARNING,
-  EventIcon,
-} from '@/constants';
+import { COLOR_INFO, EventIcon } from '@/constants';
 import type { Challenge } from '@/types';
 import { Button, Tabs } from '@radix-ui/themes';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import ChallengeIcon from 'components/ChallengeIcon';
-import { TbDownload, TbPencil } from 'react-icons/tb';
 import { Link, useSearchParams } from 'react-router';
 import ChallengeAttemptsTab from './SidebarTabs/ChallengeAttemptsTab';
 import ChallengeBlueprintTab from './SidebarTabs/ChallengeBlueprintTab';
 import ChallengeDetailsTab from './SidebarTabs/ChallengeDetailsTab';
+import ChallengeUpdateModal from './ChallengeUpdateModal';
+import ChallengeDownloadButton from './ChallengeDownloadButton';
 
 export default function ChallengeSidebar({ entity }: {entity: Challenge}) {
   const [ searchParams, setSearchParams ] = useSearchParams();
@@ -27,14 +23,8 @@ export default function ChallengeSidebar({ entity }: {entity: Challenge}) {
             Event
           </Link>
         </Button>
-        <Button variant="soft" color={COLOR_WARNING}>
-          <TbPencil />
-          Update
-        </Button>
-        <Button variant="soft" color={COLOR_POSITIVE}>
-          <TbDownload />
-          Download
-        </Button>
+        <ChallengeUpdateModal challengeId={entity.id} />
+        <ChallengeDownloadButton challenge={entity} />
       </AdminSidebarHeader>
 
       <Tabs.Root

--- a/frontend/src/routes/admin/challenges/ChallengeUpdateModal.tsx
+++ b/frontend/src/routes/admin/challenges/ChallengeUpdateModal.tsx
@@ -1,0 +1,52 @@
+import { COLOR_WARNING } from '@/constants';
+import { updateChallenge, useAdminChallengeYaml } from '@/hooks/challenge';
+import { Button } from '@radix-ui/themes';
+import Modal from 'components/Modal';
+import YamlEditor from 'components/YamlEditor';
+import { Controller } from 'react-hook-form';
+import { TbPencil } from 'react-icons/tb';
+
+export default function ChallengeUpdateModal({ challengeId }: { challengeId: number }) {
+  const { data : yaml, error, isLoading } = useAdminChallengeYaml(challengeId);
+
+  return (
+    <Modal
+      title="Update Challenge"
+      trigger={(
+        <Button variant="soft" color={COLOR_WARNING} disabled={!!error || isLoading}>
+          <TbPencil />
+          Update
+        </Button>
+      )}
+      submitVerb="Update"
+      submitColor={COLOR_WARNING}
+      onSubmit={async (data: {yaml: string}) => {
+        if (yaml?.yaml !== data.yaml) {
+          // if the yaml has changed, update it
+          return updateChallenge(challengeId, data.yaml);
+        }
+        return Promise.resolve();
+      }}
+      defaultValues={{
+        yaml : yaml?.yaml,
+      }}
+      className="!max-w-[80ch]"
+    >
+      {({ control }) => (
+        <Controller
+          control={control}
+          name="yaml"
+          render={
+            ({ field }) => (
+              <YamlEditor
+                value={field.value}
+                onChange={field.onChange}
+                ref={field.ref}
+              />
+            )
+          }
+        />
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/routes/admin/challenges/index.tsx
+++ b/frontend/src/routes/admin/challenges/index.tsx
@@ -23,7 +23,7 @@ const colDefs: ColDef<Challenge>[] = [
         <span className="min-w-0 overflow-hidden text-ellipsis">{params.value}</span>
       </>
     ),
-    cellClass : '!flex flex-row items-center gap-1 ',
+    cellClass : '!flex flex-row items-center gap-1',
     filter : true,
     floatingFilter : true,
   },

--- a/frontend/src/routes/admin/events/ChallengeUploadModal.tsx
+++ b/frontend/src/routes/admin/events/ChallengeUploadModal.tsx
@@ -1,20 +1,12 @@
 import { COLOR_POSITIVE } from '@/constants';
 import { createChallenge } from '@/hooks/challenge';
-import {
-  Button,
-  Callout,
-  Code,
-  Heading,
-  Text,
-} from '@radix-ui/themes';
+import { Button } from '@radix-ui/themes';
 import Modal from 'components/Modal';
-import { useState } from 'react';
-import Dropzone from 'react-dropzone';
-import { TbPlus, TbUpload } from 'react-icons/tb';
+import YamlEditor from 'components/YamlEditor';
+import { Controller } from 'react-hook-form';
+import { TbPlus } from 'react-icons/tb';
 
 export default function ChallengeUploadModal({ eventId }: { eventId: number }) {
-  const [ fileContent, setFileContent ] = useState<string | null>(null);
-
   return (
     <Modal
       title="Add Challenge"
@@ -26,55 +18,26 @@ export default function ChallengeUploadModal({ eventId }: { eventId: number }) {
         </Button>
       )}
       submitVerb="Upload"
-      submitDisabled={!fileContent}
-      onSubmit={async () => {
-        if (!fileContent) throw new Error('No file content to submit');
-        return createChallenge(eventId, fileContent).then(() => {
-          setFileContent(null);
-        });
+      onSubmit={async ({ yaml }: {yaml: string}) => {
+        if (!yaml) throw new Error('No file content to submit');
+        return createChallenge(eventId, yaml);
       }}
-      onOpenChange={(open) => {
-        if (open) {
-          setFileContent(null);
-        }
-      }}
+      className="!max-w-[80ch]"
     >
-      <Dropzone
-        onDrop={(files) => {
-          if (files.length > 0) {
-            const file = files[0];
-            file.text().then((content) => {
-              setFileContent(content);
-            }).catch(() => {
-              setFileContent(null);
-            });
+      {({ control }) => (
+        <Controller
+          control={control}
+          name="yaml"
+          render={
+            ({ field }) => (
+              <YamlEditor
+                value={field.value}
+                onChange={field.onChange}
+                ref={field.ref}
+              />
+            )
           }
-        }}
-        accept={{
-          'application/yaml' : [ '.yaml', '.yml' ],
-        }}
-        multiple={false}
-      >
-        {({ getRootProps, getInputProps, isDragActive }) => (
-          <Callout.Root
-            {...getRootProps()}
-            variant={(isDragActive) ? 'surface' : 'outline'}
-            className="cursor-pointer !p-8 !flex flex-col !items-center"
-          >
-            <input
-              {...getInputProps()}
-              name="file"
-            />
-            <Heading size="6"><TbUpload /></Heading>
-            <Text>Drag and drop a YAML file here, or click to select one.</Text>
-          </Callout.Root>
-        )}
-      </Dropzone>
-
-      {fileContent && (
-        <Code className="block !p-2 whitespace-pre-wrap !h-64 overflow-auto" color="gray">
-          {fileContent}
-        </Code>
+        />
       )}
     </Modal>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   frontend:
     dependencies:
+      '@codemirror/lang-yaml':
+        specifier: ^6.1.2
+        version: 6.1.2
       '@milkdown/crepe':
         specifier: ^7.15.0
         version: 7.16.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.2)(typescript@5.8.3)
@@ -23,13 +26,16 @@ importers:
         version: 7.16.0
       '@milkdown/react':
         specifier: ^7.15.0
-        version: 7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
+        version: 7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
       '@milkdown/theme-nord':
         specifier: ^7.15.0
         version: 7.16.0
       '@radix-ui/themes':
         specifier: ^3.2.1
         version: 3.2.1(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@uiw/react-codemirror':
+        specifier: ^4.25.2
+        version: 4.25.2(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.18.7)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ag-grid-community:
         specifier: ^33.3.2
         version: 33.3.2
@@ -234,6 +240,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
@@ -337,8 +347,8 @@ packages:
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
-  '@codemirror/view@6.38.2':
-    resolution: {integrity: sha512-bTWAJxL6EOFLPzTx+O5P5xAO3gTqpatQ2b/ARQ8itfU/v2LlpS3pH2fkL0A3E/Fx8Y2St2KES7ZEV0sHTsSW/A==}
+  '@codemirror/view@6.38.6':
+    resolution: {integrity: sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==}
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -1759,6 +1769,28 @@ packages:
   '@typescript-eslint/visitor-keys@8.42.0':
     resolution: {integrity: sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@uiw/codemirror-extensions-basic-setup@4.25.2':
+    resolution: {integrity: sha512-s2fbpdXrSMWEc86moll/d007ZFhu6jzwNu5cWv/2o7egymvLeZO52LWkewgbr+BUCGWGPsoJVWeaejbsb/hLcw==}
+    peerDependencies:
+      '@codemirror/autocomplete': '>=6.0.0'
+      '@codemirror/commands': '>=6.0.0'
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
+      '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/react-codemirror@4.25.2':
+    resolution: {integrity: sha512-XP3R1xyE0CP6Q0iR0xf3ed+cJzJnfmbLelgJR6osVVtMStGGZP3pGQjjwDRYptmjGHfEELUyyBLdY25h0BQg7w==}
+    peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -3932,6 +3964,8 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/runtime@7.28.4': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -3964,14 +3998,14 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.3
 
   '@codemirror/commands@6.8.1':
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.3
 
   '@codemirror/lang-angular@0.1.4':
@@ -4011,7 +4045,7 @@ snapshots:
       '@codemirror/lang-javascript': 6.2.4
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.3
       '@lezer/css': 1.3.0
       '@lezer/html': 1.3.10
@@ -4027,7 +4061,7 @@ snapshots:
       '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.8.5
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.3
       '@lezer/javascript': 1.5.1
 
@@ -4050,7 +4084,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.9
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
@@ -4061,7 +4095,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.9
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.3
       '@lezer/markdown': 1.4.3
 
@@ -4124,7 +4158,7 @@ snapshots:
       '@codemirror/autocomplete': 6.18.7
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.3
       '@lezer/xml': 1.0.6
 
@@ -4166,7 +4200,7 @@ snapshots:
   '@codemirror/language@6.11.3':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
@@ -4179,13 +4213,13 @@ snapshots:
   '@codemirror/lint@6.8.5':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       crelt: 1.0.6
 
   '@codemirror/search@6.5.11':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       crelt: 1.0.6
 
   '@codemirror/state@6.5.2':
@@ -4196,10 +4230,10 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@lezer/highlight': 1.2.1
 
-  '@codemirror/view@6.38.2':
+  '@codemirror/view@6.38.6':
     dependencies:
       '@codemirror/state': 6.5.2
       crelt: 1.0.6
@@ -4472,11 +4506,11 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@milkdown/components@7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)(typescript@5.8.3)':
+  '@milkdown/components@7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(typescript@5.8.3)':
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
       '@floating-ui/dom': 1.7.4
       '@milkdown/core': 7.16.0
       '@milkdown/ctx': 7.16.0
@@ -4517,8 +4551,8 @@ snapshots:
       '@codemirror/language-data': 6.5.1
       '@codemirror/state': 6.5.2
       '@codemirror/theme-one-dark': 6.1.3
-      '@codemirror/view': 6.38.2
-      '@milkdown/kit': 7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)(typescript@5.8.3)
+      '@codemirror/view': 6.38.6
+      '@milkdown/kit': 7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(typescript@5.8.3)
       '@types/lodash-es': 4.17.12
       clsx: 2.1.1
       codemirror: 6.0.2
@@ -4541,9 +4575,9 @@ snapshots:
 
   '@milkdown/exception@7.16.0': {}
 
-  '@milkdown/kit@7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)(typescript@5.8.3)':
+  '@milkdown/kit@7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(typescript@5.8.3)':
     dependencies:
-      '@milkdown/components': 7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)(typescript@5.8.3)
+      '@milkdown/components': 7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(typescript@5.8.3)
       '@milkdown/core': 7.16.0
       '@milkdown/ctx': 7.16.0
       '@milkdown/plugin-block': 7.16.0
@@ -4718,10 +4752,10 @@ snapshots:
       prosemirror-transform: 1.10.4
       prosemirror-view: 1.41.2
 
-  '@milkdown/react@7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.8.3)':
+  '@milkdown/react@7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.8.3)':
     dependencies:
       '@milkdown/crepe': 7.16.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.2)(typescript@5.8.3)
-      '@milkdown/kit': 7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)(typescript@5.8.3)
+      '@milkdown/kit': 7.16.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(typescript@5.8.3)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
@@ -5853,6 +5887,33 @@ snapshots:
       '@typescript-eslint/types': 8.42.0
       eslint-visitor-keys: 4.2.1
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.2(@codemirror/autocomplete@6.18.7)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.7
+      '@codemirror/commands': 6.8.1
+      '@codemirror/language': 6.11.3
+      '@codemirror/lint': 6.8.5
+      '@codemirror/search': 6.5.11
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.6
+
+  '@uiw/react-codemirror@4.25.2(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.18.7)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@codemirror/commands': 6.8.1
+      '@codemirror/state': 6.5.2
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.38.6
+      '@uiw/codemirror-extensions-basic-setup': 4.25.2(@codemirror/autocomplete@6.18.7)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)
+      codemirror: 6.0.2
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -6175,7 +6236,7 @@ snapshots:
       '@codemirror/lint': 6.8.5
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.2
+      '@codemirror/view': 6.38.6
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
Closes #221.

Modal for updating existing challenges in the system, as well as a button to download the YAML content of a challenge as a file. Also includes a backend fix to properly update container blueprints based on name matching instead of creating new ones with each update.

<img width="808" height="45" alt="image" src="https://github.com/user-attachments/assets/e6e2dc92-2941-4573-ba91-d714a5a49ff2" />

<img width="822" height="694" alt="image" src="https://github.com/user-attachments/assets/ef621097-4486-4c86-8a2f-958092fa635e" />

The modal uses `react-codemirror` for YAML editing, which handles highlighting, indentation, etc. - we can eventually connect to our challenge linting output to codemirror's parse tree for lint highlighting as well. The editor is wrapped with `react-dropzone` to allow dragging files in, as well as selecting a file via the upload button in the corner.

As a code editor, codemirror captures tab events when focused for indentation purposes - to keyboard-navigate out of codemirror, users need to press Ctrl+M first to switch from tab indentation to navigation.

This PR also reworks the existing challenge upload modal to use this same editor for consistency. Eventually the two will also be able to share linting logic.