### PR TITLE
Fix current challenge exception when workspace has not yet been created

### DIFF
--- a/backend/ng/containers/controllers/get_current_connected_challenge.py
+++ b/backend/ng/containers/controllers/get_current_connected_challenge.py
@@ -1,7 +1,10 @@
 from ..models.IndvidualContainer import IndvidualContainer
 
-def get_current_connected_challenge(current_user) -> int:
+def get_current_connected_challenge(current_user) -> int | None:
     user_container = IndvidualContainer.get_user_indvidual_container(current_user)
+    if not user_container:
+        return None
+
     current_challenge_id = user_container.get_current_challenge()
 
     return current_challenge_id


### PR DESCRIPTION
Current challenge endpoint comes back with an error while the user workspace is being created, which results in error message flicker on the challenge page. Instead, the endpoint should indicate that no challenge is connected for the user (which is true, since the workspace doesn't exist yet.)