### PR TITLE
User-facing challenge reset button

### DIFF
--- a/frontend/src/hooks/container.ts
+++ b/frontend/src/hooks/container.ts
@@ -15,6 +15,14 @@ export function connectWorkspace(eventId: number, challengeId: number) {
   });
 }
 
+export function recycleChallengeContainers(eventId: number, challengeId: number) {
+  return apiMutation(`/events/${eventId}/challenge/${challengeId}/containers/recycle`, undefined, {
+    method : 'POST',
+  }).then(() => {
+    mutate('/container/me/current_challenge');
+  });
+}
+
 /* ADMIN ENDPOINTS */
 
 export function useAllDeployments() {

--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -15,7 +15,7 @@ import { ErrorCallout } from 'components/Callouts';
 import ChallengeIcon from 'components/ChallengeIcon';
 import RadixMarkdown from 'components/RadixMarkdown';
 import { groupBy } from 'lodash';
-import { TbArrowLeft, TbDotsVertical } from 'react-icons/tb';
+import { TbArrowLeft } from 'react-icons/tb';
 import { Link, useParams } from 'react-router';
 import ChallengeHeader from './ChallengeHeader';
 import ChallengeQuestion from './ChallengeQuestion';
@@ -90,9 +90,6 @@ export default function ChallengeSidebar() {
             {challenge && event && granted && (
               <Flex direction="row" gap="2" mt="3" align="center">
                 <ConnectModal eventId={event.id} challengeId={challenge.id} />
-                <Button variant="ghost" className="!m-0 !p-2" color="gray">
-                  <TbDotsVertical />
-                </Button>
               </Flex>
             )}
           </ChallengeHeader>

--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -89,7 +89,7 @@ export default function ChallengeSidebar() {
 
             {challenge && event && granted && (
               <Flex direction="row" gap="2" mt="3" align="center">
-                <ConnectModal eventId={event.id} challengeId={challenge.id} />
+                <ConnectModal eventId={event.id} challengeId={challenge.id} isTeam={event.max_team_size > 1} />
               </Flex>
             )}
           </ChallengeHeader>

--- a/frontend/src/routes/events/challenge/ConnectModal.tsx
+++ b/frontend/src/routes/events/challenge/ConnectModal.tsx
@@ -6,9 +6,10 @@ import Modal from 'components/Modal';
 import { useState } from 'react';
 import { TbCheck, TbPlayerPlay, TbRotateClockwise } from 'react-icons/tb';
 
-export default function ConnectModal({ eventId, challengeId }: {
+export default function ConnectModal({ eventId, challengeId, isTeam }: {
   eventId: number;
   challengeId: number;
+  isTeam: boolean;
 }) {
   const {
     data : currentChallenge, isValidating, error,
@@ -38,8 +39,7 @@ export default function ConnectModal({ eventId, challengeId }: {
         </Button>
         <Modal
           title="Reset challenge?"
-          description="The current challenge instance will be destroyed and a new one
-          will be created. Progress outside of your own workspace machine may be lost."
+          description={`The challenge will be reset to its initial state${isTeam ? ' for all players on your team' : ''}.`}
           trigger={(
             <Button variant="ghost" className="!m-0" color={COLOR_NEGATIVE}>
               <TbRotateClockwise />

--- a/frontend/src/routes/events/challenge/ConnectModal.tsx
+++ b/frontend/src/routes/events/challenge/ConnectModal.tsx
@@ -1,16 +1,18 @@
-import { COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
-import { connectWorkspace, useCurrentChallengeId } from '@/hooks/container';
+import { COLOR_NEGATIVE, COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
+import { connectWorkspace, recycleChallengeContainers, useCurrentChallengeId } from '@/hooks/container';
 import { Button } from '@radix-ui/themes';
 import { ErrorCallout } from 'components/Callouts';
 import Modal from 'components/Modal';
 import { useState } from 'react';
-import { TbCheck, TbPlayerPlay } from 'react-icons/tb';
+import { TbCheck, TbPlayerPlay, TbRotateClockwise } from 'react-icons/tb';
 
 export default function ConnectModal({ eventId, challengeId }: {
   eventId: number;
   challengeId: number;
 }) {
-  const { data : currentChallenge, error } = useCurrentChallengeId();
+  const {
+    data : currentChallenge, isValidating, error,
+  } = useCurrentChallengeId();
   const [ loading, setLoading ] = useState(false);
 
   const handleConnect = async () => {
@@ -20,6 +22,8 @@ export default function ConnectModal({ eventId, challengeId }: {
     });
   };
 
+  const handleReset = async () => recycleChallengeContainers(eventId, challengeId);
+
   if (error) {
     // if we can't get the current challenge, show an error where the button would otherwise go
     return <ErrorCallout>{error.message}</ErrorCallout>;
@@ -27,17 +31,33 @@ export default function ConnectModal({ eventId, challengeId }: {
 
   if (currentChallenge === challengeId) {
     return (
-      <Button variant="soft" disabled m="0">
-        <TbCheck />
-        Connected
-      </Button>
+      <>
+        <Button variant="soft" disabled m="0">
+          <TbCheck />
+          Connected
+        </Button>
+        <Modal
+          title="Reset challenge?"
+          description="The current challenge instance will be destroyed and a new one
+          will be created. Progress outside of your own workspace machine may be lost."
+          trigger={(
+            <Button variant="ghost" className="!m-0" color={COLOR_NEGATIVE}>
+              <TbRotateClockwise />
+              Reset
+            </Button>
+          )}
+          submitVerb="Reset"
+          submitColor={COLOR_NEGATIVE}
+          onSubmit={handleReset}
+        />
+      </>
     );
   }
 
   if (currentChallenge === null) {
     // If the workspace isn't connected to anything, don't require confirmation
     return (
-      <Button onClick={handleConnect} loading={loading} color={COLOR_POSITIVE} className="pulsate">
+      <Button onClick={handleConnect} loading={loading || isValidating} color={COLOR_POSITIVE} className="pulsate">
         <TbPlayerPlay />
         Start Challenge
       </Button>
@@ -49,7 +69,7 @@ export default function ConnectModal({ eventId, challengeId }: {
       title="Switch challenge?"
       description="Your workspace will be disconnected from your previous challenge and connected to this one."
       trigger={(
-        <Button loading={loading} color={COLOR_POSITIVE} className="pulsate">
+        <Button loading={loading || isValidating} color={COLOR_POSITIVE} className="pulsate">
           <TbPlayerPlay />
           Start Challenge
         </Button>


### PR DESCRIPTION
Resolves #307.

Adds a reset button on the challenge page to recycle a challenge's containers. Also fixes some loading jank/flickering on the challenge's connect button.