### PR TITLE
Hint redemption UI, respect event hints_enabled flag for endpoints

### DIFF
--- a/backend/ng/challenge/models/Challenge.py
+++ b/backend/ng/challenge/models/Challenge.py
@@ -175,7 +175,7 @@ class Challenge(db.Model):
         data = {
             "challenge": self.serialize(),
             "questions": Question.query.filter_by(challenge_id=self.id).all(),
-            "hints": [hint.serialize(team=team) for hint in hints],
+            "hints": [hint.serialize(team=team) for hint in hints] if self.event.hints_enabled else [],
             "attempts": Attempt.query.filter_by(
                 team_id=team.id,
                 challenge_id=self.id

--- a/backend/ng/conftest.py
+++ b/backend/ng/conftest.py
@@ -305,6 +305,7 @@ def event_factory(db_session):
             "start_time": utc_now() - timedelta(days=1),
             "end_time": utc_now() + timedelta(days=1),
             "time_limit_minutes": 120,
+            "hints_enabled": True,
         }
         defaults.update(kwargs)
         event = Event.create_event(**defaults)
@@ -504,6 +505,7 @@ def event(db_session):
         description="A test event.",
         max_team_size=4,
         locked=False,
+        hints_enabled=True,
     )
     db_session.add(event)
     db_session.flush()
@@ -519,6 +521,7 @@ def locked_event(db_session):
         name="Locked Event",
         description="This event is locked",
         locked=True,
+        hints_enabled=True,
         start_time=utc_now() - timedelta(days=10),
         end_time=utc_now() - timedelta(days=5),
     )

--- a/backend/ng/scoring/controllers/user_actions/redeem_hint.py
+++ b/backend/ng/scoring/controllers/user_actions/redeem_hint.py
@@ -2,6 +2,7 @@
 Handles hint redemption for challenges.
 """
 
+from ....core import BusinessLogicError
 from ...models import HintRedemption
 from ....notifications.services import NotificationService
 
@@ -16,6 +17,10 @@ def redeem_hint(
     """
     Redeem a hint for a challenge
     """
+
+    if not event.hints_enabled:
+        raise BusinessLogicError("Hints are disabled for this event.")
+
     HintRedemption.create_redemption(
         hint_id=hint.id,
         user_id=current_user.id,

--- a/backend/ng/scoring/tests/test_scoring_api.py
+++ b/backend/ng/scoring/tests/test_scoring_api.py
@@ -441,19 +441,28 @@ class TestUserScoringEndpoints:
 
     def test_challenge_endpoint_hints_disabled(self, started_player_client, challenge_factory, hint_factory):
         """
-        Test that no hints are returned through challenge endpoint when hints are disabled
+        Test that no hints are returned through challenge endpoint when hints are disabled,
+        and that they are returned again when enabled
         """
         challenge = challenge_factory(event_id=1)
         challenge.event.hints_enabled = False
+        hint_factory(challenge_id=challenge.id)
 
-        hint = hint_factory(challenge_id=challenge.id)
         response = started_player_client.get(f"/ng/events/{challenge.event_id}/challenges/{challenge.id}")
 
         assert response.status_code == 200
         data = response.get_json()
-
         hints = data["data"]["hints"]
         assert len(hints) == 0
+
+        challenge.event.hints_enabled = True
+        response = started_player_client.get(f"/ng/events/{challenge.event_id}/challenges/{challenge.id}")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        hints = data["data"]["hints"]
+        assert len(hints) == 1
+
 
     def test_hint_visibility_through_challenge_endpoint(self, started_player_client, challenge_factory, hint_factory):
         """

--- a/backend/ng/scoring/tests/test_scoring_api.py
+++ b/backend/ng/scoring/tests/test_scoring_api.py
@@ -415,6 +415,45 @@ class TestUserScoringEndpoints:
         data = response.get_json()
         assert data["success"] is False
 
+    def test_redeem_hint_hints_disabled(
+        self,
+        started_player_client,
+        challenge_factory,
+        hint_factory,
+        event
+    ):
+        """Test that hints can't be redeemed when hints are disabled"""
+        # Get the CSRF token (nonce) from the session
+        with started_player_client.session_transaction() as sess:
+            nonce = sess.get("nonce")
+
+        challenge = challenge_factory(event_id=1)
+        challenge.event.hints_enabled = False
+        hint = hint_factory(challenge_id=challenge.id)
+
+        response = started_player_client.post(
+            f"/ng/events/{challenge.event_id}/challenges/{challenge.id}/hint/{hint.id}/redeem", data={"nonce": nonce}
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["success"] is False
+
+    def test_challenge_endpoint_hints_disabled(self, started_player_client, challenge_factory, hint_factory):
+        """
+        Test that no hints are returned through challenge endpoint when hints are disabled
+        """
+        challenge = challenge_factory(event_id=1)
+        challenge.event.hints_enabled = False
+
+        hint = hint_factory(challenge_id=challenge.id)
+        response = started_player_client.get(f"/ng/events/{challenge.event_id}/challenges/{challenge.id}")
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        hints = data["data"]["hints"]
+        assert len(hints) == 0
 
     def test_hint_visibility_through_challenge_endpoint(self, started_player_client, challenge_factory, hint_factory):
         """

--- a/frontend/src/routes/events/challenge/HintsModal.tsx
+++ b/frontend/src/routes/events/challenge/HintsModal.tsx
@@ -1,9 +1,79 @@
 import { COLOR_HINT } from '@/constants';
-import { useChallenge } from '@/hooks/challenge';
-import { Button, Skeleton, Table } from '@radix-ui/themes';
-import { ErrorCallout, WarningCallout } from 'components/Callouts';
+import { redeemHint, useChallenge } from '@/hooks/challenge';
+import type { Hint } from '@/types';
+import {
+  Button,
+  Flex,
+  Popover,
+  Table,
+  Text,
+} from '@radix-ui/themes';
+import { ErrorCallout } from 'components/Callouts';
 import Modal from 'components/Modal';
-import { TbBulb } from 'react-icons/tb';
+import { useState } from 'react';
+import { TbBulb, TbLockOpen } from 'react-icons/tb';
+
+function HintRow({ hint, eventId }: {hint: Hint, eventId: number}) {
+  const [ loading, setLoading ] = useState(false);
+
+  const handleRedeem = async () => {
+    setLoading(true);
+    return redeemHint(eventId, hint.challenge_id, hint.id).finally(() => {
+      setLoading(false);
+    });
+  };
+
+  return (
+    <Table.Row key={hint.id}>
+      <Table.Cell>{hint.preview}</Table.Cell>
+      <Table.Cell>
+        {hint.deduction}
+      </Table.Cell>
+      <Table.Cell align="right">
+        {hint.body
+          ? <Text>{hint.body}</Text>
+          : (
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button variant="ghost" color={COLOR_HINT} type="button">
+                  <TbLockOpen />
+                  {' '}
+                  Redeem
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content width="360px">
+                <Text>
+                  Are you sure you want to redeem
+                  {' '}
+                  {hint.preview}
+                  ?
+                </Text>
+                <br />
+                <Text color="gray" size="2">
+                  This will deduct
+                  {' '}
+                  {hint.deduction}
+                  {' '}
+                  points from your score.
+                </Text>
+
+                <Flex direction="row" gap="2" mt="2" className="*:!grow">
+                  <Popover.Close>
+                    <Button variant="soft" color="gray">
+                      Cancel
+                    </Button>
+                  </Popover.Close>
+                  <Button variant="soft" color={COLOR_HINT} onClick={handleRedeem} loading={loading}>
+                    Confirm
+                  </Button>
+                </Flex>
+              </Popover.Content>
+            </Popover.Root>
+          )}
+      </Table.Cell>
+    </Table.Row>
+  );
+}
 
 export default function HintsModal({
   eventId, challengeId,
@@ -31,9 +101,6 @@ export default function HintsModal({
       )}
 
       {data && (
-      <>
-        <WarningCallout>Hint redemption is not yet implemented, enjoy your free hints for now!</WarningCallout>
-
         <Table.Root>
           <Table.Header>
             <Table.Row>
@@ -44,21 +111,10 @@ export default function HintsModal({
           </Table.Header>
           <Table.Body>
             {data?.hints.map((hint) => (
-              <Table.Row key={hint.id}>
-                <Table.Cell>{hint.preview}</Table.Cell>
-                <Table.Cell>
-                  {hint.deduction}
-                </Table.Cell>
-                <Table.Cell>
-                  <Skeleton loading={hint.body === null}>
-                    {hint.body ?? 'Not redeemed'}
-                  </Skeleton>
-                </Table.Cell>
-              </Table.Row>
+              <HintRow key={hint.id} hint={hint} eventId={eventId} />
             ))}
           </Table.Body>
         </Table.Root>
-      </>
       )}
     </Modal>
   );


### PR DESCRIPTION
Can now redeem hints through the hint modal.

<img width="1002" height="394" alt="image" src="https://github.com/user-attachments/assets/ed57fc06-c3f7-4763-87eb-c080b2785b06" />

Also resolves #246 - hints are not sent to clients and cannot be redeemed if their event has `hints_enabled` set to False. This also has the side effect of hiding the hints button, since no hints are present in this situation.