### PR TITLE
Team Related Bugfixes

### DIFF
--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -854,14 +854,17 @@ class Test_Event_Team_Management:
 
     def test_leaving_user_can_reregister(
         self,
-        logged_in_client,
-        user,
+        client_factory,
+        user_factory,
         event_factory,
         team_factory
     ):
         """Test that a user who leaves a team can re-register for the event."""
         event = event_factory(name = "Reregister Test Event", public = True)
-        team = team_factory(event = event, members = [user])
+        user = user_factory(name = "reregisteruser", email = "reregisteruser@example.com")
+        user2 = user_factory(name = "otheruser", email = "otheruser@example.com")
+        team = team_factory(event = event, members = [user2, user])
+        logged_in_client = client_factory(user = user)
 
         response = logged_in_client.post(
             f"/ng/events/{event.id}/me/team/leave",
@@ -871,12 +874,12 @@ class Test_Event_Team_Management:
 
         response = logged_in_client.post(
             f"/ng/events/{event.id}/me/register",
-            json = {"team_name": "New Team Name"},
+            json = {"invite_code": team.invite_code},
         )
         assert response.status_code == 201
         data = response.get_json()
         assert data["success"] is True
-        assert data["data"]["name"] == "New Team Name"
+        assert data["data"]["name"] == "Test Team 1"
 
     def test_update_name(self, team_captain_client):
         """Test that the team name can be updated."""
@@ -963,6 +966,37 @@ class Test_Event_Team_Start:
         assert not data["success"]
         assert "errors" in data
         assert "TEAM_HAS_STARTED" in data["errors"]["forbidden"]
+
+    def test_start_near_end_of_event_end_time_is_clamped(
+        self,
+        client_factory,
+        user_factory,
+        event_factory,
+        team_factory,
+        db_session
+    ):
+        """Test that starting an event near its end time clamps the end time correctly."""
+        time = utc_now()
+        event = event_factory(
+            name = "Clamp End Time Event",
+            public = True,
+            start_time = time - timedelta(hours = 1),
+            end_time = time + timedelta(minutes = 30),
+            time_limit_minutes = 600
+        )
+        user = user_factory(name = "clampuser", email = "clampuser@example.com")
+        team_factory(event = event, members = [user])
+        client = client_factory(user = user)
+        response = client.post(
+            f"/ng/events/{event.id}/me/team/start",
+            json = {}
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"]
+        assert "end_time" in data["data"]
+        team_end_time = datetime.fromisoformat(data["data"]["end_time"]).replace(tzinfo=None)
+        assert team_end_time <= event.end_time
 
 
 class Test_Event_Admin_Register:

--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -852,6 +852,32 @@ class Test_Event_Team_Management:
         data = response.get_json()
         assert data["success"] is True
 
+    def test_leaving_user_can_reregister(
+        self,
+        logged_in_client,
+        user,
+        event_factory,
+        team_factory
+    ):
+        """Test that a user who leaves a team can re-register for the event."""
+        event = event_factory(name = "Reregister Test Event", public = True)
+        team = team_factory(event = event, members = [user])
+
+        response = logged_in_client.post(
+            f"/ng/events/{event.id}/me/team/leave",
+            json = {}
+        )
+        assert response.status_code == 200
+
+        response = logged_in_client.post(
+            f"/ng/events/{event.id}/me/register",
+            json = {"team_name": "New Team Name"},
+        )
+        assert response.status_code == 201
+        data = response.get_json()
+        assert data["success"] is True
+        assert data["data"]["name"] == "New Team Name"
+
     def test_update_name(self, team_captain_client):
         """Test that the team name can be updated."""
         new_name = "Updated Team Name"

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -152,6 +152,10 @@ class Team(db.Model):
             )
             if res:
                 raise ValidationError(f"Team name '{data['name']}' already exists in event ID {data['event_id']}.")
+        if "start_timestamp" in data:
+            validator.validate_datetime(data, "start_timestamp", friendly_name="Start timestamp")
+        if "end_time" in data:
+            validator.validate_datetime(data, "end_time", friendly_name="End time")
 
         return validator.validate()
 

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -152,10 +152,12 @@ class Team(db.Model):
             )
             if res:
                 raise ValidationError(f"Team name '{data['name']}' already exists in event ID {data['event_id']}.")
-        if "start_timestamp" in data:
-            validator.validate_datetime(data, "start_timestamp", friendly_name="Start timestamp")
-        if "end_time" in data:
-            validator.validate_datetime(data, "end_time", friendly_name="End time")
+        if "start_timestamp" in data and "end_time" in data:
+            validator.validate_time_window(data, start_field="start_timestamp", end_field="end_time")
+        elif "start_timestamp" in data:
+            validator.validate_datetime(data, "start_timestamp", friendly_name="Start Timestamp")
+        elif "end_time" in data:
+            validator.validate_datetime(data, "end_time", friendly_name="End Time")
 
         return validator.validate()
 
@@ -263,7 +265,7 @@ class Team(db.Model):
     def set_end_time(self, end_time: datetime | None = None, commit=True):
         """Set the team's end time."""
         end_time = end_time.replace(tzinfo=None)
-        if end_time > self.event.end_time:
+        if self.event.end_time and end_time > self.event.end_time:
             self.end_time = self.event.end_time
         else:
             self.end_time = end_time

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -262,7 +262,11 @@ class Team(db.Model):
 
     def set_end_time(self, end_time: datetime | None = None, commit=True):
         """Set the team's end time."""
-        self.end_time = end_time
+        end_time = end_time.replace(tzinfo=None)
+        if end_time > self.event.end_time:
+            self.end_time = self.event.end_time
+        else:
+            self.end_time = end_time
         if commit:
             db.session.commit()
 

--- a/backend/ng/team/tests/test_admin_routes.py
+++ b/backend/ng/team/tests/test_admin_routes.py
@@ -43,6 +43,24 @@ def test_teamdetail_update_invalid_name(admin_client, event, team_factory, user)
     data = response.get_json()
     assert data['errors']['validation'] == "Team name cannot include a member's name."
 
+def test_teamdetail_update_event_timestamps(admin_client, event, team_factory, user):
+    """Test that the team detail endpoint can update event timestamps of a team."""
+    team = team_factory(event=event, members=[user])
+    new_start_timestamp = "2024-01-01T12:00:00Z"
+    new_end_time = "2024-12-31T12:00:00Z"
+    response = admin_client.put(
+        f"/ng/admin/teams/{team.id}",
+        json={
+            "start_timestamp": new_start_timestamp,
+            "end_time": new_end_time
+        }
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['data']["start_timestamp"] == new_start_timestamp
+    assert data['data']["end_time"] == new_end_time
+    assert data['success']
+
 def test_update_team_ranked_status(admin_client, event, team_factory, user):
     """Test that the team detail endpoint can update the ranked status of a team."""
     team = team_factory(event=event, members=[user], ranked=False)

--- a/backend/ng/team/tests/test_admin_routes.py
+++ b/backend/ng/team/tests/test_admin_routes.py
@@ -1,5 +1,5 @@
 import pytest
-
+from datetime import datetime
 
 pytestmark = pytest.mark.db
 
@@ -60,6 +60,84 @@ def test_teamdetail_update_event_timestamps(admin_client, event, team_factory, u
     assert data['data']["start_timestamp"] == new_start_timestamp
     assert data['data']["end_time"] == new_end_time
     assert data['success']
+
+def test_teamdetail_update_timestamps_must_have_continuity(admin_client, event, team_factory, user):
+    """Test that the team detail endpoint enforces continuity when updating timestamps."""
+    team = team_factory(event=event, members=[user])
+    new_start_timestamp = "2024-12-31T12:00:00Z"
+    new_end_time = "2024-01-01T12:00:00Z"
+    response = admin_client.put(
+        f"/ng/admin/teams/{team.id}",
+        json={
+            "start_timestamp": new_start_timestamp,
+            "end_time": new_end_time
+        }
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data['errors']['validation'] ==  "Validation failed: {'end_time': 'End Time must be after start timestamp.'}"
+
+def test_teamdetail_update_just_start(admin_client, event, team_factory, user):
+    """Test that the team detail endpoint allows updating just start timestamp."""
+    team = team_factory(event=event, members=[user])
+    team.set_start_timestamp(datetime(2024, 1, 1, 12, 0, 0))
+    team.set_end_time(datetime(2024, 12, 31, 12, 0, 0))
+    new_start_timestamp = "2024-01-01T12:00:00Z"
+    response = admin_client.put(
+        f"/ng/admin/teams/{team.id}",
+        json={
+            "start_timestamp": new_start_timestamp
+        }
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['data']["start_timestamp"] == new_start_timestamp
+    assert data['success']
+
+def test_teamdetail_update_just_start_continuity(admin_client, event, team_factory, user):
+    """Test that the team detail endpoint enforces continuity when updating just start timestamp."""
+    team = team_factory(event=event, members=[user])
+    team.set_start_timestamp(datetime(2024, 1, 1, 12, 0, 0))
+    team.set_end_time(datetime(2024, 12, 31, 12, 0, 0))
+    new_start_timestamp = "2025-01-01T12:00:00Z"
+    response = admin_client.put(
+        f"/ng/admin/teams/{team.id}",
+        json={
+            "start_timestamp": new_start_timestamp
+        }
+    )
+    assert response.status_code == 400
+    
+def test_teamdetail_update_just_end(admin_client, event, team_factory, user):
+    """Test that the team detail endpoint allows updating just end time."""
+    team = team_factory(event=event, members=[user])
+    team.set_start_timestamp(datetime(2024, 1, 1, 12, 0, 0))
+    team.set_end_time(datetime(2024, 12, 31, 12, 0, 0))
+    new_end_time = "2024-12-31T12:00:00Z"
+    response = admin_client.put(
+        f"/ng/admin/teams/{team.id}",
+        json={
+            "end_time": new_end_time
+        }
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['data']["end_time"] == new_end_time
+    assert data['success']
+
+def test_teamdetail_update_just_end_continuity(admin_client, event, team_factory, user):
+    """Test that the team detail endpoint enforces continuity when updating just end time."""
+    team = team_factory(event=event, members=[user])
+    team.set_start_timestamp(datetime(2024, 1, 1, 12, 0, 0))
+    team.set_end_time(datetime(2024, 12, 31, 12, 0, 0))
+    new_end_time = "2023-12-31T12:00:00Z"
+    response = admin_client.put(
+        f"/ng/admin/teams/{team.id}",
+        json={
+            "end_time": new_end_time
+        }
+    )
+    assert response.status_code == 400
 
 def test_update_team_ranked_status(admin_client, event, team_factory, user):
     """Test that the team detail endpoint can update the ranked status of a team."""

--- a/backend/ng/team/tests/test_admin_routes.py
+++ b/backend/ng/team/tests/test_admin_routes.py
@@ -107,7 +107,7 @@ def test_teamdetail_update_just_start_continuity(admin_client, event, team_facto
         }
     )
     assert response.status_code == 400
-    
+
 def test_teamdetail_update_just_end(admin_client, event, team_factory, user):
     """Test that the team detail endpoint allows updating just end time."""
     team = team_factory(event=event, members=[user])


### PR DESCRIPTION
Closes #258, Closes #277, Closes #281

Modifies `Team.set_end_time` to clamp a teams end time to the events end time if it would exceed it
Adds` start_timestamp` and `end_time` to the team validator so admins can modify them if needed
#277 was accidentally fixed in #253 but added tests here to verify functionality so closing with this PR
