### PR TITLE
Add image pulling to the admin Challenges section, fix image name in container status

### DIFF
--- a/backend/ng/challenge/routes/admin_routes.py
+++ b/backend/ng/challenge/routes/admin_routes.py
@@ -131,7 +131,11 @@ class PullImages(Resource):
                         current_user.id
                     )
                 except Exception as err:
-                    emit_to_user("pull-fail", {"error": str(err)}, current_user.id)
+                    emit_to_user(
+                        "pull-fail",
+                        { "error": str(err), "id" : blueprint.id, "image": blueprint.image },
+                        current_user.id
+                    )
 
 
             proc = multiprocessing.Process(target=background_task, args=(blueprint, current_user))

--- a/backend/ng/containers/models/ContainerInstance.py
+++ b/backend/ng/containers/models/ContainerInstance.py
@@ -211,10 +211,18 @@ class ContainerInstance(db.Model):
         client = get_client(config.DOCKER_HOST)
         ctr = client.containers.get(self.dockerid)
 
+        image = "unknown"
+        if ctr.image.attrs["RepoTags"]:
+            # if the image is tagged, show the tag
+            image = ctr.image.attrs["RepoTags"][0]
+        elif ctr.image.attrs["RepoDigests"]:
+            # if this image is no longer tagged, show the digest instead
+            image = ctr.image.attrs["RepoDigests"][0]
+
         data = {
             "id": self.id,
             "name": ctr.name,
-            "image": ctr.image.tags[0] if ctr.image.tags else "unknown",
+            "image": image,
             "docker_id": self.dockerid,
             "status": ctr.status,
         }

--- a/frontend/src/components/AdminSidebarHeader.tsx
+++ b/frontend/src/components/AdminSidebarHeader.tsx
@@ -15,7 +15,7 @@ export default function AdminSidebarHeader({
         {icon && <Heading>{icon}</Heading>}
         <Heading>{title}</Heading>
       </Flex>
-      <Flex direction="row" align="center" gap="2">
+      <Flex direction="row" align="center" gap="2" wrap="wrap" justify="end">
         {children}
       </Flex>
     </Flex>

--- a/frontend/src/routes/admin/challenges/ChallengeSidebar.tsx
+++ b/frontend/src/routes/admin/challenges/ChallengeSidebar.tsx
@@ -1,15 +1,15 @@
-import { COLOR_INFO, EventIcon } from '@/constants';
+import { COLOR_INFO, DeploymentIcon, EventIcon } from '@/constants';
 import type { Challenge } from '@/types';
 import { Button, Tabs } from '@radix-ui/themes';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import ChallengeIcon from 'components/ChallengeIcon';
 import { Link, useSearchParams } from 'react-router';
+import ChallengeDownloadButton from './ChallengeDownloadButton';
+import ChallengeUpdateModal from './ChallengeUpdateModal';
 import ChallengeAttemptsTab from './SidebarTabs/ChallengeAttemptsTab';
 import ChallengeBlueprintTab from './SidebarTabs/ChallengeBlueprintTab';
 import ChallengeDetailsTab from './SidebarTabs/ChallengeDetailsTab';
-import ChallengeUpdateModal from './ChallengeUpdateModal';
-import ChallengeDownloadButton from './ChallengeDownloadButton';
 
 export default function ChallengeSidebar({ entity }: {entity: Challenge}) {
   const [ searchParams, setSearchParams ] = useSearchParams();
@@ -21,6 +21,19 @@ export default function ChallengeSidebar({ entity }: {entity: Challenge}) {
           <Link to={`/admin/events?id=${entity.event_id}`}>
             <EventIcon />
             Event
+          </Link>
+        </Button>
+        <Button variant="soft" color={COLOR_INFO} asChild>
+          <Link
+            to={`/admin/deployments/?filter=${btoa(JSON.stringify(
+              {
+                challenge_name : { filterType : 'text', type : 'equals', filter : entity.name },
+                event_name : { filterType : 'text', type : 'equals', filter : entity.event_name },
+              },
+            ))}`}
+          >
+            <DeploymentIcon />
+            Deployments
           </Link>
         </Button>
         <ChallengeUpdateModal challengeId={entity.id} />

--- a/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeBlueprintTab.tsx
+++ b/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeBlueprintTab.tsx
@@ -1,62 +1,151 @@
+import { COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
+import { apiMutation } from '@/fetchers';
 import { useAdminChallengeBlueprints } from '@/hooks/challenge';
+import socket from '@/socket';
 import {
   Button,
   Card,
   Code,
   DataList,
-  Heading,
+  Grid,
+  Spinner,
+  Text,
 } from '@radix-ui/themes';
-import { ErrorCallout } from 'components/Callouts';
+import AdminSidebarHeader from 'components/AdminSidebarHeader';
+import { ErrorCallout, WarningCallout } from 'components/Callouts';
+import Modal from 'components/Modal';
+import { useEffect, useState } from 'react';
+import { TbCheck, TbDownload, TbPackage } from 'react-icons/tb';
 
 export default function ChallengeBlueprintTab({ challengeId }: {challengeId: number}) {
   const { data : blueprints, error } = useAdminChallengeBlueprints(challengeId);
+
+  const [ pullStates, setPullStates ] = useState<{[key: number]:'pulling' | 'success'}>({});
+  const [ pullErrors, setPullErrors ] = useState<string[]>([]);
+
+  const handlePull = async () => {
+    setPullStates((prev) => {
+      const current = { ...prev };
+      (blueprints || []).forEach((bp) => {
+        current[bp.id] = 'pulling';
+      });
+      return current;
+    });
+    setPullErrors([]);
+
+    return apiMutation(`/admin/challenges/${challengeId}/pull`, {}, {
+      method : 'POST',
+    });
+  };
+
+  useEffect(() => {
+    socket.on('pull-success', ({ id }: {id: number}) => {
+      setPullStates((prev) => ({
+        ...prev,
+        [id] : 'success',
+      }));
+    });
+
+    socket.on('pull-fail', ({ error : pullError }: {error: string}) => {
+      setPullErrors((prev) => ([ ...prev, pullError ]));
+    });
+
+    return () => {
+      socket.off('pull-success');
+      socket.off('pull-failure');
+    };
+  });
 
   if (error) {
     return <ErrorCallout>{error.message}</ErrorCallout>;
   }
 
-  return blueprints?.map((blueprint) => (
-    <Card key={blueprint.id}>
-      <Heading>{blueprint.hostname}</Heading>
-      <DataList.Root className="!gap-1 !mt-3">
-        <DataList.Item>
-          <DataList.Label>Image</DataList.Label>
-          <DataList.Value>
-            {blueprint.image}
-            <Button variant="ghost" className="!ml-2">Re-pull</Button>
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Command</DataList.Label>
-          <DataList.Value>
-            {JSON.stringify(blueprint.command)}
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Entrypoint</DataList.Label>
-          <DataList.Value>
-            {JSON.stringify(blueprint.entrypoint)}
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>TTY</DataList.Label>
-          <DataList.Value>
-            {blueprint.tty ? 'Yes' : 'No'}
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Stdin Open</DataList.Label>
-          <DataList.Value>
-            {blueprint.stdin_open ? 'Yes' : 'No'}
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Networks</DataList.Label>
-          <DataList.Value>
-            {blueprint.networks.map((n) => <Code color="gray" key={n} className="!me-1">{n}</Code>)}
-          </DataList.Value>
-        </DataList.Item>
-      </DataList.Root>
-    </Card>
-  ));
+  return (
+    <>
+      <AdminSidebarHeader title="Containers">
+        <Modal
+          title="Pull Images"
+          description="This will pull all container images used by this challenge.
+          Existing deployments will need to be recycled to use updated images."
+          trigger={(
+            <Button variant="soft" color={COLOR_WARNING} disabled={!blueprints}>
+              <TbDownload />
+              Pull Images
+            </Button>
+          )}
+          onSubmit={handlePull}
+          submitVerb="Pull"
+          submitColor={COLOR_WARNING}
+        >
+          <WarningCallout>
+            This will affect all challenges using these images.
+          </WarningCallout>
+        </Modal>
+      </AdminSidebarHeader>
+
+      {pullErrors.map((err) => (
+        <ErrorCallout key={err} className="mt-2">{err}</ErrorCallout>
+      ))}
+
+      <Grid columns="2" mt="2">
+        {blueprints?.map((blueprint) => (
+          <Card key={blueprint.id} className="mb-3">
+            <AdminSidebarHeader title={blueprint.name} icon={<TbPackage />}>
+              {pullStates[blueprint.id] === 'pulling' && (<Spinner />)}
+              {pullStates[blueprint.id] === 'success' && (
+                <Text color={COLOR_POSITIVE}>
+                  <TbCheck className="inline me-1" />
+                  Pulled
+                </Text>
+              )}
+            </AdminSidebarHeader>
+            <DataList.Root className="!gap-1 !mt-3">
+              <DataList.Item>
+                <DataList.Label>Image</DataList.Label>
+                <DataList.Value>
+                  {blueprint.image}
+                </DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>Hostname</DataList.Label>
+                <DataList.Value>
+                  {blueprint.hostname}
+                </DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>Command</DataList.Label>
+                <DataList.Value>
+                  {JSON.stringify(blueprint.command)}
+                </DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>Entrypoint</DataList.Label>
+                <DataList.Value>
+                  {JSON.stringify(blueprint.entrypoint)}
+                </DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>TTY</DataList.Label>
+                <DataList.Value>
+                  {blueprint.tty ? 'Yes' : 'No'}
+                </DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>Stdin Open</DataList.Label>
+                <DataList.Value>
+                  {blueprint.stdin_open ? 'Yes' : 'No'}
+                </DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>Networks</DataList.Label>
+                <DataList.Value>
+                  {blueprint.networks.map((n) => <Code color="gray" key={n} className="!me-1">{n}</Code>)}
+                </DataList.Value>
+              </DataList.Item>
+            </DataList.Root>
+          </Card>
+        ))}
+      </Grid>
+    </>
+  );
 }

--- a/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeBlueprintTab.tsx
+++ b/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeBlueprintTab.tsx
@@ -1,4 +1,4 @@
-import { COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
+import { COLOR_NEGATIVE, COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
 import { apiMutation } from '@/fetchers';
 import { useAdminChallengeBlueprints } from '@/hooks/challenge';
 import socket from '@/socket';
@@ -15,12 +15,17 @@ import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout, WarningCallout } from 'components/Callouts';
 import Modal from 'components/Modal';
 import { useEffect, useState } from 'react';
-import { TbCheck, TbDownload, TbPackage } from 'react-icons/tb';
+import {
+  TbCancel,
+  TbCheck,
+  TbDownload,
+  TbPackage,
+} from 'react-icons/tb';
 
 export default function ChallengeBlueprintTab({ challengeId }: {challengeId: number}) {
   const { data : blueprints, error } = useAdminChallengeBlueprints(challengeId);
 
-  const [ pullStates, setPullStates ] = useState<{[key: number]:'pulling' | 'success'}>({});
+  const [ pullStates, setPullStates ] = useState<{[key: number]:'pulling' | 'success' | 'fail'}>({});
   const [ pullErrors, setPullErrors ] = useState<string[]>([]);
 
   const handlePull = async () => {
@@ -46,15 +51,19 @@ export default function ChallengeBlueprintTab({ challengeId }: {challengeId: num
       }));
     });
 
-    socket.on('pull-fail', ({ error : pullError }: {error: string}) => {
+    socket.on('pull-fail', ({ error : pullError, id }: {error: string, id: number}) => {
       setPullErrors((prev) => ([ ...prev, pullError ]));
+      setPullStates((prev) => ({
+        ...prev,
+        [id] : 'fail',
+      }));
     });
 
     return () => {
       socket.off('pull-success');
-      socket.off('pull-failure');
+      socket.off('pull-fail');
     };
-  });
+  }, []);
 
   if (error) {
     return <ErrorCallout>{error.message}</ErrorCallout>;
@@ -96,6 +105,12 @@ export default function ChallengeBlueprintTab({ challengeId }: {challengeId: num
                 <Text color={COLOR_POSITIVE}>
                   <TbCheck className="inline me-1" />
                   Pulled
+                </Text>
+              )}
+              {pullStates[blueprint.id] === 'fail' && (
+                <Text color={COLOR_NEGATIVE}>
+                  <TbCancel className="inline me-1" />
+                  Error
                 </Text>
               )}
             </AdminSidebarHeader>


### PR DESCRIPTION
Adds a "Pull Images" confirmation modal to the blueprints section of a challenge:

<img width="1135" height="401" alt="image" src="https://github.com/user-attachments/assets/d6fa9ed8-57de-4981-842f-8f1947b46114" />

<img width="639" height="272" alt="image" src="https://github.com/user-attachments/assets/e7f6bcc3-1c7d-4f52-b20d-088f3737f76c" />

Clicking pull will have the backend pull associated challenge images, and will show the pull status on each card as sent by the websocket. Pull errors will also be shown above the containers.

<img width="639" height="272" alt="image" src="https://github.com/user-attachments/assets/b5a2735f-a178-4093-841b-381457a839c8" />
<img width="457" height="286" alt="image" src="https://github.com/user-attachments/assets/29383b2d-4ab9-451e-8266-493383427b8e" />
<img width="755" height="381" alt="image" src="https://github.com/user-attachments/assets/731bc335-e014-43d2-a3f2-f9688019b366" />

Also uses `image.attrs` to get image names for container statuses, since `image.tags` becomes empty for containers running older versions of an image that was previously tagged.
