### PR TITLE
replace imghdr with filetype library

### DIFF
--- a/backend/ng/core/utils/file_helpers.py
+++ b/backend/ng/core/utils/file_helpers.py
@@ -2,7 +2,7 @@
 File handling utility functions
 """
 
-import imghdr
+import filetype
 from werkzeug.datastructures import FileStorage
 
 
@@ -50,26 +50,19 @@ def validate_image_content(file: FileStorage) -> tuple[str, str]:
 
     Returns:
         Tuple[str, str]: (image_format, content_type)
-            - image_format: 'webp', 'png', 'jpeg', etc.
+            - image_format: 'webp', 'png', 'jpg', etc.
             - content_type: 'image/webp', 'image/png', etc.
 
     Raises:
         ValueError: If the file is not a valid image
     """
-    image_type = imghdr.what(file)
+    kind = filetype.guess(file)
     file.seek(0)
 
-    if image_type is None:
+    if kind is None or not kind.mime.startswith('image/'):
         raise ValueError("File is not a valid image")
 
-    content_type_map = {
-        'webp': 'image/webp',
-        'png': 'image/png',
-        'jpeg': 'image/jpeg',
-        'gif': 'image/gif',
-        'bmp': 'image/bmp',
-    }
+    image_format = kind.extension
+    content_type = kind.mime
 
-    content_type = content_type_map.get(image_type, f'image/{image_type}')
-
-    return image_type, content_type
+    return image_format, content_type

--- a/backend/ng/requirements.txt
+++ b/backend/ng/requirements.txt
@@ -19,3 +19,4 @@ types-docker==7.1.0.20250822
 requests-oauthlib==1.3.0
 sqlalchemy[mypy]==1.4.54
 types-boto3==1.40.40
+filetype==1.2.0


### PR DESCRIPTION
"""
imghdr — Determine the type of an image
Deprecated since version 3.11, removed in version 3.13.

This module is no longer part of the Python standard library. It was [removed in Python 3.13](https://docs.python.org/3/whatsnew/3.13.html#whatsnew313-pep594) after being deprecated in Python 3.11. The removal was decided in [PEP 594](https://peps.python.org/pep-0594/).

Possible replacements are third-party libraries from PyPI: [filetype](https://pypi.org/project/filetype/), [puremagic](https://pypi.org/project/puremagic/), or [python-magic](https://pypi.org/project/python-magic/). These are not supported or maintained by the Python core team.

The last version of Python that provided the imghdr module was [Python 3.12](https://docs.python.org/3.12/library/imghdr.html).
"""
https://docs.python.org/3/library/imghdr.html