### PR TITLE
Admin panel permission checks

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -17,7 +17,7 @@ export default function NavBar() {
   };
 
   const { isAuthenticated, isUnauthenticated, user } = useAuth();
-  const { granted: canAccessAdminPanel } = useGlobalPermission("CAN_ACCESS_ADMIN_PANEL");
+  const { granted : canAccessAdminPanel } = useGlobalPermission('CAN_ACCESS_ADMIN_PANEL');
 
   const location = useLocation();
 
@@ -133,14 +133,16 @@ export default function NavBar() {
                     Profile*
                   </NavLink>
                 </li>
-                {canAccessAdminPanel && <li>
-                  <NavLink
-                    to="/admin"
-                    className={contentItem}
-                  >
-                    Admin Portal
-                  </NavLink>
-                </li>}
+                {canAccessAdminPanel && (
+                  <li>
+                    <NavLink
+                      to="/admin"
+                      className={contentItem}
+                    >
+                      Admin Portal
+                    </NavLink>
+                  </li>
+                )}
                 <li>
                   <ThemeToggle className="ml-3 py-2" />
                 </li>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,4 +1,5 @@
 import { apiMutation } from '@/fetchers';
+import { useGlobalPermission } from '@/hooks/permissions';
 import { useAuth } from '@/hooks/users';
 import { Flex } from '@radix-ui/themes';
 import NotificationsPopover from 'components/NotificationsPopover';
@@ -16,6 +17,7 @@ export default function NavBar() {
   };
 
   const { isAuthenticated, isUnauthenticated, user } = useAuth();
+  const { granted: canAccessAdminPanel } = useGlobalPermission("CAN_ACCESS_ADMIN_PANEL");
 
   const location = useLocation();
 
@@ -131,14 +133,14 @@ export default function NavBar() {
                     Profile*
                   </NavLink>
                 </li>
-                <li>
+                {canAccessAdminPanel && <li>
                   <NavLink
                     to="/admin"
                     className={contentItem}
                   >
                     Admin Portal
                   </NavLink>
-                </li>
+                </li>}
                 <li>
                   <ThemeToggle className="ml-3 py-2" />
                 </li>

--- a/frontend/src/hooks/permissions.ts
+++ b/frontend/src/hooks/permissions.ts
@@ -22,6 +22,17 @@ export function useMyEventPermissions(eventId: number | null) {
   );
 }
 
+export function useGlobalPermission(permission: string) {
+  const { data, error, isLoading } = useMyGlobalPermissions();
+
+  return {
+    granted : data ? data.permissions.includes(permission) : false,
+    denied : data ? !data.permissions.includes(permission) : false,
+    isLoading,
+    error,
+  };
+}
+
 /**
  * Helper for performing an event-level permission check.
  */

--- a/frontend/src/routes/admin/layout.tsx
+++ b/frontend/src/routes/admin/layout.tsx
@@ -6,7 +6,9 @@ import {
   TeamIcon,
   UserIcon,
 } from '@/constants';
-import { Card, Flex } from '@radix-ui/themes';
+import { useGlobalPermission } from '@/hooks/permissions';
+import { Card, Flex, Skeleton } from '@radix-ui/themes';
+import { ErrorCallout } from 'components/Callouts';
 import { NavigationMenu } from 'radix-ui';
 import type { IconType } from 'react-icons';
 import {
@@ -27,9 +29,9 @@ function NavItem({
   label,
   icon : Icon = undefined,
 }: {
-    to: string;
-    label: string;
-    icon?: IconType
+  to: string;
+  label: string;
+  icon?: IconType
 }) {
   return (
     <NavigationMenu.Item>
@@ -58,30 +60,40 @@ function NavItem({
  * Pages that exceed viewport height will scroll within the outlet.
  */
 export default function AdminLayout() {
+  const { denied, isLoading } = useGlobalPermission('CAN_ACCESS_ADMIN_PANEL');
+
+  if (denied) {
+    return <ErrorCallout>You do not have permission to access this page.</ErrorCallout>;
+  }
+
   return (
     <Flex direction="row" className="absolute inset-0 overflow-hidden">
       <div className="flex-shrink-0 h-full p-3 pr-0">
-        <Card className="h-full w-48">
-          <NavigationMenu.Root orientation="vertical" aria-label="Sidebar" className="h-full overflow-y-auto">
-            <NavigationMenu.List>
-              <NavItem to="/admin" label="Dashboard" icon={TbLayoutDashboard} />
-              <NavItem to="/admin/reports" label="Reports" icon={TbChartPie} />
-              <NavItem to="/admin/events" label="Events" icon={EventIcon} />
-              <NavItem to="/admin/users" label="Users" icon={UserIcon} />
-              <NavItem to="/admin/teams" label="Teams" icon={TeamIcon} />
-              <NavItem to="/admin/challenges" label="Challenges" icon={ChallengeIcon} />
-              <NavItem to="/admin/deployments" label="Deployments" icon={DeploymentIcon} />
-              <NavItem to="/admin/announcements" label="Announcements" icon={AnnouncementIcon} />
-              <NavItem to="/admin/tickets" label="Tickets" icon={TbMessage} />
-              <NavItem to="/admin/tags" label="Tags" icon={TbTags} />
-              <NavItem to="/admin/settings" label="Settings" icon={TbSettings} />
-              <NavItem to="/admin/api-test" label="API Test" icon={TbBraces} />
-            </NavigationMenu.List>
-          </NavigationMenu.Root>
-        </Card>
+        {isLoading
+          ? <Skeleton className="!h-full w-48" />
+          : (
+            <Card className="h-full w-48">
+              <NavigationMenu.Root orientation="vertical" aria-label="Sidebar" className="h-full overflow-y-auto">
+                <NavigationMenu.List>
+                  <NavItem to="/admin" label="Dashboard" icon={TbLayoutDashboard} />
+                  <NavItem to="/admin/reports" label="Reports" icon={TbChartPie} />
+                  <NavItem to="/admin/events" label="Events" icon={EventIcon} />
+                  <NavItem to="/admin/users" label="Users" icon={UserIcon} />
+                  <NavItem to="/admin/teams" label="Teams" icon={TeamIcon} />
+                  <NavItem to="/admin/challenges" label="Challenges" icon={ChallengeIcon} />
+                  <NavItem to="/admin/deployments" label="Deployments" icon={DeploymentIcon} />
+                  <NavItem to="/admin/announcements" label="Announcements" icon={AnnouncementIcon} />
+                  <NavItem to="/admin/tickets" label="Tickets" icon={TbMessage} />
+                  <NavItem to="/admin/tags" label="Tags" icon={TbTags} />
+                  <NavItem to="/admin/settings" label="Settings" icon={TbSettings} />
+                  <NavItem to="/admin/api-test" label="API Test" icon={TbBraces} />
+                </NavigationMenu.List>
+              </NavigationMenu.Root>
+            </Card>
+          )}
       </div>
       <main className="flex-grow overflow-y-auto p-3">
-        <Outlet />
+        {isLoading ? <Skeleton className="!h-full" /> : <Outlet />}
       </main>
     </Flex>
   );


### PR DESCRIPTION
- Only show admin panel link in user menu when `CAN_ACCESS_ADMIN_PANEL` is granted.
- Show access denied message on admin pages for users that don't have `CAN_ACCESS_ADMIN_PANEL`, as well as introduce a loading state for the admin layout to show while permissions are being checked to prevent layout flash.