### PR TITLE
User impersonation integration

### DIFF
--- a/backend/ng/admin/routes/admin.py
+++ b/backend/ng/admin/routes/admin.py
@@ -4,8 +4,11 @@ Administrative operations and system management API routes.
 
 from flask_restx import Namespace, Resource
 from flask import session
+from ...user.models import User
 from ...core.utils import utc_now
 from CTFd.utils.security.csrf import generate_nonce
+from CTFd.utils.security.signing import hmac
+
 from ..controllers import (
     get_data_counts,
     get_detailed_stats,
@@ -122,7 +125,7 @@ class AdminImpersonate(Resource):
             404: "User not found"
         }
     )
-    def post(self, json_data,current_user, permissions, **kwargs):
+    def post(self, json_data, current_user: User, user: User, permissions, **kwargs):
         """Impersonate a user by ID"""
         user_id = json_data.get("user_id")
 
@@ -141,6 +144,7 @@ class AdminImpersonate(Resource):
         session["admin_id"] = current_user.id
         session["impersonated"] = True
         session["id"] = user_id
+        session["hash"] = hmac(user.ctfd_user.password)
         session["nonce"] = generate_nonce()
 
         return success_response()
@@ -156,26 +160,22 @@ class AdminStopImpersonating(Resource):
             403: "Forbidden - User is not impersonating"
         }
     )
-    def post(self,json_data, **kwargs):
+    def post(self, json_data, **kwargs):
         """Stop impersonating a user"""
         if not session.get("impersonated"):
             return error_response("You are not currently impersonating any user.", "impersonation", 403)
 
         logger.info(f"Admin {session['admin_id']} stopped impersonating user {session['id']}")
 
-        session["id"] = session["admin_id"]
+        impersonated_id = session["id"]
+        admin = User.find_by_id(session["admin_id"])
+        if not admin:
+            return error_response("Original admin user not found.", "impersonation", 400)
+
+        session["id"] = admin.id
+        session["hash"] = hmac(admin.ctfd_user.password)
         session.pop("admin_id", None)
         session.pop("impersonated", None)
         session["nonce"] = generate_nonce()
 
-
-        return success_response()
-
-
-
-
-
-
-
-
-
+        return success_response(impersonated_id)

--- a/backend/views/dev_entrypoint.html
+++ b/backend/views/dev_entrypoint.html
@@ -8,6 +8,7 @@
     window.init = {
       csrfToken: '{{ Session.nonce }}',
       userId: '{{ user_id }}' || null,
+      impersonated: {{ (session.impersonated or false) | tojson }}
     };
   </script>
   <script type="module">

--- a/backend/views/prod_entrypoint.html
+++ b/backend/views/prod_entrypoint.html
@@ -8,6 +8,7 @@
     window.init = {
       csrfToken: '{{ Session.nonce }}',
       userId: '{{ user_id }}' || null,
+      impersonated: {{ (session.impersonated or false) | tojson }}
     };
   </script>
   <script type="module" crossorigin src="/dist/index.js"></script>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,11 +1,12 @@
+import { COLOR_HINT } from '@/constants';
 import { apiMutation } from '@/fetchers';
 import { useGlobalPermission } from '@/hooks/permissions';
-import { useAuth } from '@/hooks/users';
-import { Flex } from '@radix-ui/themes';
+import { stopImpersonation, useAuth } from '@/hooks/users';
+import { Flex, Skeleton, Text } from '@radix-ui/themes';
 import NotificationsPopover from 'components/NotificationsPopover';
 import ThemeToggle from 'components/ThemeToggle';
 import { NavigationMenu } from 'radix-ui';
-import { TbUserCircle } from 'react-icons/tb';
+import { TbGhost, TbUserCircle } from 'react-icons/tb';
 import { NavLink, useLocation } from 'react-router';
 
 export default function NavBar() {
@@ -16,7 +17,9 @@ export default function NavBar() {
     });
   };
 
-  const { isAuthenticated, isUnauthenticated, user } = useAuth();
+  const {
+    isAuthenticated, isUnauthenticated, isImpersonated, user, isLoading,
+  } = useAuth();
   const { granted : canAccessAdminPanel } = useGlobalPermission('CAN_ACCESS_ADMIN_PANEL');
 
   const location = useLocation();
@@ -114,10 +117,21 @@ export default function NavBar() {
               onPointerMove={(event) => event.preventDefault()}
               onPointerLeave={(event) => event.preventDefault()}
             >
-              <Flex direction="row" align="center" gap="1">
-                <TbUserCircle className="inline" />
-                {user ? ` ${user.name}` : ' Log In'}
-              </Flex>
+              <Text
+                color={isImpersonated ? COLOR_HINT : undefined}
+                className={isImpersonated ? 'animate-pulse' : undefined}
+              >
+                <Flex direction="row" align="center" gap="1">
+                  {isImpersonated ? <TbGhost className="inline" /> : <TbUserCircle className="inline" />}
+                  {/* Show skeleton until we have auth state */}
+                  <Skeleton loading={isLoading}>
+                    <Text>
+                      {isImpersonated ? 'Impersonating ' : ''}
+                      {user ? user.name : 'Log In'}
+                    </Text>
+                  </Skeleton>
+                </Flex>
+              </Text>
             </NavigationMenu.Trigger>
             <NavigationMenu.Content
               className={contentBase}
@@ -148,15 +162,28 @@ export default function NavBar() {
                 </li>
 
                 {isAuthenticated && (
-                  <li>
-                    <button
-                      type="button"
-                      onClick={logout}
-                      className={contentItem}
-                    >
-                      Log Out
-                    </button>
-                  </li>
+                  <>
+                    {isImpersonated && (
+                      <li>
+                        <button
+                          type="button"
+                          onClick={stopImpersonation}
+                          className={contentItem}
+                        >
+                          Stop Impersonating
+                        </button>
+                      </li>
+                    )}
+                    <li>
+                      <button
+                        type="button"
+                        onClick={logout}
+                        className={contentItem}
+                      >
+                        Log Out
+                      </button>
+                    </li>
+                  </>
                 )}
                 {isUnauthenticated && (
                   <li>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,4 +1,4 @@
-import { COLOR_HINT } from '@/constants';
+import { COLOR_HINT, ImpersonateIcon } from '@/constants';
 import { apiMutation } from '@/fetchers';
 import { useGlobalPermission } from '@/hooks/permissions';
 import { stopImpersonation, useAuth } from '@/hooks/users';
@@ -6,7 +6,7 @@ import { Flex, Skeleton, Text } from '@radix-ui/themes';
 import NotificationsPopover from 'components/NotificationsPopover';
 import ThemeToggle from 'components/ThemeToggle';
 import { NavigationMenu } from 'radix-ui';
-import { TbGhost, TbUserCircle } from 'react-icons/tb';
+import { TbUserCircle } from 'react-icons/tb';
 import { NavLink, useLocation } from 'react-router';
 
 export default function NavBar() {
@@ -122,7 +122,7 @@ export default function NavBar() {
                 className={isImpersonated ? 'animate-pulse' : undefined}
               >
                 <Flex direction="row" align="center" gap="1">
-                  {isImpersonated ? <TbGhost className="inline" /> : <TbUserCircle className="inline" />}
+                  {isImpersonated ? <ImpersonateIcon className="inline" /> : <TbUserCircle className="inline" />}
                   {/* Show skeleton until we have auth state */}
                   <Skeleton loading={isLoading}>
                     <Text>

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -28,6 +28,8 @@ export function useAuth() {
       user : undefined,
       isAuthenticated : !!window.init.userId,
       isUnauthenticated : window.init.userId === null,
+      isLoading,
+      isImpersonated : window.init.impersonated,
     };
   }
 
@@ -35,6 +37,8 @@ export function useAuth() {
     user : data,
     isAuthenticated : !!data,
     isUnauthenticated : !data && error?.message.includes('Authentication is required'),
+    isLoading,
+    isImpersonated : window.init.impersonated,
   };
 }
 
@@ -112,4 +116,22 @@ export function useUserEvents(userId: number | undefined) {
   return useSWR<Event[], Error>(
     userId ? `/admin/users/${userId}/events` : null,
   );
+}
+
+export function impersonateUser(userId: number) {
+  return apiMutation('/admin/impersonate', { user_id : userId }, {
+    method : 'POST',
+  }).then(() => {
+    // On success, redirect to the home page to refresh the session
+    window.location.href = '/';
+  });
+}
+
+export function stopImpersonation() {
+  return apiMutation('/admin/stop_impersonating', {}, {
+    method : 'POST',
+  }).then((data: unknown) => {
+    // On success, redirect to the admin user page
+    window.location.href = `/admin/users?id=${data}`;
+  });
 }

--- a/frontend/src/routes/admin/users/ImpersonateUserButton.tsx
+++ b/frontend/src/routes/admin/users/ImpersonateUserButton.tsx
@@ -1,8 +1,7 @@
-import { COLOR_HINT } from '@/constants';
+import { COLOR_HINT, ImpersonateIcon } from '@/constants';
 import { impersonateUser, useCurrentUser } from '@/hooks/users';
 import type { User } from '@/types';
 import { Button } from '@radix-ui/themes';
-import { TbGhost } from 'react-icons/tb';
 
 export default function ImpersonateUserButton({ user }: {user: User}) {
   const { data : currentUser } = useCurrentUser();
@@ -15,7 +14,7 @@ export default function ImpersonateUserButton({ user }: {user: User}) {
       onClick={handleImpersonate}
       disabled={currentUser?.id === user.id || user.roles.length > 0} // Disable for disallowed impersonation targets
     >
-      <TbGhost />
+      <ImpersonateIcon />
       Impersonate
     </Button>
   );

--- a/frontend/src/routes/admin/users/ImpersonateUserButton.tsx
+++ b/frontend/src/routes/admin/users/ImpersonateUserButton.tsx
@@ -1,0 +1,22 @@
+import { COLOR_HINT } from '@/constants';
+import { impersonateUser, useCurrentUser } from '@/hooks/users';
+import type { User } from '@/types';
+import { Button } from '@radix-ui/themes';
+import { TbGhost } from 'react-icons/tb';
+
+export default function ImpersonateUserButton({ user }: {user: User}) {
+  const { data : currentUser } = useCurrentUser();
+  const handleImpersonate = () => impersonateUser(user.id);
+
+  return (
+    <Button
+      variant="soft"
+      color={COLOR_HINT}
+      onClick={handleImpersonate}
+      disabled={currentUser?.id === user.id || user.roles.length > 0} // Disable for disallowed impersonation targets
+    >
+      <TbGhost />
+      Impersonate
+    </Button>
+  );
+}

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -11,6 +11,7 @@ import Entity from 'components/Entity';
 import RoleBadge from 'components/RoleBadge';
 import { keyBy } from 'lodash';
 import AdminRegisterUserModal from './AdminRegisterUserModal';
+import ImpersonateUserButton from './ImpersonateUserButton';
 
 function RegistrationRow({ userId, team, event }: { userId: number, team: Team, event: Event }) {
   const { data : teamMembers } = useTeamMembers(team.id);
@@ -53,7 +54,9 @@ export default function UserSidebar({ entity }: { entity: User }) {
 
   return (
     <AdminSidebar>
-      <AdminSidebarHeader title={entity.name} icon={<UserIcon />} />
+      <AdminSidebarHeader title={entity.name} icon={<UserIcon />}>
+        <ImpersonateUserButton user={entity} />
+      </AdminSidebarHeader>
 
       <AdminDataList data={{ ...entity }} />
 

--- a/frontend/src/types/window.d.ts
+++ b/frontend/src/types/window.d.ts
@@ -2,5 +2,6 @@ interface Window {
   init: {
     csrfToken: string;
     userId: string | null;
+    impersonated: boolean;
   };
 }


### PR DESCRIPTION
Closes #341 and closes #197. Impersonation endpoints now update the session hash so auth will continue to function, and they have been integrated into the UI.

On the admin panel:
<img width="507" height="156" alt="image" src="https://github.com/user-attachments/assets/d5044cf6-9332-45d8-bc15-83cdad9695e8" />

After clicking the button, the admin will be signed in as that user, and see this in the navbar. It gets a special color and subtle pulse animation to draw attention to it, ensuring the admin remains aware that they are impersonating someone.
<img width="360" height="271" alt="image" src="https://github.com/user-attachments/assets/2e175570-18b3-4f28-a386-4b58ff2d9770" />

Stopping impersonation will restore the admin's session and return them to the admin panel where they were previously.
