### PR TITLE
Fix CAN_START_TEAM_TIMER Logic

### DIFF
--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -1075,6 +1075,33 @@ class Test_Event_Team_Start:
         assert "errors" in data
         assert "TEAM_HAS_STARTED" in data["errors"]["forbidden"]
 
+    def test_start_event_for_team_event_not_started(
+        self,
+        client_factory,
+        event_factory,
+        team_factory,
+        user_factory
+    ):
+        event = event_factory(
+            name = "Future Event for Team Start",
+            public = True,
+            start_time = datetime.utcnow() + timedelta(days = 1),
+            end_time = datetime.utcnow() + timedelta(days = 2),
+        )
+        user = user_factory(name = "futureuser", email = "futureuser@example.com")
+        client = client_factory(user = user)
+        team_factory(event = event, members = [user])
+
+        response = client.post(
+            self.post_endpoint(event.id),
+            json = {}
+        )
+        assert response.status_code == 403
+        data = response.get_json()
+        assert not data["success"]
+        assert "errors" in data
+        assert "EVENT_NOT_STARTED" in data["errors"]["forbidden"]
+
 
 class Test_Event_Admin_Register:
     def post_endpoint(self, event_id: int, user_id: int) -> str:

--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -1130,7 +1130,7 @@ class Test_Event_Team_Start:
         assert not data["success"]
         assert "errors" in data
         assert "EVENT_NOT_STARTED" in data["errors"]["forbidden"]
-        
+
     def test_start_near_end_of_event_end_time_is_clamped(
         self,
         client_factory,

--- a/backend/ng/permissions/controllers/get_team_management_permissions.py
+++ b/backend/ng/permissions/controllers/get_team_management_permissions.py
@@ -28,7 +28,10 @@ def get_team_management_permissions(team, user):
         return trace
     if team_member.role == TeamRole.CAPTAIN:
         trace.add_grant(PermissionEnum.CAN_EDIT_TEAM)
-        trace.add_grant(PermissionEnum.CAN_START_TEAM_TIMER)
+        if team.event.start_time is None or team.event.start_time <= datetime.utcnow():
+            trace.add_grant(PermissionEnum.CAN_START_TEAM_TIMER)
+        else:
+            trace.add_denial(PermissionEnum.CAN_START_TEAM_TIMER, DenyReason.EVENT_NOT_STARTED)
     else:
         trace.add_denial(PermissionEnum.CAN_EDIT_TEAM, DenyReason.MISSING_ROLE)
         trace.add_denial(PermissionEnum.CAN_START_TEAM_TIMER, DenyReason.MISSING_ROLE)


### PR DESCRIPTION
Fixes a permissions bug where teams could start before an event has started fixes #383 