### PR TITLE
Suppress focus on leaderboard grid

### DIFF
--- a/frontend/src/routes/events/OverviewTabs/LeaderboardTab/index.tsx
+++ b/frontend/src/routes/events/OverviewTabs/LeaderboardTab/index.tsx
@@ -51,6 +51,8 @@ export default function LeaderboardTab() {
           paginationPageSize={20}
           domLayout="autoHeight"
           loadingOverlayComponent={Spinner}
+          suppressCellFocus
+          suppressHeaderFocus
         />
       </Flex>
     </Container>


### PR DESCRIPTION
Resolves #374. Gets rid of false affordance for selection on leaderboard grid.