### PR TITLE
Reusable admin link component and unicode-safe base64

### DIFF
--- a/frontend/src/components/AdminGrid.tsx
+++ b/frontend/src/components/AdminGrid.tsx
@@ -1,4 +1,5 @@
 import { radixTheme } from '@/grid';
+import { base64ToUtf8, utf8ToBase64 } from '@/util';
 import { Flex, Spinner } from '@radix-ui/themes';
 import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
@@ -63,7 +64,7 @@ export default function AdminGrid<T>({
     if (searchParams.has('filter')) {
       const filterModel = searchParams.get('filter')!;
       try {
-        gridApi.setFilterModel(JSON.parse(atob(filterModel)));
+        gridApi.setFilterModel(JSON.parse(base64ToUtf8(filterModel)));
       } catch {
         // If parsing fails, reset filters
         gridApi.setFilterModel({});
@@ -80,7 +81,7 @@ export default function AdminGrid<T>({
         const filter = searchParams.get('filter');
         if (filter) {
           try {
-            return JSON.parse(atob(filter));
+            return JSON.parse(base64ToUtf8(filter));
           } catch {
             return {};
           }
@@ -138,7 +139,7 @@ export default function AdminGrid<T>({
           // Update the URL when grid filter model changes
             const filterModel = params.api.getFilterModel();
             if (Object.keys(filterModel).length > 0) {
-              const filterString = btoa(JSON.stringify(filterModel));
+              const filterString = utf8ToBase64(JSON.stringify(filterModel));
 
               // don't double nav if the filter won't change
               if (searchParams.get('filter') === filterString) return;

--- a/frontend/src/components/AdminLink.tsx
+++ b/frontend/src/components/AdminLink.tsx
@@ -1,0 +1,31 @@
+import { COLOR_INFO } from '@/constants';
+import { utf8ToBase64 } from '@/util';
+import { Button } from '@radix-ui/themes';
+import type { FilterModel } from 'ag-grid-community';
+import type { IconType } from 'react-icons';
+import { Link } from 'react-router';
+
+export default function AdminLink({
+  to, icon : Icon, label, id, filter,
+}: {to: string, icon?: IconType, label: string, id?: number, filter?: FilterModel}) {
+  const params = new URLSearchParams();
+
+  if (id !== undefined) {
+    params.append('id', id.toString());
+  }
+
+  if (filter !== undefined) {
+    params.append('filter', utf8ToBase64(JSON.stringify(filter)));
+  }
+
+  return (
+    <Button variant="soft" color={COLOR_INFO} asChild>
+      <Link
+        to={params.toString() ? `${to}?${params.toString()}` : to}
+      >
+        {Icon && <Icon />}
+        {label}
+      </Link>
+    </Button>
+  );
+}

--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -8,6 +8,7 @@ import type {
   MeChallenge,
   Question,
 } from '@/types';
+import { utf8ToBase64 } from '@/util';
 import useSWR, { mutate } from 'swr';
 
 export function useEventChallenges(eventId: number | null) {
@@ -122,7 +123,7 @@ export function useAdminChallengeBlueprints(challengeId: number | null) {
 }
 
 export function createChallenge(eventId: number, yaml: string) {
-  return apiMutation('/admin/challenges', { yaml : btoa(yaml), event_id : eventId }, {
+  return apiMutation('/admin/challenges', { yaml : utf8ToBase64(yaml), event_id : eventId }, {
     method : 'POST',
   }).then(() => {
     // refresh the challenges list when a new challenge is created
@@ -131,7 +132,7 @@ export function createChallenge(eventId: number, yaml: string) {
 }
 
 export function updateChallenge(challengeId: number, yaml: string) {
-  return apiMutation(`/admin/challenges/${challengeId}`, { yaml : btoa(yaml) }, {
+  return apiMutation(`/admin/challenges/${challengeId}`, { yaml : utf8ToBase64(yaml) }, {
     method : 'PUT',
   }).then(() => {
     // refresh the challenges list when a challenge is updated

--- a/frontend/src/routes/admin/challenges/ChallengeSidebar.tsx
+++ b/frontend/src/routes/admin/challenges/ChallengeSidebar.tsx
@@ -1,10 +1,11 @@
-import { COLOR_INFO, DeploymentIcon, EventIcon } from '@/constants';
+import { DeploymentIcon, EventIcon } from '@/constants';
 import type { Challenge } from '@/types';
-import { Button, Tabs } from '@radix-ui/themes';
+import { Tabs } from '@radix-ui/themes';
+import AdminLink from 'components/AdminLink';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import ChallengeIcon from 'components/ChallengeIcon';
-import { Link, useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router';
 import ChallengeDownloadButton from './ChallengeDownloadButton';
 import ChallengeUpdateModal from './ChallengeUpdateModal';
 import ChallengeAttemptsTab from './SidebarTabs/ChallengeAttemptsTab';
@@ -17,25 +18,21 @@ export default function ChallengeSidebar({ entity }: {entity: Challenge}) {
   return (
     <AdminSidebar>
       <AdminSidebarHeader title={entity.name} icon={<ChallengeIcon icon={entity.icon} />}>
-        <Button variant="soft" color={COLOR_INFO} asChild>
-          <Link to={`/admin/events?id=${entity.event_id}`}>
-            <EventIcon />
-            Event
-          </Link>
-        </Button>
-        <Button variant="soft" color={COLOR_INFO} asChild>
-          <Link
-            to={`/admin/deployments/?filter=${btoa(JSON.stringify(
-              {
-                challenge_name : { filterType : 'text', type : 'equals', filter : entity.name },
-                event_name : { filterType : 'text', type : 'equals', filter : entity.event_name },
-              },
-            ))}`}
-          >
-            <DeploymentIcon />
-            Deployments
-          </Link>
-        </Button>
+        <AdminLink
+          to="/admin/events"
+          id={entity.event_id}
+          icon={EventIcon}
+          label="Event"
+        />
+        <AdminLink
+          to="/admin/deployments"
+          filter={{
+            challenge_name : { filterType : 'text', type : 'equals', filter : entity.name },
+            event_name : { filterType : 'text', type : 'equals', filter : entity.event_name },
+          }}
+          icon={DeploymentIcon}
+          label="Deployments"
+        />
         <ChallengeUpdateModal challengeId={entity.id} />
         <ChallengeDownloadButton challenge={entity} />
       </AdminSidebarHeader>

--- a/frontend/src/routes/admin/deployments/DeploymentSidebar.tsx
+++ b/frontend/src/routes/admin/deployments/DeploymentSidebar.tsx
@@ -1,5 +1,5 @@
 import {
-  COLOR_INFO,
+  ChallengeIcon,
   DeploymentIcon,
   EventIcon,
   TeamIcon,
@@ -7,17 +7,12 @@ import {
 } from '@/constants';
 import { useDeploymentServices } from '@/hooks/container';
 import type { Deployment } from '@/types';
-import {
-  Button,
-  Code,
-  Skeleton,
-  Table,
-} from '@radix-ui/themes';
+import { Code, Skeleton, Table } from '@radix-ui/themes';
+import AdminLink from 'components/AdminLink';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout, WarningCallout } from 'components/Callouts';
 import Entity from 'components/Entity';
-import { Link } from 'react-router';
 import ServiceRow from './ServiceRow';
 
 export default function DeploymentSidebar({ entity }: {entity: Deployment}) {
@@ -26,18 +21,24 @@ export default function DeploymentSidebar({ entity }: {entity: Deployment}) {
   return (
     <AdminSidebar>
       <AdminSidebarHeader title={`${entity.challenge_name} - ${entity.team_name}`} icon={<DeploymentIcon />}>
-        <Button variant="soft" color={COLOR_INFO} asChild>
-          <Link to={`/admin/teams?id=${entity.team_id}`}>
-            <TeamIcon />
-            Team
-          </Link>
-        </Button>
-        <Button variant="soft" color={COLOR_INFO} asChild>
-          <Link to={`/admin/events?id=${entity.event_id}`}>
-            <EventIcon />
-            Event
-          </Link>
-        </Button>
+        <AdminLink
+          to="/admin/challenges"
+          id={entity.challenge_id}
+          icon={ChallengeIcon}
+          label="Challenge"
+        />
+        <AdminLink
+          to="/admin/teams"
+          id={entity.team_id}
+          icon={TeamIcon}
+          label="Team"
+        />
+        <AdminLink
+          to="/admin/events"
+          id={entity.event_id}
+          icon={EventIcon}
+          label="Event"
+        />
       </AdminSidebarHeader>
 
       <AdminSidebarHeader title="Services" />

--- a/frontend/src/routes/admin/events/AdminChallengeCard.tsx
+++ b/frontend/src/routes/admin/events/AdminChallengeCard.tsx
@@ -1,8 +1,5 @@
-import { COLOR_INFO, DeploymentIcon } from '@/constants';
 import type { Challenge } from '@/types';
 import {
-  Box,
-  Button,
   Card,
   Flex,
   Heading,
@@ -13,30 +10,18 @@ import { Link } from 'react-router';
 
 export default function AdminChallengeCard({ challenge }: { challenge: Challenge }) {
   return (
-    <Card>
-      <Flex direction="row" align="center" justify="between" gap="2">
-        <Box>
-          <Flex direction="row" align="center" gap="1">
-            <ChallengeIcon icon={challenge.icon} />
-            <Heading size="3">
-              {challenge.name}
-            </Heading>
-          </Flex>
-          <Text color="gray">
-            {challenge.summary}
-          </Text>
-        </Box>
-        <Flex direction="row" align="center" gap="2">
-          <Button variant="ghost" color={COLOR_INFO} asChild className="!m-0">
-            <Link
-              to={`/admin/deployments/?filter=${btoa(JSON.stringify({ challenge_name : { filterType : 'text', type : 'equals', filter : challenge.name } }))}`}
-            >
-              <DeploymentIcon />
-              Deployments
-            </Link>
-          </Button>
+    <Card asChild>
+      <Link to={`/admin/challenges?id=${challenge.id}`}>
+        <Flex direction="row" align="center" gap="1">
+          <ChallengeIcon icon={challenge.icon} />
+          <Heading size="3">
+            {challenge.name}
+          </Heading>
         </Flex>
-      </Flex>
+        <Text color="gray">
+          {challenge.summary}
+        </Text>
+      </Link>
     </Card>
   );
 }

--- a/frontend/src/routes/admin/events/EventSidebar.tsx
+++ b/frontend/src/routes/admin/events/EventSidebar.tsx
@@ -1,17 +1,11 @@
-import {
-  COLOR_INFO,
-  DeploymentIcon,
-  EventIcon,
-  TeamIcon,
-} from '@/constants';
+import { DeploymentIcon, EventIcon, TeamIcon } from '@/constants';
 import { useAdminEventChallenges } from '@/hooks/challenge';
 import type { Event } from '@/types';
-import { Button } from '@radix-ui/themes';
+import AdminLink from 'components/AdminLink';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout } from 'components/Callouts';
 import EventHeader from 'components/EventHeader';
-import { Link } from 'react-router';
 import AdminChallengeCard from './AdminChallengeCard';
 import ChallengeUploadModal from './ChallengeUploadModal';
 import EventModal from './EventModal';
@@ -22,18 +16,18 @@ export default function EventSidebar({ entity }: { entity: Event }) {
   return (
     <AdminSidebar>
       <AdminSidebarHeader title={entity.name} icon={<EventIcon />}>
-        <Button variant="soft" color={COLOR_INFO} asChild>
-          <Link to={`/admin/deployments?filter=${btoa(JSON.stringify({ event_name : { filterType : 'text', type : 'equals', filter : entity.name } }))}`}>
-            <DeploymentIcon />
-            Deployments
-          </Link>
-        </Button>
-        <Button variant="soft" color={COLOR_INFO} asChild>
-          <Link to={`/admin/teams?filter=${btoa(JSON.stringify({ event_name : { filterType : 'text', type : 'equals', filter : entity.name } }))}`}>
-            <TeamIcon />
-            Teams
-          </Link>
-        </Button>
+        <AdminLink
+          to="/admin/deployments"
+          filter={{ event_name : { filterType : 'text', type : 'equals', filter : entity.name } }}
+          icon={DeploymentIcon}
+          label="Deployments"
+        />
+        <AdminLink
+          to="/admin/teams"
+          filter={{ event_name : { filterType : 'text', type : 'equals', filter : entity.name } }}
+          icon={TeamIcon}
+          label="Teams"
+        />
         <EventModal eventToUpdate={entity} />
       </AdminSidebarHeader>
 

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -1,5 +1,4 @@
 import {
-  COLOR_INFO,
   DeploymentIcon,
   EventIcon,
   TeamIcon,
@@ -7,19 +6,19 @@ import {
 } from '@/constants';
 import { useTeamMembers } from '@/hooks/team';
 import type { Team } from '@/types';
-import { Button, Flex, Table } from '@radix-ui/themes';
+import { Flex, Table } from '@radix-ui/themes';
 import AdminDataList from 'components/AdminDataList';
+import AdminLink from 'components/AdminLink';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout } from 'components/Callouts';
 import Entity from 'components/Entity';
 import RoleBadge from 'components/RoleBadge';
-import { Link } from 'react-router';
+import EditTeamModal from './EditTeamModal';
 import KickUserModal from './KickUserModal';
 import PromoteUserModal from './PromoteUserModal';
 import ScoreAdjustModal from './ScoreAdjustModal';
 import TeamActivity from './TeamActivity';
-import EditTeamModal from './EditTeamModal';
 
 export default function TeamSidebar({ entity }: { entity: Team }) {
   const { data : members, error : membersError } = useTeamMembers(entity.id);
@@ -27,24 +26,21 @@ export default function TeamSidebar({ entity }: { entity: Team }) {
   return (
     <AdminSidebar>
       <AdminSidebarHeader title={entity.name} icon={<TeamIcon />}>
-        <Button variant="soft" color={COLOR_INFO} asChild>
-          <Link to={`/admin/deployments?filter=${btoa(JSON.stringify(
-            {
-              team_name : { filterType : 'text', type : 'equals', filter : entity.name },
-              event_name : { filterType : 'text', type : 'equals', filter : entity.event_name },
-            },
-          ))}`}
-          >
-            <DeploymentIcon />
-            Deployments
-          </Link>
-        </Button>
-        <Button variant="soft" color={COLOR_INFO} asChild>
-          <Link to={`/admin/events?id=${entity.event_id}`}>
-            <EventIcon />
-            Event
-          </Link>
-        </Button>
+        <AdminLink
+          to="/admin/deployments"
+          filter={{
+            team_name : { filterType : 'text', type : 'equals', filter : entity.name },
+            event_name : { filterType : 'text', type : 'equals', filter : entity.event_name },
+          }}
+          icon={DeploymentIcon}
+          label="Deployments"
+        />
+        <AdminLink
+          to="/admin/events"
+          id={entity.event_id}
+          icon={EventIcon}
+          label="Event"
+        />
         <EditTeamModal teamToUpdate={entity} />
       </AdminSidebarHeader>
       <AdminDataList data={{ ...entity }} />

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -7,6 +7,7 @@ import {
   useWorkspaceStatus,
 } from '@/hooks/users';
 import type { Event, Team, User } from '@/types';
+import { utf8ToBase64 } from '@/util';
 import { Table } from '@radix-ui/themes';
 import AdminDataList from 'components/AdminDataList';
 import AdminSidebar from 'components/AdminSidebar';
@@ -40,7 +41,10 @@ function RegistrationRow({ userId, team, event }: { userId: number, team: Team, 
         <Entity
           label={team.name}
           icon={TeamIcon}
-          to={`/admin/teams?id=${team.id}&filter=${btoa(JSON.stringify({ event_name : { filterType : 'text', type : 'equals', filter : event.name } }))}`}
+          to={
+            `/admin/teams?id=${team.id}&filter=${
+              encodeURIComponent(utf8ToBase64(JSON.stringify({ event_name : { filterType : 'text', type : 'equals', filter : event.name } })))}`
+          }
         />
       </Table.Cell>
       <Table.Cell>

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -20,7 +20,7 @@ export function adjustDateForInput(date: Date | null): string | null {
 export function utf8ToBase64(str: string): string {
   const encoder = new TextEncoder();
   const data = encoder.encode(str);
-  const binary = Array.from(data).map((byte) => String.fromCodePoint(byte)).join('');
+  const binary = Array.from(data, (byte) => String.fromCodePoint(byte)).join('');
   return btoa(binary);
 }
 

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -31,7 +31,7 @@ export function utf8ToBase64(str: string): string {
  */
 export function base64ToUtf8(str: string): string {
   const binary = atob(str);
-  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  const bytes = Uint8Array.from(binary, (c) => c.codePointAt(0) as number);
   const decoder = new TextDecoder();
   return decoder.decode(bytes);
 }

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -3,7 +3,6 @@
  * @param date Date object to format
  * @returns String compatible with datetime-local input
  */
-// eslint-disable-next-line import/prefer-default-export
 export function adjustDateForInput(date: Date | null): string | null {
   // Adjust the date to be in the format required by datetime-local input
   if (date === null) return null;
@@ -11,4 +10,28 @@ export function adjustDateForInput(date: Date | null): string | null {
   const offset = dateObj.getTimezoneOffset();
   const localDate = new Date(dateObj.getTime() - (offset * 60 * 1000));
   return localDate.toISOString().slice(0, 16);
+}
+
+/**
+ * Safely encodes a UTF-8 string to Base64.
+ * @param str - The UTF-8 string to encode.
+ * @returns The Base64 encoded string.
+ */
+export function utf8ToBase64(str: string): string {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(str);
+  const binary = Array.from(data).map((byte) => String.fromCodePoint(byte)).join('');
+  return btoa(binary);
+}
+
+/**
+ * Safely decodes a Base64 string to a UTF-8 string.
+ * @param base64 - The Base64 encoded string to decode.
+ * @returns The decoded UTF-8 string.
+ */
+export function base64ToUtf8(str: string): string {
+  const binary = atob(str);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  const decoder = new TextDecoder();
+  return decoder.decode(bytes);
 }


### PR DESCRIPTION
Resolves #395.

- Adds `base64ToUtf8` and `utf8ToBase64` utils for Unicode-safe base64 conversions, and uses them where the unsafe `atob`/`btoa` were previously used. This allows unicode to be used in base64 strings, which would previously result in an exception and potential UI crash.
  - See https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa#unicode_strings
- Adds AdminLink component for reusable logic for link buttons to navigate between admin pages.