### PR TITLE
Display variables on challenge and deployment admin panels

### DIFF
--- a/backend/ng/challenge/models/ChallengeVariable.py
+++ b/backend/ng/challenge/models/ChallengeVariable.py
@@ -28,6 +28,18 @@ class ChallengeVariable(db.Model):
     def __repr__(self):
         return f"<NgChallengeVariable {self.id}, name={self.name}>"
 
+    def serialize(self, include_admin_fields=False):
+      if not include_admin_fields:
+        # Do not expose variable details to non-admins
+        return {}
+
+      return {
+        "id": self.id,
+        "name": self.name,
+        "default": self.default,
+        "template": self.template,
+      }
+
     @classmethod
     def validate(cls, data: dict[str, Any]) -> dict[str, Any]:
         """

--- a/backend/ng/challenge/models/Question.py
+++ b/backend/ng/challenge/models/Question.py
@@ -65,7 +65,7 @@ class Question(db.Model):
             "challenge_id": self.challenge_id,
         }
         if include_admin_fields:
-            data["answer"] = self.answer_variable.name if self.answer_variable else "\"" + self.answer + "\""
+            data["answer"] = self.answer_variable.name if self.answer_variable else f'"{self.answer}"'
 
         return data
 

--- a/backend/ng/challenge/models/Question.py
+++ b/backend/ng/challenge/models/Question.py
@@ -65,7 +65,7 @@ class Question(db.Model):
             "challenge_id": self.challenge_id,
         }
         if include_admin_fields:
-            data["answer"] = self.answer_variable.template if self.answer_variable else self.answer
+            data["answer"] = self.answer_variable.name if self.answer_variable else "\"" + self.answer + "\""
 
         return data
 

--- a/backend/ng/challenge/routes/admin_routes.py
+++ b/backend/ng/challenge/routes/admin_routes.py
@@ -165,6 +165,17 @@ class ChallengeAttempts(Resource):
 
         return success_response(attempts)
 
+
+@challenge_admin_namespace.route("/<int:challenge_id>/variables")
+class ChallengeVars(Resource):
+    @admin_endpoint()
+    @load_challenge(source = LoaderType.PARAM)
+    def get(self, challenge: Challenge, **kwargs):
+        """
+        Get the variables for a specific challenge, including defaults/templates.
+        """
+        return success_response(challenge.variables)
+
 @challenge_admin_namespace.route("/<int:challenge_id>/pull")
 class PullImages(Resource):
     @challenge_admin_namespace.doc(

--- a/backend/ng/containers/routes/admin_routes.py
+++ b/backend/ng/containers/routes/admin_routes.py
@@ -1,5 +1,7 @@
 from flask_restx import Namespace, Resource
 from flask import request
+from ...challenge.utils import generate_seed
+from ...challenge.models import Challenge
 from ..controllers.get_stats import get_stats
 from ..controllers.admin_exec import admin_exec
 from ..models.ContainerInstance import ContainerInstance
@@ -10,7 +12,9 @@ from ...core.middleware import (
 
 from ...core.middleware.loaders import (
     LoaderType,
+    load_team,
     load_container_instance,
+    load_challenge
 )
 
 from ...core.utils import (
@@ -66,7 +70,28 @@ class ServiceGroup(Resource):
         res = ContainerInstance.get_service_group(challenge_id, team_id)
         return success_response(res)
 
+@admin_container_namespace.route("/challenge/<int:challenge_id>/team/<int:team_id>/variables")
+class ContainerVars(Resource):
+    @admin_container_namespace.doc(
+        description="Get Container instance variables for a challenge given a team",
+        params={
+            "challenge_id": "Id of the challenge",
+            "team_id": "Id of the team",
+        },
+        responses={
+            200: "Success",
+            400: "Bad request"
+        },
+    )
+    @load_team(LoaderType.PARAM)
+    @load_challenge(LoaderType.PARAM)
+    @admin_endpoint()
+    def get(self, challenge: Challenge, team, **kwargs):
+      # create answer variable to question map to ensure seeding is consistent with questions/env
+      qids = {q.answer_variable_id: q.id  for q in challenge.questions}
 
+      values = {v.name: v.as_attr().template.eval(generate_seed(challenge.event_id, challenge.id, qids.get(v.id), team_seed=team.seed)) for v in challenge.variables}
+      return success_response(values)
 
 @admin_container_namespace.route("/<int:container_instance_id>/status")
 class InstanceStatus(Resource):

--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -3,6 +3,7 @@ import type {
   AdminQuestion,
   Attempt,
   Challenge,
+  ChallengeVariable,
   ContainerBlueprint,
   Hint,
   MeChallenge,
@@ -113,6 +114,12 @@ export function useAdminChallengeQuestions(challengeId: number | null) {
 export function useAdminChallengeHints(challengeId: number | null) {
   return useSWR<Hint[], Error>(
     challengeId ? `/admin/challenges/${challengeId}/hints` : null,
+  );
+}
+
+export function useAdminChallengeVariables(challengeId: number | null) {
+  return useSWR<ChallengeVariable[], Error>(
+    challengeId ? `/admin/challenges/${challengeId}/variables` : null,
   );
 }
 

--- a/frontend/src/hooks/container.ts
+++ b/frontend/src/hooks/container.ts
@@ -33,6 +33,10 @@ export function useDeploymentServices(challengeId: number, teamId: number) {
   return useSWR<ContainerInstance[], Error>(`/admin/container/challenge/${challengeId}/team/${teamId}/services`);
 }
 
+export function useDeploymentVariables(challengeId: number, teamId: number) {
+  return useSWR<Record<string, string>, Error>(`/admin/container/challenge/${challengeId}/team/${teamId}/variables`);
+}
+
 export function useContainerStatus(id: number) {
   return useSWR<ContainerStatus, Error>(`/admin/container/${id}/status`, {
     refreshInterval : 5000, // Refresh every 5 seconds

--- a/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeBlueprintTab.tsx
+++ b/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeBlueprintTab.tsx
@@ -96,7 +96,7 @@ export default function ChallengeBlueprintTab({ challengeId }: {challengeId: num
         <ErrorCallout key={err} className="mt-2">{err}</ErrorCallout>
       ))}
 
-      <Grid columns="2" mt="2">
+      <Grid columns="2" gap="2" mt="2">
         {blueprints?.map((blueprint) => (
           <Card key={blueprint.id} className="mb-3">
             <AdminSidebarHeader title={blueprint.name} icon={<TbPackage />}>

--- a/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeDetailsTab.tsx
+++ b/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeDetailsTab.tsx
@@ -1,13 +1,15 @@
-import { useAdminChallengeHints, useAdminChallengeQuestions } from '@/hooks/challenge';
+import { useAdminChallengeHints, useAdminChallengeQuestions, useAdminChallengeVariables } from '@/hooks/challenge';
 import type { Challenge } from '@/types';
-import { Table } from '@radix-ui/themes';
+import { Code, Table } from '@radix-ui/themes';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
-import { ErrorCallout } from 'components/Callouts';
+import { ErrorCallout, InfoCallout } from 'components/Callouts';
 import RadixMarkdown from 'components/RadixMarkdown';
+import { TbVariable } from 'react-icons/tb';
 
 export default function ChallengeDetailsTab({ challenge }: {challenge: Challenge}) {
   const { data : questions, error : questionsError } = useAdminChallengeQuestions(challenge.id);
   const { data : hints, error : hintsError } = useAdminChallengeHints(challenge.id);
+  const { data : variables, error : varsError } = useAdminChallengeVariables(challenge.id);
 
   return (
     <>
@@ -18,7 +20,8 @@ export default function ChallengeDetailsTab({ challenge }: {challenge: Challenge
 
       <AdminSidebarHeader title="Questions" />
       {questionsError && <ErrorCallout>{questionsError.message}</ErrorCallout> }
-      {questions
+      {questions && questions.length === 0 && <InfoCallout>This challenge does not have any questions.</InfoCallout>}
+      {questions && questions.length > 0
         && (
         <Table.Root>
           <Table.Header>
@@ -35,7 +38,10 @@ export default function ChallengeDetailsTab({ challenge }: {challenge: Challenge
               <Table.Row key={q.id}>
                 <Table.Cell>{q.name}</Table.Cell>
                 <Table.Cell>{q.body}</Table.Cell>
-                <Table.Cell>{q.answer}</Table.Cell>
+                <Table.Cell>
+                  {q.answer.startsWith('"') ? null : <TbVariable className="inline me-1 opacity-50" aria-label="Variable" />}
+                  {q.answer.replace(/^"(.*)"$/, '$1')}
+                </Table.Cell>
                 <Table.Cell>{q.max_attempts}</Table.Cell>
                 <Table.Cell>{q.points}</Table.Cell>
               </Table.Row>
@@ -46,7 +52,8 @@ export default function ChallengeDetailsTab({ challenge }: {challenge: Challenge
 
       <AdminSidebarHeader title="Hints" />
       {hintsError && <ErrorCallout>{hintsError.message}</ErrorCallout> }
-      {hints
+      {hints && hints.length === 0 && <InfoCallout>This challenge does not have any hints.</InfoCallout>}
+      {hints && hints.length > 0
         && (
         <Table.Root>
           <Table.Header>
@@ -64,6 +71,34 @@ export default function ChallengeDetailsTab({ challenge }: {challenge: Challenge
                 <Table.Cell>{h.preview}</Table.Cell>
                 <Table.Cell>{h.body}</Table.Cell>
                 <Table.Cell>{h.deduction}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+        )}
+
+      <AdminSidebarHeader title="Variables" />
+      {varsError && <ErrorCallout>{varsError.message}</ErrorCallout> }
+      {variables && variables.length === 0 && <InfoCallout>This challenge does not have any variables.</InfoCallout>}
+      {variables && variables.length > 0
+        && (
+        <Table.Root>
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Default</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Template</Table.ColumnHeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {variables?.map((v) => (
+              <Table.Row key={v.id}>
+                <Table.Cell>
+                  <TbVariable className="inline me-1 opacity-50" aria-label="Variable" />
+                  {v.name}
+                </Table.Cell>
+                <Table.Cell>{v.default}</Table.Cell>
+                <Table.Cell><Code color="gray">{v.template}</Code></Table.Cell>
               </Table.Row>
             ))}
           </Table.Body>

--- a/frontend/src/routes/admin/deployments/DeploymentSidebar.tsx
+++ b/frontend/src/routes/admin/deployments/DeploymentSidebar.tsx
@@ -4,17 +4,19 @@ import {
   EventIcon,
   TeamIcon,
 } from '@/constants';
-import { useDeploymentServices } from '@/hooks/container';
+import { useDeploymentServices, useDeploymentVariables } from '@/hooks/container';
 import type { Deployment } from '@/types';
-import { Grid, Skeleton } from '@radix-ui/themes';
+import { Grid, Skeleton, Table } from '@radix-ui/themes';
 import AdminLink from 'components/AdminLink';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
-import { ErrorCallout } from 'components/Callouts';
+import { ErrorCallout, InfoCallout } from 'components/Callouts';
+import { TbVariable } from 'react-icons/tb';
 import ServiceCard from './ServiceCard';
 
 export default function DeploymentSidebar({ entity }: {entity: Deployment}) {
   const { data : serviceData, error } = useDeploymentServices(entity.challenge_id, entity.team_id);
+  const { data : variables, error : varsError } = useDeploymentVariables(entity.challenge_id, entity.team_id);
 
   return (
     <AdminSidebar>
@@ -42,12 +44,36 @@ export default function DeploymentSidebar({ entity }: {entity: Deployment}) {
       <AdminSidebarHeader title="Services" />
       {error && <ErrorCallout>{error.message}</ErrorCallout>}
       <Skeleton loading={!serviceData}>
-        <Grid columns="2">
+        <Grid columns="2" gap="2">
           { serviceData?.map((service) => (
             <ServiceCard key={service.id} service={service} />
           )) }
         </Grid>
       </Skeleton>
+
+      <AdminSidebarHeader title="Variables" />
+      {varsError && <ErrorCallout>{varsError.message}</ErrorCallout> }
+      {variables && Object.keys(variables).length === 0 && <InfoCallout>This challenge does not have any variables.</InfoCallout>}
+      {variables && Object.keys(variables).length > 0
+      && (
+        <Table.Root>
+          <Table.Header>
+            <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>Value</Table.ColumnHeaderCell>
+          </Table.Header>
+          <Table.Body>
+            {Object.entries(variables || {}).map(([ key, value ]) => (
+              <Table.Row key={key}>
+                <Table.Cell>
+                  <TbVariable className="inline me-1 opacity-50" aria-label="Variable" />
+                  {key}
+                </Table.Cell>
+                <Table.Cell>{value as string}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
     </AdminSidebar>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -83,6 +83,7 @@ export interface AdminQuestion extends Question {
 export interface Hint {
   id: number;
   challenge_id: number;
+  name: string;
   preview: string;
   body: string | null; // Null if hint has not been redeemed, string if it has.
   deduction: number;
@@ -280,4 +281,11 @@ export interface Workspace {
   hostip : string;
   dockerid : string;
   user : number;
+}
+
+export interface ChallengeVariable {
+  id: number;
+  name: string;
+  default: string;
+  template: string;
 }


### PR DESCRIPTION
Challenges show variables with their default/template values. Variable names are used in the question table instead of templates to save space. Also shows callouts instead of empty tables when nothing is present.
<img width="1132" height="725" alt="Screenshot From 2025-11-20 12-18-09" src="https://github.com/user-attachments/assets/e5d65943-158a-46f0-b0f1-5aa22a98a34b" />
The Question serializer has been updated to wrap literal string answers with quotes to distinguish them from variables. We can reliably distinguish them this way, since a variable won't have quotes in its name.

Deployments show variables rendered for the corresponding team:
<img width="1132" height="477" alt="Screenshot From 2025-11-20 12-16-05" src="https://github.com/user-attachments/assets/d0d59bdf-ee77-4350-bae4-8ed06e97e7ba" />
