### PR TITLE
Markdown styling improvements

### DIFF
--- a/frontend/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/frontend/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1,8 +1,8 @@
-import { nord } from '@milkdown/theme-nord';
 import { Crepe } from '@milkdown/crepe';
+import { automd } from '@milkdown/plugin-automd';
 import { listener as listenerPlugin } from '@milkdown/plugin-listener';
 import { Milkdown, MilkdownProvider, useEditor } from '@milkdown/react';
-import { automd } from '@milkdown/plugin-automd';
+import { nord } from '@milkdown/theme-nord';
 
 import '@milkdown/crepe/theme/common/style.css';
 import '@milkdown/crepe/theme/nord.css';
@@ -36,6 +36,7 @@ function CrepeEditor({
   const featureConfigs = {
     placeholder : {
       text : 'Type here...',
+      mode : 'doc' as const,
     },
   };
 

--- a/frontend/src/components/RichTextEditor/milkdown.module.css
+++ b/frontend/src/components/RichTextEditor/milkdown.module.css
@@ -2,10 +2,31 @@
 
 .milkdownEditor :global(.milkdown) {
   /* Text color */
-  --crepe-color-on-background : var(--gray-12);
+  --crepe-color-on-background : var(--gray-a11);
   /* Background color */
   --crepe-color-background: var(--gray-1);
-  --crepe-color-selected: var(--accent-8);
+  --crepe-color-selected: var(--accent-a8);
+  --crepe-color-hover: var(--accent-a8);
+
+  --crepe-color-surface: var(--color-panel);
+  --crepe-color-surface-low: var(--color-panel);
+
+  --crepe-color-on-surface: var(--gray-12);
+  --crepe-color-outline: var(--gray-12);
+  --crepe-color-on-surface-variant: var(--accent-contrast);
+
+  --crepe-color-primary: var(--accent-9);
+  --crepe-color-secondary: var(--accent-9);
+  --crepe-color-on-primary: var(--accent-contrast);
+
+  --crepe-color-inline-area: var(--gray-a3);
+  --crepe-color-inline-code: var(--gray-a11);
+
+  --crepe-font-title: var(--heading-font-family);
+  --crepe-font-text: var(--default-font-family);
+
+  --crepe-shadow-1: var(--base-card-surface-box-shadow);
+  --crepe-shadow-2: var(--base-card-surface-box-shadow);
 }
 
 .milkdownEditor :global(.milkdown .editor) {
@@ -19,8 +40,44 @@
   display : none;
 }
 
-/* End Milkdown Overrides */
+.milkdownEditor :global(.milkdown .ProseMirror h1) {
+  font-size: var(--font-size-6);
+  line-height: var(--heading-line-height-6);
+  font-weight: var(--font-weight-bold);
+  color: var(--gray-12);
+  margin: 0;
+}
 
+.milkdownEditor :global(.milkdown .ProseMirror h2) {
+  font-size: var(--font-size-5);
+  line-height: var(--heading-line-height-5);
+  font-weight: var(--font-weight-bold);
+  color: var(--gray-12);
+  margin: 0;
+}
+
+.milkdownEditor :global(.milkdown .ProseMirror h3) {
+  font-size: var(--font-size-4);
+  line-height: var(--heading-line-height-4);
+  font-weight: var(--font-weight-bold);
+  color: var(--gray-12);
+  margin: 0;
+}
+
+.milkdownEditor :global(.milkdown .ProseMirror h4), :global(.milkdown .ProseMirror h5), :global(.milkdown .ProseMirror h6) {
+  font-size: var(--font-size-3);
+  line-height: var(--heading-line-height-3);
+  font-weight: var(--font-weight-bold);
+  color: var(--gray-12);
+  margin: 0;
+}
+
+.milkdownEditor :global(.milkdown .ProseMirror th) {
+  font-weight: var(--font-weight-bold);
+  color: var(--gray-12);
+}
+
+/* End Milkdown Overrides */
 
 .milkdownEditor :global(.milkdown .milkdown-slash-menu), .milkdownEditor :global(.milkdown .milkdown-toolbar) {
   z-index: 3;

--- a/frontend/src/components/RichTextEditor/milkdown.module.css
+++ b/frontend/src/components/RichTextEditor/milkdown.module.css
@@ -13,10 +13,10 @@
 
   --crepe-color-on-surface: var(--gray-12);
   --crepe-color-outline: var(--gray-12);
-  --crepe-color-on-surface-variant: var(--accent-contrast);
+  --crepe-color-on-surface-variant: var(--gray-12);
 
-  --crepe-color-primary: var(--accent-9);
-  --crepe-color-secondary: var(--accent-9);
+  --crepe-color-primary: var(--accent-8);
+  --crepe-color-secondary: var(--accent-8);
   --crepe-color-on-primary: var(--accent-contrast);
 
   --crepe-color-inline-area: var(--gray-a3);
@@ -75,6 +75,10 @@
 .milkdownEditor :global(.milkdown .ProseMirror th) {
   font-weight: var(--font-weight-bold);
   color: var(--gray-12);
+}
+
+.milkdownEditor :global(.milkdown .ProseMirror table) {
+  width: auto;
 }
 
 /* End Milkdown Overrides */

--- a/frontend/src/components/TicketMessagesCard/index.tsx
+++ b/frontend/src/components/TicketMessagesCard/index.tsx
@@ -8,7 +8,6 @@ import {
 import RadixMarkdown from 'components/RadixMarkdown';
 import { map } from 'lodash';
 import { twMerge } from 'tailwind-merge';
-import styles from './ticketMessagesCard.module.css';
 
 export default function TicketMessagesCard({
   messages,
@@ -25,7 +24,7 @@ export default function TicketMessagesCard({
         <Card
           className={
             twMerge(
-              message.author_id === currentUserId ? styles.cardSelf : styles.cardResponder,
+              message.author_id === currentUserId ? '' : 'outline outline-(--accent-8)',
               'mb-2',
               className,
             )

--- a/frontend/src/components/TicketMessagesCard/index.tsx
+++ b/frontend/src/components/TicketMessagesCard/index.tsx
@@ -24,7 +24,7 @@ export default function TicketMessagesCard({
         <Card
           className={
             twMerge(
-              message.author_id === currentUserId ? '' : 'outline outline-(--accent-8)',
+              message.author_id !== currentUserId && 'before:!bg-(--accent-2)',
               'mb-2',
               className,
             )

--- a/frontend/src/components/TicketMessagesCard/ticketMessagesCard.module.css
+++ b/frontend/src/components/TicketMessagesCard/ticketMessagesCard.module.css
@@ -1,8 +1,0 @@
-
-.cardResponder:global(.rt-Card:where(.rt-variant-surface)::before){
-  background-color: light-dark(var(--accent-2), var(--accent-5));
-}
-
-.cardSelf:global(.rt-Card:where(.rt-variant-surface)::before){
-  background-color: light-dark(var(--gray-2), var(--gray-5))
-}


### PR DESCRIPTION
Resolves #408.

- Tweaks milkdown styling to improve consistency with radix, and to better follow dark/light theme settings.
- Tweaks ticket card backdrops to always use palette stop 2, as palette stop 5 had contrast issues with slightly gray markdown text rendered above it.
- Changes placeholder mode to `doc` to prevent showing placeholder text on every line of the editor. This now behaves consistently with other TextAreas in the application.

<img width="422" height="1267" alt="image" src="https://github.com/user-attachments/assets/4e9aee95-b3af-4fa2-9e4c-5930cafb3a09" />
