### PR TITLE
Minimal event image model implementation

### DIFF
--- a/backend/ng/event/models/Event.py
+++ b/backend/ng/event/models/Event.py
@@ -23,6 +23,7 @@ class Event(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(config.EVENT_NAME_MAX_LENGTH), nullable=False, unique=True)
     description = db.Column(db.Text, nullable=True)
+    image = db.Column(db.String(255), nullable=True)
     max_team_size = db.Column(db.Integer, default=config.MAX_TEAM_SIZE, nullable=False)
     start_time = db.Column(db.DateTime, nullable=True)
     end_time = db.Column(db.DateTime, nullable=True)
@@ -80,6 +81,7 @@ class Event(db.Model):
             "id": self.id,
             "name": self.name,
             "description": self.description,
+            "image": self.image,
             "max_team_size": self.max_team_size,
             "start_time": self.start_time.isoformat() + "Z" if self.start_time else None,
             "end_time": self.end_time.isoformat() + "Z" if self.end_time else None,
@@ -112,6 +114,13 @@ class Event(db.Model):
             config.EVENT_DESCRIPTION_MAX_LENGTH,
             required=False,
             friendly_name="Event description",
+        )
+        validator.validate_string(
+            data,
+            "image",
+            255,
+            required=False,
+            friendly_name="Event image filename",
         )
         validator.validate_integer_range(
             data,
@@ -174,6 +183,7 @@ class Event(db.Model):
         cls,
         name: str,
         description: str = "",
+        image: str | None = None,
         max_team_size: int | None = config.MAX_TEAM_SIZE,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
@@ -208,6 +218,7 @@ class Event(db.Model):
         event = cls(
             name=name,
             description=description,
+            image=image,
             max_team_size=max_team_size,
             start_time=start_time,
             end_time=end_time,

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -42,6 +42,21 @@ export default function EventDataForm({
         )}
       </FormField>
 
+      <FormField label="Image" error={errors.image}>
+        {(injected) => (
+          <TextField.Root
+            placeholder="Image"
+            {...register('image', {
+              maxLength : {
+                value : 255,
+                message : 'Image name cannot exceed 255 characters',
+              },
+            })}
+            {...injected}
+          />
+        )}
+      </FormField>
+
       <Flex direction="row" gap="2" className="*:grow *:basis-0">
 
         <FormField label="Public" error={errors.public}>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2,6 +2,7 @@ export interface Event {
   id: number;
   name: string;
   description?: string | null;
+  image?: string | null;
   max_team_size: number;
   start_time?: Date;
   end_time?: Date;


### PR DESCRIPTION
Resolves #427. Added `image` field to the Event model, which is configurable with the event.

Once S3 stuff is merged, this can be connected to images on the frontend - for now this is just the model change and minimal admin UI.