### PR TITLE
Landing page and navbar polish/accessibility

### DIFF
--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -2,6 +2,7 @@ import { useRoutes } from 'react-router';
 
 import NotFound from 'components/NotFound';
 import Dashboard from 'routes/dashboard';
+import Landing from 'routes/dashboard/Landing';
 import Profile from 'routes/profile';
 
 import RequireUser from 'components/RequireUser';
@@ -19,20 +20,20 @@ import Overview from 'routes/events/Overview';
 import Challenge from 'routes/events/challenge';
 
 // Admin Section
+import AdminAnnouncements from 'routes/admin/announcements';
 import AdminApiTest from 'routes/admin/api-test';
 import AdminChallenges from 'routes/admin/challenges';
 import AdminDashboard from 'routes/admin/dashboard';
 import AdminDeployments from 'routes/admin/deployments';
 import AdminEvents from 'routes/admin/events';
 import AdminLayout from 'routes/admin/layout';
-import AdminAnnouncements from 'routes/admin/announcements';
 import AdminReports from 'routes/admin/reports';
 import AdminSettings from 'routes/admin/settings';
+import AdminSponsors from 'routes/admin/sponsors';
 import AdminTags from 'routes/admin/tags';
 import AdminTeams from 'routes/admin/teams';
 import AdminTickets from 'routes/admin/tickets';
 import AdminUsers from 'routes/admin/users';
-import AdminSponsors from 'routes/admin/sponsors';
 
 function Routes() {
   const routes = useRoutes([
@@ -40,7 +41,7 @@ function Routes() {
       path : '*',
       element : <NotFound />, // Catch-all route for 404 page
     },
-    { path : '/', element : <RequireUser replace={<AvailableEvents />}><Dashboard /></RequireUser> },
+    { path : '/', element : <RequireUser replace={<Landing />}><Dashboard /></RequireUser> },
     { path : '/login', element : <Login /> },
     {
       path : '/events',

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -87,7 +87,7 @@ export default function NavBar() {
         <div className="flex">
           <NavLink to="/" className={location.pathname === '/' ? activeLinkClass : defaultLinkClass}>
             <NavigationMenu.Item>
-              Dashboard
+              {isAuthenticated ? 'Dashboard' : 'Home'}
             </NavigationMenu.Item>
           </NavLink>
           <NavLink to="/events" className={location.pathname === '/events' ? activeLinkClass : defaultLinkClass}>
@@ -102,17 +102,19 @@ export default function NavBar() {
           </NavLink> */}
         </div>
         <div className="flex ml-auto">
-          <NavLink to="/support" className={location.pathname === '/support' ? activeLinkClass : defaultLinkClass}>
-            <NavigationMenu.Item>
-              Support
-            </NavigationMenu.Item>
-          </NavLink>
 
           {isAuthenticated && (
-            <NotificationsPopover
-              triggerClassName={defaultLinkClass}
-              contentClassName={contentBase}
-            />
+            <>
+              <NavLink to="/support" className={location.pathname === '/support' ? activeLinkClass : defaultLinkClass}>
+                <NavigationMenu.Item>
+                  Support
+                </NavigationMenu.Item>
+              </NavLink>
+              <NotificationsPopover
+                triggerClassName={defaultLinkClass}
+                contentClassName={contentBase}
+              />
+            </>
           )}
 
           <NavigationMenu.Item>
@@ -143,14 +145,17 @@ export default function NavBar() {
               onPointerLeave={(event) => event.preventDefault()}
             >
               <ul className="grid gap-2 p-3">
-                <li>
-                  <NavLink
-                    to="/profile"
-                    className={contentItem}
-                  >
-                    Profile
-                  </NavLink>
-                </li>
+                {isAuthenticated && (
+                  <li>
+                    <NavLink
+                      to="/profile"
+                      className={contentItem}
+                    >
+                      Profile
+                    </NavLink>
+                  </li>
+                )}
+
                 {canAccessAdminPanel && (
                   <li>
                     <NavLink

--- a/frontend/src/components/NotificationsPopover.tsx
+++ b/frontend/src/components/NotificationsPopover.tsx
@@ -84,8 +84,9 @@ export default function NotificationsPopover({ triggerClassName, contentClassNam
         onPointerMove={(event) => event.preventDefault()}
         onPointerLeave={(event) => event.preventDefault()}
       >
-        <TbBell />
-        {unreadCount && unreadCount.count > 0 && <TbCircleDotFilled color="var(--accent-indicator)" className="absolute -mt-6 ml-2" />}
+        <TbBell aria-label="Notifications" />
+        {unreadCount && unreadCount.count > 0
+          && <TbCircleDotFilled color="var(--accent-indicator)" className="absolute -mt-6 ml-2" aria-label="Unread" />}
       </NavigationMenu.Trigger>
       <NavigationMenu.Content
         className={twMerge(contentClassName, 'p-4')}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,6 +1,6 @@
+import { Flex, Switch, Text } from '@radix-ui/themes';
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
-import { Flex, Switch, Text } from '@radix-ui/themes';
 
 export default function ThemeToggle({ className }: {className : string}) {
   const { theme, setTheme } = useTheme();
@@ -15,6 +15,7 @@ export default function ThemeToggle({ className }: {className : string}) {
       <Switch
         checked={theme === 'dark'}
         onCheckedChange={(checked) => setTheme(checked ? 'dark' : 'light')}
+        aria-label="Dark Theme"
       />
       <Text
         className="dark:text-(--gray-a11)"

--- a/frontend/src/routes/dashboard/Landing.tsx
+++ b/frontend/src/routes/dashboard/Landing.tsx
@@ -1,0 +1,49 @@
+import {
+  Button,
+  Card,
+  Flex,
+  Heading,
+  Link as RadixLink,
+  Text,
+} from '@radix-ui/themes';
+import { TbArrowRight, TbUserCircle } from 'react-icons/tb';
+import { Link } from 'react-router';
+
+export default function Landing() {
+  return (
+    <Flex className="absolute inset-0 overflow-hidden bg-dots-1" align="center" justify="center" direction="column" gap="3" p="3">
+      <title>Login</title>
+      <Heading size="8">Welcome to President&apos;s Cup</Heading>
+      <Card size="3" className="max-w-172" role="main">
+        <Flex direction="row" gap="8">
+          <Flex direction="column" gap="2" flexGrow="1" flexBasis="0">
+            <Text color="gray">
+              To register and participate, you must log in. You may also view event details and standings without logging in.
+            </Text>
+            <Text color="gray">
+              See
+              {' '}
+              <RadixLink href="https://presidentscup.cisa.gov">presidentscup.cisa.gov</RadixLink>
+              {' '}
+              for more information about the President&apos;s Cup Cybersecurity Competition.
+            </Text>
+          </Flex>
+          <Flex direction="column" gap="2" flexGrow="1" flexBasis="0">
+            <Button asChild size="4">
+              <Link to="/login">
+                Log In
+                <TbUserCircle />
+              </Link>
+            </Button>
+            <Button variant="soft" size="3" asChild>
+              <Link to="/events">
+                View Events
+                <TbArrowRight />
+              </Link>
+            </Button>
+          </Flex>
+        </Flex>
+      </Card>
+    </Flex>
+  );
+}

--- a/frontend/src/routes/dashboard/Landing.tsx
+++ b/frontend/src/routes/dashboard/Landing.tsx
@@ -12,7 +12,7 @@ import { Link } from 'react-router';
 export default function Landing() {
   return (
     <Flex className="absolute inset-0 overflow-hidden bg-dots-1" align="center" justify="center" direction="column" gap="3" p="3">
-      <title>Login</title>
+      <title>Home</title>
       <Heading size="8">Welcome to President&apos;s Cup</Heading>
       <Card size="3" className="max-w-172" role="main">
         <Flex direction="row" gap="8">


### PR DESCRIPTION
<img width="2494" height="1341" alt="image" src="https://github.com/user-attachments/assets/80b823b9-e28b-46ec-b264-bd8069ced646" />

Landing page on `/` for unauthed users. Resolves #439.

Added missing navbar permission checks (support and profile are not shown when unauthed.)

Added accessibility attributes for notification icon (previously wasn't read as an option by screen readers.) Will now be read as "Notifications" or ("Notifications Unread" if unread indicator is present) in the nav list.