### PR TITLE
Expose leaderboard controls to the frontend

### DIFF
--- a/backend/ng/event/models/Event.py
+++ b/backend/ng/event/models/Event.py
@@ -94,6 +94,7 @@ class Event(db.Model):
             "hints_enabled": self.hints_enabled,
             "time_limit_minutes": self.time_limit_minutes,
             "allowed_domains": self.allowed_domains,
+            "show_leaderboard": self.show_leaderboard,
         }
 
         return data
@@ -175,6 +176,12 @@ class Event(db.Model):
             "allowed_domains",
             required=False,
             friendly_name="Allowed email domains",
+        )
+        validator.validate_boolean(
+            data,
+            "show_leaderboard",
+            required=False,
+            friendly_name="Show leaderboard",
         )
 
         return validator.validate()

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -84,6 +84,56 @@ export default function EventDataForm({
           )}
         </FormField>
 
+        <FormField label="Registration Open" error={errors.public}>
+          {(injected) => (
+            <Controller
+              control={rhf.control}
+              name="registration_open"
+              defaultValue
+              rules={{}}
+              render={({ field }) => (
+                <Box>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={(checked) => {
+                      field.onChange(checked);
+                    }}
+                    name={field.name}
+                    ref={field.ref}
+                    size="3"
+                    {...injected}
+                  />
+                </Box>
+              )}
+            />
+          )}
+        </FormField>
+
+        <FormField label="Show Leaderboard" error={errors.show_leaderboard}>
+          {(injected) => (
+            <Controller
+              control={rhf.control}
+              name="show_leaderboard"
+              defaultValue
+              rules={{}}
+              render={({ field }) => (
+                <Box>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={(checked) => {
+                      field.onChange(checked);
+                    }}
+                    name={field.name}
+                    ref={field.ref}
+                    size="3"
+                    {...injected}
+                  />
+                </Box>
+              )}
+            />
+          )}
+        </FormField>
+
         <FormField label="Hints Enabled" error={errors.hints_enabled}>
           {(injected) => (
             <Controller

--- a/frontend/src/routes/admin/events/EventDataForm.tsx
+++ b/frontend/src/routes/admin/events/EventDataForm.tsx
@@ -84,7 +84,7 @@ export default function EventDataForm({
           )}
         </FormField>
 
-        <FormField label="Registration Open" error={errors.public}>
+        <FormField label="Registration Open" error={errors.registration_open}>
           {(injected) => (
             <Controller
               control={rhf.control}

--- a/frontend/src/routes/events/OverviewTabs/LeaderboardTab/index.tsx
+++ b/frontend/src/routes/events/OverviewTabs/LeaderboardTab/index.tsx
@@ -2,7 +2,7 @@ import { radixTheme } from '@/grid';
 import { useLeaderboard } from '@/hooks/events';
 import { Container, Flex, Spinner } from '@radix-ui/themes';
 import { AgGridReact } from 'ag-grid-react';
-import { ErrorCallout } from 'components/Callouts';
+import { ErrorCallout, WarningCallout } from 'components/Callouts';
 import { useParams } from 'react-router';
 import TeamPerformance from './TeamPerformance';
 
@@ -15,45 +15,51 @@ export default function LeaderboardTab() {
       <Flex direction="column" gap="3">
         <TeamPerformance eventId={Number(idEvent)} />
 
-        {leaderboardError && <ErrorCallout>{leaderboardError.message}</ErrorCallout>}
+        {leaderboardError
+          && (leaderboardError.message.includes('Leaderboard is not available')
+            ? <WarningCallout>The leaderboard for this event is currently hidden.</WarningCallout>
+            : <ErrorCallout>{leaderboardError.message}</ErrorCallout>
+          )}
 
-        <AgGridReact
-          rowData={leaderboard}
-          columnDefs={[
-            {
-              headerName : '#',
-              valueGetter : (params) => (params.node?.rowIndex != null ? params.node.rowIndex + 1 : ''),
-              width : 80,
-            },
-            {
-              headerName : 'Team',
-              field : 'team_name',
-              flex : 1,
-            },
-            {
-              headerName : 'Score',
-              field : 'points',
-              cellClass : 'tabular-nums',
-            },
-            {
-              headerName : 'Last Updated',
-              field : 'last_update',
-              valueFormatter : ({ value }) => value.toLocaleString(),
-            },
-          ]}
-          theme={radixTheme}
-          defaultColDef={{
-            sortable : false, // disable sorting for all columns - server side sort is the source of truth
-            lockPinned : true,
-            suppressMovable : true,
-          }}
-          pagination
-          paginationPageSize={20}
-          domLayout="autoHeight"
-          loadingOverlayComponent={Spinner}
-          suppressCellFocus
-          suppressHeaderFocus
-        />
+        {!leaderboardError && (
+          <AgGridReact
+            rowData={leaderboard}
+            columnDefs={[
+              {
+                headerName : '#',
+                valueGetter : (params) => (params.node?.rowIndex != null ? params.node.rowIndex + 1 : ''),
+                width : 80,
+              },
+              {
+                headerName : 'Team',
+                field : 'team_name',
+                flex : 1,
+              },
+              {
+                headerName : 'Score',
+                field : 'points',
+                cellClass : 'tabular-nums',
+              },
+              {
+                headerName : 'Last Updated',
+                field : 'last_update',
+                valueFormatter : ({ value }) => value.toLocaleString(),
+              },
+            ]}
+            theme={radixTheme}
+            defaultColDef={{
+              sortable : false, // disable sorting for all columns - server side sort is the source of truth
+              lockPinned : true,
+              suppressMovable : true,
+            }}
+            pagination
+            paginationPageSize={20}
+            domLayout="autoHeight"
+            loadingOverlayComponent={Spinner}
+            suppressCellFocus
+            suppressHeaderFocus
+          />
+        )}
       </Flex>
     </Container>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -13,6 +13,7 @@ export interface Event {
   registration_end_date?: Date;
   hints_enabled: boolean;
   time_limit_minutes: number | null;
+  show_leaderboard: boolean;
 }
 
 export interface Sponsor {


### PR DESCRIPTION
Added missing validator/serialize fields for show_leaderboard, and expose it on event form. (Also brought back missing registration open switch.)
<img width="646" height="711" alt="image" src="https://github.com/user-attachments/assets/c45989cf-3dc7-44c9-b5ff-33eaba6128d0" />
The switches look a bit janky now - updating this is on my list for later.

Leaderboard page catches the hidden leaderboard error, hides the grid, and displays this warning:
<img width="1317" height="221" alt="image" src="https://github.com/user-attachments/assets/24c8c240-6601-4543-8a9d-4018c8067c91" />


