### PR TITLE
Expose ctfd ban/unban behavior

### DIFF
--- a/backend/ng/core/middleware/auth.py
+++ b/backend/ng/core/middleware/auth.py
@@ -64,6 +64,8 @@ def _auth_handler(f, auth_required, json_required, validation_func):
         if not current_user and auth_required:
             raise AuthenticationError("Authentication is required to access this endpoint.")
         if current_user:
+            if current_user.banned:
+                raise AuthenticationError("Your account has been banned.")
             kwargs["current_user"] = User.find_or_create_by_ctfd_id(current_user.id)
 
         if json_required:

--- a/backend/ng/user/controllers/ban_user.py
+++ b/backend/ng/user/controllers/ban_user.py
@@ -1,0 +1,23 @@
+"""
+Controller for banning and unbanning users
+"""
+
+from CTFd.cache import clear_user_session
+from CTFd.models import db
+
+
+def ban_user(user):
+    """
+    Ban a user, invalidating all their existing sessions
+    """
+    user.ctfd_user.banned = True
+    clear_user_session(user_id=user.id)
+    db.session.commit()
+
+
+def unban_user(user):
+    """
+    Unban a user, allowing them to log in again
+    """
+    user.ctfd_user.banned = False
+    db.session.commit()

--- a/backend/ng/user/models/User.py
+++ b/backend/ng/user/models/User.py
@@ -72,6 +72,7 @@ class User(db.Model):
                 "roles": [role.name for role in self.roles],
                 "registered_at": self.ctfd_user.created.isoformat() + "Z",
                 "affiliation": self.affiliation.serialize(include_admin_fields=True) if self.affiliation else None,
+                "banned": self.ctfd_user.banned,
             }
         return {
             "id": self.id,

--- a/backend/ng/user/routes/admin_routes.py
+++ b/backend/ng/user/routes/admin_routes.py
@@ -12,6 +12,10 @@ from ...core.middleware.loaders import (
 )
 
 from ..models.User import User
+from ..controllers.ban_user import (
+    ban_user,
+    unban_user,
+)
 
 
 users_admin_namespace = Namespace("/admin/users", description="user endpoints for admins")
@@ -217,3 +221,45 @@ class UserIndvidualContainerRecycle(Resource):
         indvidual_container.recycle()
         res = indvidual_container.serialize()
         return success_response(res)
+
+
+@users_admin_namespace.route("/<int:user_id>/ban")
+class UserBan(Resource):
+    @admin_endpoint()
+    @load_user(source=LoaderType.PARAM, output_key="target_user")
+    @users_admin_namespace.doc(
+        description="Ban a user",
+        responses={
+            200: "User banned successfully",
+            403: "Forbidden - Admin access required",
+            404: "User not found",
+            500: "Internal server error",
+        },
+    )
+    def post(self, user_id, target_user, **kwargs):
+        """
+        Ban a user
+        """
+        ban_user(target_user)
+        return success_response()
+
+
+@users_admin_namespace.route("/<int:user_id>/unban")
+class UserUnban(Resource):
+    @admin_endpoint()
+    @load_user(source=LoaderType.PARAM, output_key="target_user")
+    @users_admin_namespace.doc(
+        description="Unban a user",
+        responses={
+            200: "User unbanned successfully",
+            403: "Forbidden - Admin access required",
+            404: "User not found",
+            500: "Internal server error",
+        },
+    )
+    def post(self, user_id, target_user, **kwargs):
+        """
+        Unban a user
+        """
+        unban_user(target_user)
+        return success_response()

--- a/backend/ng/user/routes/user_routes.py
+++ b/backend/ng/user/routes/user_routes.py
@@ -7,7 +7,11 @@ from CTFd.utils.security.csrf import generate_nonce
 from CTFd.utils.security.signing import hmac
 from flask_restx import Namespace, Resource
 from flask import session
-from ...core.utils import success_response
+
+from ...core.utils import (
+    error_response,
+    success_response,
+)
 from ...core.middleware import (
     user_endpoint,
     public_endpoint,
@@ -111,18 +115,18 @@ class UserSponsor(Resource):
 
         sponsor_id = json_data.get("sponsor_id")
         if not sponsor_id:
-            return {"success": False, "errors": {"sponsor": "Sponsor data is required"}}, 400
+            return error_response("Sponsor data is required", "sponsor", 400)
 
         sponsor = Sponsor.find_by_id(sponsor_id)
         if not sponsor:
-            return {"success": False, "errors": {"sponsor": "Sponsor not found"}}, 404
+            return error_response("Sponsor not found", "sponsor", 404)
 
         current_user.set_sponsor(sponsor)
 
         return success_response(sponsor)
 
 
-#The POST request for login must have a nonce attached to it or it will be blocked by CSRF protection in many cases
+# The POST request for login must have a nonce attached to it or it will be blocked by CSRF protection in many cases
 @users_user_namespace.route("/login")
 class UserLogin(Resource):
     @public_endpoint(json_required=True)
@@ -145,8 +149,11 @@ class UserLogin(Resource):
             user = Users.query.filter_by(email=username).first()
 
         if user:
+            if user.banned:
+                return error_response("Your account has been banned.", "authentication", 403)
+
             if user.password is None:
-                return {"success": False, "errors": {"authentication": "Invalid username or password"}}, 401
+                return error_response("Invalid username or password", "authentication", 401)
 
             if user and verify_password(password, user.password):
                 session['id'] = user.id
@@ -154,12 +161,12 @@ class UserLogin(Resource):
                 session['hash'] = hmac(user.password)
                 session['permanent'] = True
 
-                return {"success": True}, 200
+                return success_response()
             else:
-                return {"success": False, "errors": {"authentication": "Invalid username or password"}}, 401
+                return error_response("Invalid username or password", "authentication", 401)
 
         else:
-            return {"success": False, "errors": {"authentication": "Invalid username or password"}}, 401
+            return error_response("Invalid username or password", "authentication", 401)
 
 
 
@@ -179,4 +186,4 @@ class UserLogout(Resource):
 
         session.clear()
 
-        return {"success": True}, 200
+        return success_response()

--- a/backend/ng/user/tests/test_user_ban.py
+++ b/backend/ng/user/tests/test_user_ban.py
@@ -1,0 +1,95 @@
+"""
+Tests for user ban/unban functionality
+"""
+
+
+def test_admin_ban_user(admin_client, user_factory, db_session):
+    """
+    Test that an admin can ban a user
+    """
+    user = user_factory(
+        name = "bannable_user",
+        email = "banme@example.com"
+    )
+
+    response = admin_client.post(
+        f"/ng/admin/users/{user.id}/ban",
+        json = {}
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+
+    db_session.refresh(user.ctfd_user)
+    assert user.ctfd_user.banned is True
+
+
+def test_admin_unban_user(admin_client, user_factory, db_session):
+    """
+    Test that an admin can unban a user
+    """
+    user = user_factory(
+        name = "banned_user",
+        email = "banned@example.com"
+    )
+    user.ctfd_user.banned = True
+    db_session.commit()
+
+    response = admin_client.post(
+        f"/ng/admin/users/{user.id}/unban",
+        json = {}
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+
+    db_session.refresh(user.ctfd_user)
+    assert user.ctfd_user.banned is False
+
+
+def test_banned_user_cannot_login(
+    logged_in_client,
+    user_factory,
+    db_session
+):
+    """
+    Test that a banned user cannot login
+    """
+    user = user_factory(
+        name = "banned_login_user",
+        email = "bannedlogin@example.com"
+    )
+    user.ctfd_user.banned = True
+    db_session.commit()
+
+    response = logged_in_client.post(
+        "/ng/users/login",
+        json = {
+            "username": "banned_login_user",
+            "password": "password"
+        }
+    )
+
+    assert response.status_code == 403
+    data = response.get_json()
+    assert data["success"] is False
+    assert "banned" in data["errors"]["authentication"].lower()
+
+
+def test_non_admin_cannot_ban_user(logged_in_client, user_factory):
+    """
+    Test that a non admin user cannot ban another user
+    """
+    target_user = user_factory(
+        name = "target_user",
+        email = "target@example.com"
+    )
+
+    response = logged_in_client.post(
+        f"/ng/admin/users/{target_user.id}/ban",
+        json = {}
+    )
+
+    assert response.status_code == 403

--- a/backend/ng/user/tests/test_user_model.py
+++ b/backend/ng/user/tests/test_user_model.py
@@ -142,6 +142,7 @@ class TestUser:
         assert "registered_at" in data
         assert data["registered_at"].endswith("Z")
         assert "roles" not in data
+        assert "banned" not in data
 
     def test_serialize_with_admin_fields(self, user_factory):
         """
@@ -160,6 +161,8 @@ class TestUser:
         assert "registered_at" in data
         assert "roles" in data
         assert isinstance(data["roles"], list)
+        assert "banned" in data
+        assert isinstance(data["banned"], bool)
 
     def test_serialize_missing_ctfd_user(self):
         """


### PR DESCRIPTION
- Add  `ban_controller.py` to to use ctfd's ban feature
- Add `/ng/admin/users/<int:user_id>/unban`  & `/ng/admin/users/<int:user_id>/ban` endpoints
- Add `test_user_ban.py` to test banning functionality
- Edit login endpoint to check for banned users & `auth.py`  decorator as fallback

Closes issue: https://github.com/CyberSkyline/ctf-ng/issues/358