### PR TITLE
Move image pull to celery worker

### DIFF
--- a/backend/ng/challenge/models/ContainerBlueprint.py
+++ b/backend/ng/challenge/models/ContainerBlueprint.py
@@ -1,13 +1,14 @@
 from typing import Any, Literal
 
 from CTFd.models import db
+from CTFd.utils import get_app_config
+
 from sqlalchemy.orm import Mapped
 
 from ..utils.challenge_yaml import EnvVarRenderer
 
 from ...core.utils.validator import BaseValidator
 from ...containers.utils.get_client import get_client
-from ... import config
 
 from cyber_skyline.chall_parser.compose.service import ServiceNetwork
 
@@ -179,7 +180,8 @@ class ContainerBlueprint(db.Model):
 
         return {k: (v(team_seed=team_seed) if isinstance(v, EnvVarRenderer) else v) for k, v in self.environment.items()}
 
-    def pull_image(self):
-        client = get_client(config.DOCKER_HOST)
+    def pull_image(self, user_id):
+        DOCKER_HOST = get_app_config("DOCKER_HOST")
 
-        client.pull_image(self.image)
+        client = get_client(DOCKER_HOST)
+        client.pull_image(self.image, user_id, self.id)

--- a/backend/ng/challenge/models/ContainerBlueprint.py
+++ b/backend/ng/challenge/models/ContainerBlueprint.py
@@ -181,7 +181,7 @@ class ContainerBlueprint(db.Model):
         return {k: (v(team_seed=team_seed) if isinstance(v, EnvVarRenderer) else v) for k, v in self.environment.items()}
 
 
-    def pull_image(self):
+    def pull_image(self, user_id):
         DOCKER_HOST = get_app_config("DOCKER_HOST")
 
         client = get_client(DOCKER_HOST)

--- a/backend/ng/challenge/routes/admin_routes.py
+++ b/backend/ng/challenge/routes/admin_routes.py
@@ -1,6 +1,5 @@
 import base64
 from flask_restx import Namespace, Resource
-import multiprocessing
 
 from ..controllers.admin import import_challenge_from_yaml, update_challenge_from_yaml, lint_challenge
 from ..models import Challenge, ContainerBlueprint
@@ -8,7 +7,6 @@ from ...core.middleware.loaders import load_event, load_challenge
 from ...core.middleware.loaders._util import LoaderType
 from ...core.middleware.auth import admin_endpoint
 from ...core.utils.api import success_response
-from ...core.utils.emitters import emit_to_user
 from ...event.models import Event
 
 challenge_admin_namespace = Namespace("/admin/challenges", description="challenge management")
@@ -192,25 +190,6 @@ class PullImages(Resource):
     def post(self, challenge: Challenge, current_user, **kwargs):
         blueprints = ContainerBlueprint.get_for_challenge(challenge.id)
         for blueprint in blueprints:
-            # Will emit a websocket event to the user
-            # On pull or fail
-            def background_task(blueprint, current_user):
-                try:
-                    blueprint.pull_image()
-                    emit_to_user(
-                        "pull-success",
-                        { "id" : blueprint.id, "image": blueprint.image },
-                        current_user.id
-                    )
-                except Exception as err:
-                    emit_to_user(
-                        "pull-fail",
-                        { "error": str(err), "id" : blueprint.id, "image": blueprint.image },
-                        current_user.id
-                    )
-
-
-            proc = multiprocessing.Process(target=background_task, args=(blueprint, current_user))
-            proc.start()
+            blueprint.pull_image(current_user.id)
 
         return success_response(True)

--- a/backend/ng/containers/tasks.py
+++ b/backend/ng/containers/tasks.py
@@ -1,0 +1,59 @@
+import os
+import json
+import docker
+import redis
+
+from celery import Celery
+
+redis_url = os.getenv("REDIS_URL")
+
+app = Celery(broker=f"{redis_url}/1", result_backend=f"{redis_url}/1")
+
+# Redis client defaults from
+# ng/core/utils/redis_notifications
+# Celery really doesn't like relative imports
+redis_client = None
+
+if redis_url:
+    redis_client = redis.from_url(
+        redis_url,
+        decode_responses = True
+    )
+else:
+    redis_client = redis.Redis(
+        host = os.getenv("REDIS_HOST") or "localhost",
+        port = os.getenv('REDIS_PORT') or 6379,
+        db = os.getenv('REDIS_DB') or 0,
+        password = os.getenv('REDIS_PASSWORD') or None,
+        decode_responses = True,
+        socket_connect_timeout = 5,
+        socket_timeout = 5
+    )
+
+@app.task
+def pull_image_celery(host, image, user_id, blueprint_id, auth_conf=None):
+    tls_config = docker.tls.TLSConfig(client_cert=("/var/lib/certs/ssl/cert.pem", "/var/lib/certs/ssl/key.pem"))
+    client = docker.DockerClient(base_url=f"https://{host}:2376/", tls=tls_config)
+    try:
+        if auth_conf:
+            client.images.pull(image, auth_config=auth_conf)
+        else:
+            client.images.pull(image)
+
+        # Similar to above this is what emit_notification is doing
+        # these will send a notifcation when the image is done pulling
+        message = {
+            "user_ids": [user_id],
+            "event_name": "pull-success",
+            "data": { "id" : blueprint_id, "image": image }
+        }
+
+        redis_client.publish("ctf_notifications", json.dumps(message))
+    except Exception as err:
+        message = {
+            "user_ids": [user_id],
+            "event_name": "pull-fail",
+            "data": { "error": str(err), "id" : blueprint_id, "image": image }
+        }
+
+        redis_client.publish("ctf_notifications", json.dumps(message))

--- a/backend/ng/containers/utils/Client.py
+++ b/backend/ng/containers/utils/Client.py
@@ -72,7 +72,6 @@ class Client(docker.DockerClient):
                     "password": get_app_config("CONTAINER_REGISTRY_PASSWORD"),
                 }
             host = get_app_config("DOCKER_HOST")
-            print(auth)
             pull_image_celery.delay(host, image, user_id, blueprint_id, auth_conf=auth)
         else:
             pull_image_celery.delay(host, image, user_id, blueprint_id)

--- a/backend/ng/containers/utils/Client.py
+++ b/backend/ng/containers/utils/Client.py
@@ -4,6 +4,7 @@ import re
 import boto3
 import docker
 from CTFd.utils import get_app_config
+from ..tasks import pull_image_celery
 
 from ..constants import DOCKER_RUNNING
 
@@ -53,8 +54,9 @@ class Client(docker.DockerClient):
             "registry": auth_data["proxyEndpoint"],
         }
 
-    def pull_image(self, image):
+    def pull_image(self, image, user_id, blueprint_id):
         auth_repo = get_app_config("CONTAINER_REGISTRY")
+        host = get_app_config("DOCKER_HOST")
 
         #  Auth repo will default to blank str not none
         if auth_repo != "" and re.search(auth_repo, image):
@@ -69,6 +71,8 @@ class Client(docker.DockerClient):
                     "username": get_app_config("CONTAINER_REGISTRY_USER"),
                     "password": get_app_config("CONTAINER_REGISTRY_PASSWORD"),
                 }
-            self.images.pull(image, auth_config=auth)
+            host = get_app_config("DOCKER_HOST")
+            print(auth)
+            pull_image_celery.delay(host, image, user_id, blueprint_id, auth_conf=auth)
         else:
-            self.images.pull(image)
+            pull_image_celery.delay(host, image, user_id, blueprint_id)

--- a/backend/ng/requirements.txt
+++ b/backend/ng/requirements.txt
@@ -20,3 +20,4 @@ requests-oauthlib==1.3.0
 sqlalchemy[mypy]==1.4.54
 types-boto3==1.40.40
 filetype==1.2.0
+celery[redis]==5.3.0

--- a/conf/ctfd/entrypoint.sh
+++ b/conf/ctfd/entrypoint.sh
@@ -14,6 +14,7 @@ install_plugin_deps() {
 }
 
 start_dev() {
+  celery -A CTFd.plugins.ng.containers.tasks worker --loglevel=INFO &
   python serve_debug.py
 }
 
@@ -44,6 +45,8 @@ start_prod() {
 
   # Initialize database
   flask db upgrade
+
+  celery -A CTFd.plugins.ng.containers.tasks worker --loglevel=INFO &
 
   # Start CTFd
   echo "Starting CTFd"


### PR DESCRIPTION
Migrates the pull thread to a dedicated celery worker because gunicorn doesn't let you just run a background thread.