### PR TITLE
Add messages to select sponsor

### DIFF
--- a/backend/ng/admin/tests/test_admin_integration.py
+++ b/backend/ng/admin/tests/test_admin_integration.py
@@ -103,9 +103,10 @@ class TestAdminImpersonation:
         data = response.get_json()
         assert data["data"] == []
 
-    def test_admin_team_management_as_user(self, admin_client, user_factory, team_factory, event_factory):
+    def test_admin_team_management_as_user(self, admin_client, user_factory, sponsor_factory, event_factory):
         """Test that admin can manage teams as the impersonated user."""
-        user = user_factory()
+        sponsor = sponsor_factory()
+        user = user_factory(sponsor = sponsor)
         event = event_factory()
 
         response = self.impersonate(admin_client, user.id)

--- a/backend/ng/event/controllers/user/join_event_controller.py
+++ b/backend/ng/event/controllers/user/join_event_controller.py
@@ -11,6 +11,8 @@ def join_event_controller(event: Event, user : User, invite_code : str = "", tea
     """
     if (not invite_code) and (not team_name):
         raise ValidationError("Either invite_code or team_name must be provided")
+    if (not user.affiliation):
+        raise ValidationError("User sponsor not set")
 
     try:
         Demographic.create_demographic(user_id=user.id, event_id=event.id, commit=False)

--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -281,21 +281,24 @@ class Test_Event_Eligibility:
 
     def test_check_event_eligibility_already_registered(
         self,
-        logged_in_client,
-        user,
+        sponsor_factory,
+        user_factory,
         event_factory,
-        team_factory
+        client_factory,
     ):
         event = event_factory(name = "Already Registered Event", public = True)
+        sponsor = sponsor_factory()
+        user = user_factory(name = "testuser", email = "testuser@example.com", sponsor = sponsor)
+        client = client_factory(user = user)
 
-        response = logged_in_client.post(
+        response = client.post(
             f"/ng/events/{event.id}/me/register",
             json = {
                 "team_name": "Test Team",
             },
         )
 
-        response = logged_in_client.get(self.get_endpoint(event.id))
+        response = client.get(self.get_endpoint(event.id))
 
         assert response.status_code == 400
         data = response.get_json()
@@ -309,15 +312,40 @@ class Test_Event_Registration:
     def get_endpoint(self, event_id: int) -> str:
         return f"/ng/events/{event_id}/me/register"
 
-    def test_register_for_event_with_new_team(
+    def test_register_for_event_without_user_sponsor(
         self,
         logged_in_client,
-        user,
-        event_factory
+        event_factory,
     ):
-        event = event_factory(name = "Event for Registration", public = True)
+        event = event_factory(
+            name = "Event for Missing Sponsor",
+            public = True
+        )
 
         response = logged_in_client.post(
+            self.get_endpoint(event.id),
+            json = {}
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["success"] is False
+        assert "errors" in data
+
+    def test_register_for_event_with_new_team(
+        self,
+        user,
+        client_factory,
+        event_factory,
+        user_factory,
+        sponsor_factory,
+    ):
+        event = event_factory(name = "Event for Registration", public = True)
+        sponsor = sponsor_factory()
+        user = user_factory(name = "testuser", email = "testuser@example.com", sponsor = sponsor)
+
+        client = client_factory(user = user)
+        response = client.post(
             self.get_endpoint(event.id),
             json = {
                 "team_name": "Test Team",
@@ -342,19 +370,25 @@ class Test_Event_Registration:
 
     def test_register_for_event_with_existing_team(
         self,
-        logged_in_client,
+        client_factory,
         user_factory,
         event_factory,
-        team_factory
+        team_factory,
+        sponsor_factory,
     ):
         event = event_factory(
             name = "Event for Existing Team Registration",
             public = True
         )
-        user = user_factory(name = "testuser", email = "testuser@example.com")
+        sponsor = sponsor_factory()
+
+        user = user_factory(name = "testuser", email = "testuser@example.com", sponsor = sponsor)
         existing_team = team_factory(event = event, members = [user])
 
-        response = logged_in_client.post(
+        user2 = user_factory(name = "testuser2", email = "testuser2@example.com", sponsor = sponsor)
+        client = client_factory(user = user2)
+
+        response = client.post(
             self.get_endpoint(event.id),
             json = {
                 "invite_code": existing_team.invite_code,
@@ -518,17 +552,22 @@ class Test_Event_Registration:
 
     def test_register_twice_for_event(
         self,
-        logged_in_client,
-        user,
+        user_factory,
+        client_factory,
+        sponsor_factory,
         event_factory
     ):
         event = event_factory(
             name = "Event for Duplicate Registration",
             public = True
         )
+        sponsor = sponsor_factory()
+
+        user = user_factory(name = "testuser", email = "testuser@example.com", sponsor = sponsor)
+        client = client_factory(user = user)
 
         # First registration
-        response = logged_in_client.post(
+        response = client.post(
             self.get_endpoint(event.id),
             json = {
                 "team_name": "First Team",
@@ -540,7 +579,7 @@ class Test_Event_Registration:
         assert data["success"] is True
 
         # Second registration attempt
-        response = logged_in_client.post(
+        response = client.post(
             self.get_endpoint(event.id),
             json = {
                 "team_name": "Second Team",
@@ -558,10 +597,12 @@ class Test_Event_Registration:
         self,
         client_factory,
         user_factory,
-        event_factory
+        event_factory,
+        sponsor_factory
     ):
 
-        user = user_factory(name = "domainuser", email = "domainuser@example.com")
+        sponsor = sponsor_factory()
+        user = user_factory(name = "domainuser", email = "domainuser@example.com", sponsor = sponsor)
         logged_in_client = client_factory(user = user)
         event = event_factory(
             name = "Event with Allowed Domains",
@@ -611,9 +652,11 @@ class Test_Event_Registration:
         self,
         client_factory,
         user_factory,
-        event_factory
+        event_factory,
+        sponsor_factory
     ):
-        user = user_factory(name = "multiuser", email = "multiuser@valid.mil")
+        sponsor = sponsor_factory()
+        user = user_factory(name = "multiuser", email = "multiuser@valid.mil", sponsor = sponsor)
         logged_in_client = client_factory(user = user)
         event = event_factory(name = "Event for Multiple Allowed Domains", public = True, allowed_domains = ["valid.mil", "secure.gov","trusted.org"])
 
@@ -632,9 +675,11 @@ class Test_Event_Registration:
         self,
         client_factory,
         user_factory,
-        event_factory
+        event_factory,
+        sponsor_factory
     ):
-        user = user_factory(name = "subdomainuser", email = "subdomainuser@us.valid.mil")
+        sponsor = sponsor_factory()
+        user = user_factory(name = "subdomainuser", email = "subdomainuser@us.valid.mil", sponsor = sponsor)
         logged_in_client = client_factory(user = user)
         event = event_factory(name = "Event for Subdomain Email Registration", public = True, allowed_domains = ["valid.mil"])
 
@@ -653,9 +698,11 @@ class Test_Event_Registration:
         self,
         client_factory,
         user_factory,
-        event_factory
+        event_factory,
+        sponsor_factory,
     ):
-        user = user_factory(name = "emptydomainuser", email = "emptydomainuser@invalid.com")
+        sponsor = sponsor_factory()
+        user = user_factory(name = "emptydomainuser", email = "emptydomainuser@invalid.com", sponsor = sponsor)
         logged_in_client = client_factory(user = user)
         event = event_factory(name = "Event with Empty Allowed Domains", public = True, allowed_domains = [])
 
@@ -673,11 +720,13 @@ class Test_Event_Registration:
         client_factory,
         user_factory,
         event_factory,
-        team_factory
+        team_factory,
+        sponsor_factory,
     ):
         event = event_factory(name = "Event for Non-Printable Team Name", public = True)
-        user = user_factory(name = "nonprintableuser", email = "nonprintableuser@example.com")
-        new_user = user_factory(name = "newuser", email = "newuser@example.com")
+        sponsor = sponsor_factory()
+        user = user_factory(name = "nonprintableuser", email = "nonprintableuser@example.com", sponsor = sponsor)
+        new_user = user_factory(name = "newuser", email = "newuser@example.com", sponsor = sponsor)
         team_factory(event = event, name = "ExistingTeam", members = [user])
 
         non_printable_team_name = "Exist\x00ingTeam"
@@ -940,24 +989,34 @@ class Test_Event_Team_Management:
         reponse = team_member_client.get(f"/ng/events/{1}/me/team")
         assert reponse.status_code == 404
 
-    def test_leave_and_empty_team_deletes(self, logged_in_client, event_factory):
+    def test_leave_and_empty_team_deletes(
+        self,
+        event_factory,
+        client_factory,
+        user_factory,
+        sponsor_factory
+    ):
         """Test that leaving a team as the last member deletes the team."""
+        sponsor = sponsor_factory()
+        user = user_factory(name = "testuser", email = "testuser@example.com", sponsor = sponsor)
 
         event = event_factory(name = "Solo Leave Test Event", public = True)
-        logged_in_client.post(
+
+        client = client_factory(user = user)
+        client.post(
             f"/ng/events/{event.id}/me/register",
             json = {"team_name": "Solo Team"},
         )
-        response = logged_in_client.post(
+        response = client.post(
             f"/ng/events/{event.id}/me/team/leave",
             json = {}
         )
         assert response.status_code == 200
 
-        response = logged_in_client.get(f"/ng/events/{event.id}/me/team")
+        response = client.get(f"/ng/events/{event.id}/me/team")
         assert response.status_code == 404
 
-        response = logged_in_client.get(f"/ng/events/{event.id}/me/team/score")
+        response = client.get(f"/ng/events/{event.id}/me/team/score")
         assert response.status_code == 404
 
         teams = Team.query.all()
@@ -996,10 +1055,17 @@ class Test_Event_Team_Management:
             "errors"]["forbidden"]
 
 
-    def test_user_cannot_start_event_then_leave(self,client_factory, event_factory, user_factory):
+    def test_user_cannot_start_event_then_leave(
+        self,
+        client_factory,
+        event_factory,
+        user_factory,
+        sponsor_factory
+    ):
         """Test that a user who starts an event, leaves their team, and then re-registers cannot start the event again."""
         event = event_factory(name = "Re-Register Start Event", public = True, max_team_size = 1)
-        user = user_factory(name = "Test User", email = "reregister@example.com")
+        sponsor = sponsor_factory()
+        user = user_factory(name = "Test User", email = "reregister@example.com", sponsor = sponsor)
         client = client_factory(user = user)
         # User registers and starts the event
         client.post(
@@ -1050,22 +1116,24 @@ class Test_Event_Team_Management:
         client_factory,
         user_factory,
         event_factory,
-        team_factory
+        team_factory,
+        sponsor_factory,
     ):
         """Test that a user who leaves a team can re-register for the event."""
         event = event_factory(name = "Reregister Test Event", public = True)
-        user = user_factory(name = "reregisteruser", email = "reregisteruser@example.com")
-        user2 = user_factory(name = "otheruser", email = "otheruser@example.com")
+        sponsor = sponsor_factory()
+        user = user_factory(name = "reregisteruser", email = "reregisteruser@example.com", sponsor = sponsor)
+        user2 = user_factory(name = "otheruser", email = "otheruser@example.com", sponsor = sponsor)
         team = team_factory(event = event, members = [user2, user])
-        logged_in_client = client_factory(user = user)
+        client = client_factory(user = user)
 
-        response = logged_in_client.post(
+        response = client.post(
             f"/ng/events/{event.id}/me/team/leave",
             json = {}
         )
         assert response.status_code == 200
 
-        response = logged_in_client.post(
+        response = client.post(
             f"/ng/events/{event.id}/me/register",
             json = {"invite_code": team.invite_code},
         )
@@ -1230,13 +1298,16 @@ class Test_Event_Admin_Register:
         admin_client,
         user_factory,
         event_factory,
-        team_factory
+        team_factory,
+        sponsor_factory,
     ):
         event = event_factory(name = "Admin Register Event", public = True)
-        user = user_factory(name = "testuser", email = "testuser@example.com")
+        sponsor = sponsor_factory()
+        user = user_factory(name = "testuser", email = "testuser@example.com", sponsor = sponsor)
         user2 = user_factory(
             name = "testuser2",
-            email = "testuser2@example.com"
+            email = "testuser2@example.com",
+            sponsor = sponsor
         )
         team = team_factory(event = event, members = [user])
 
@@ -1254,11 +1325,16 @@ class Test_Event_Admin_Register:
 
     def test_admin_register_user_for_event_name(
         self,
-        admin_client,
-        user,
-        event_factory
+        client_factory,
+        user_factory,
+        event_factory,
+        sponsor_factory,
     ):
         event = event_factory(name = "Admin Register Event", public = True)
+
+        sponsor = sponsor_factory()
+        user = user_factory(name = "testuser", email = "testuser@example.com", admin = True, sponsor = sponsor)
+        admin_client = client_factory(user = user)
 
         response = admin_client.post(
             self.post_endpoint(event.id,
@@ -1294,17 +1370,20 @@ class Test_Event_Admin_Register:
         admin_client,
         user_factory,
         event_factory,
-        team_factory
+        team_factory,
+        sponsor_factory,
     ):
         event = event_factory(
             name = "Admin Register Locked Event",
             public = True,
             locked = True
         )
-        user = user_factory(name = "testuser", email = "testuser@example.com")
+        sponsor = sponsor_factory()
+        user = user_factory(name = "testuser", email = "testuser@example.com", sponsor = sponsor)
         user2 = user_factory(
             name = "testuser2",
-            email = "testuser2@example.com"
+            email = "testuser2@example.com",
+            sponsor = sponsor
         )
         team = team_factory(event = event, members = [user])
 

--- a/backend/ng/scripts/populate_sample_data.py
+++ b/backend/ng/scripts/populate_sample_data.py
@@ -57,6 +57,7 @@ with app.app_context():
         # where the plugin is properly located at /opt/CTFd/CTFd/plugins/ng
         from CTFd.plugins.ng.permissions.controllers.initial_admin_setup import initial_admin_setup  # type: ignore
         from CTFd.plugins.ng.user.models.User import User as NgUser  # type: ignore
+        from CTFd.plugins.ng.sponsors.models.Sponsor import Sponsor as NgSponsor # type: ignore
     except ImportError as e:
         print(f"Failed to import plugin modules: {e}")
         print("This script should be run via 'pnpm populate-data' from the project root.")
@@ -125,11 +126,25 @@ with app.app_context():
     # Commit the events
     db.session.commit()
 
+    # Create a sponsor
+    sponsor = NgSponsor.query.filter_by(name="sample sponsor").first()
+    if not sponsor:
+        sponsor = NgSponsor.create_sponsor(name="sample sponsor", logo=None, commit=True)
+        db.session.add(sponsor)
+        db.session.commit()
+    sponsor = NgSponsor.query.filter_by(name="sample sponsor").first()
+
     # Get the admin user and create NG user extension
     ctfd_admin_user = Users.query.filter_by(name="admin").first()
+
     ng_admin_user = NgUser.query.filter_by(id=ctfd_admin_user.id).first()
     if not ng_admin_user:
         ng_admin_user = NgUser.create_user(user_id=ctfd_admin_user.id, commit=True)
+
+    ng_admin_user.affiliation = sponsor
+    db.session.add(ng_admin_user)
+    db.session.commit()
+    ng_admin_user = NgUser.query.filter_by(id=ng_admin_user.id).first()
 
     # Create additional test user for team membership
     ctfd_test_user = Users(name="testuser", email="test@example.com", password="password", type="user")
@@ -144,6 +159,15 @@ with app.app_context():
 
     test_user = NgUser.create_user(user_id=ctfd_test_user.id, commit=True)
     test_user_2 = NgUser.create_user(user_id=ctfd_test_user_2.id, commit=True)
+
+    test_user.affiliation = sponsor
+    test_user_2.affiliation = sponsor
+    db.session.add(test_user)
+    db.session.add(test_user_2)
+    db.session.commit()
+
+    test_user = NgUser.query.filter_by(id=test_user.id).first()
+    test_user_2 = NgUser.query.filter_by(id=test_user_2.id).first()
 
     # Register admin for first two events (Public CTF Championship and Private Training Event)
     admin_teams = []

--- a/frontend/src/routes/events/RegistrationCard.tsx
+++ b/frontend/src/routes/events/RegistrationCard.tsx
@@ -1,10 +1,17 @@
 import { useEventStatus, useMyEligibility } from '@/hooks/events';
-import { useRegistration } from '@/hooks/users';
+import { useMySponsor, useRegistration } from '@/hooks/users';
 import type { Event } from '@/types';
-import { Card, Flex, Text } from '@radix-ui/themes';
+import {
+  Card,
+  Flex,
+  Link as RadixLink,
+  Text,
+} from '@radix-ui/themes';
+import { Link } from 'react-router';
 import { ErrorCallout, WarningCallout } from 'components/Callouts';
 import RequireEventPermission from 'components/RequireEventPermission';
 import Statistic from 'components/Statistic';
+import { isNil } from 'lodash';
 import LeaveTeamModal from './LeaveTeamModal';
 import RegistrationModal from './RegistrationModal';
 import RenameTeamModal from './RenameTeamModal';
@@ -19,9 +26,11 @@ export default function RegistrationCard({ event }: {event: Event}) {
 
   // don't check eligibility if already registered since we know it will fail
   const { data : eligibility, error : eligibilityError } = useMyEligibility(isUnregistered ? event.id : null);
+  const { data : mySponsor, error : mySponsorError } = useMySponsor();
 
   if (isLoading) return null; // don't show anything while loading
   if (isUnregistered && !eligibility && !eligibilityError) return null; // if not eligible, don't show registration
+  if (mySponsorError) return null;
 
   if (error) {
     return <ErrorCallout>{error.message}</ErrorCallout>;
@@ -55,7 +64,19 @@ export default function RegistrationCard({ event }: {event: Event}) {
         <>
           <Text>You are not registered for this event.</Text>
           <Flex direction="row" gap="4" align="center">
-            <RegistrationModal eventId={event.id} eventName={event.name} isTeamGame={event.max_team_size > 1} />
+            {isNil(mySponsor)
+              ? (
+                <WarningCallout>
+                  You must select a sponsor on the
+                  {' '}
+                  <RadixLink asChild>
+                    <Link to="/profile">profile page</Link>
+                  </RadixLink>
+                  {' '}
+                  prior to registering for events.
+                </WarningCallout>
+              )
+              : <RegistrationModal eventId={event.id} eventName={event.name} isTeamGame={event.max_team_size > 1} />}
           </Flex>
         </>
         )}

--- a/frontend/src/routes/profile/index.tsx
+++ b/frontend/src/routes/profile/index.tsx
@@ -15,7 +15,7 @@ import {
   isUndefined,
   map,
 } from 'lodash';
-import { ErrorCallout } from 'components/Callouts';
+import { ErrorCallout, WarningCallout } from 'components/Callouts';
 import { useFileUrl } from '@/hooks/fileuploads';
 import SponsorImageCard from './SponsorImageCard';
 
@@ -57,6 +57,7 @@ export default function Profile() {
             {isEditing ? 'Cancel Edit' : 'Edit Sponsor'}
           </Button>
         </Flex>
+        {isNil(mySponsor) && <WarningCallout className="mt-4">You must select a sponsor prior to registering for events.</WarningCallout>}
         <Heading size="4" as="h2" className="pt-4">{isEditing ? 'All Sponsors:' : 'My Sponsor:'}</Heading>
         {isEditing ? (
           <>


### PR DESCRIPTION
https://github.com/CyberSkyline/ctf-ng/issues/444

<img width="595" height="375" alt="image" src="https://github.com/user-attachments/assets/92830af4-f92b-4a39-b07b-f7b12b687f36" />


The Registration Card should block them from getting to the Registration Modal at all, but if they are able to get to it, the backend will prevent registration before they have a sponsor:
<img width="757" height="623" alt="image" src="https://github.com/user-attachments/assets/8e507717-d9b4-472f-9b0c-b10518615889" />

I added one test case to account for the new sponsor requirement, but a bunch of test cases needed updated to accommodate this change as well
