### PR TITLE
Fix time windows in team validation

### DIFF
--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -152,11 +152,9 @@ class Team(db.Model):
             )
             if res:
                 raise ValidationError(f"Team name '{data['name']}' already exists in event ID {data['event_id']}.")
-        if "start_timestamp" in data and "end_time" in data:
-            validator.validate_time_window(data, start_field="start_timestamp", end_field="end_time")
-        elif "start_timestamp" in data:
+        if "start_timestamp" in data:
             validator.validate_datetime(data, "start_timestamp", friendly_name="Start Timestamp")
-        elif "end_time" in data:
+        if "end_time" in data:
             validator.validate_datetime(data, "end_time", friendly_name="End Time")
 
         return validator.validate()

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -152,9 +152,12 @@ class Team(db.Model):
             )
             if res:
                 raise ValidationError(f"Team name '{data['name']}' already exists in event ID {data['event_id']}.")
-        if "start_timestamp" in data:
+        if "start_timestamp" in data and "end_time" in data and data["start_timestamp"] is not None and data["end_time"] is not None:
+            validator.validate_time_window(data, start_field="start_timestamp", end_field="end_time")
+        else:
+          if "start_timestamp" in data:
             validator.validate_datetime(data, "start_timestamp", friendly_name="Start Timestamp")
-        if "end_time" in data:
+          if "end_time" in data:
             validator.validate_datetime(data, "end_time", friendly_name="End Time")
 
         return validator.validate()


### PR DESCRIPTION
Resolves #445. I thought this wasn't significant, but it can prevent admins from doing administrative tasks in certain cases so I think it's worth fixing.

`validate_time_window` enforces that both start and end must be present, which is not guaranteed for teams. Teams can have a start date but no end date when playing an event with no time limit. When doing a self validate, end_time will always be `in` data, but it might not actually be set, which causes validation to stop working entirely.