### PR TITLE
Remove placeholder/outdated copy text from dashboard

### DIFF
--- a/frontend/src/components/HeaderContainer.tsx
+++ b/frontend/src/components/HeaderContainer.tsx
@@ -1,11 +1,11 @@
 import { Container } from '@radix-ui/themes';
-import type { ReactNode } from 'react';
+import { Children, type ReactNode } from 'react';
 
 export default function HeaderContainer({ children = undefined }: {
   children?: ReactNode
 }) {
   return (
-    children && (
+    Children.toArray(children).length > 0 && (
       <Container
         size="2"
         px="3"
@@ -13,7 +13,7 @@ export default function HeaderContainer({ children = undefined }: {
         mx="-3"
         mt="-3"
         mb="3"
-        className="bg-dots-2 shadow dark:shadow-none"
+        className="bg-dots-2 shadow dark:shadow-none has-[.rt-ContainerInner:empty]:hidden"
       >
         {children}
       </Container>

--- a/frontend/src/routes/dashboard/UpcomingEvents.tsx
+++ b/frontend/src/routes/dashboard/UpcomingEvents.tsx
@@ -19,13 +19,10 @@ export default function UpcomingEvents() {
       <InfoCallout>
         You are not registered for any upcoming events.
         {' '}
-        <RadixLink asChild><Link to="/events">Register for an upcoming event</Link></RadixLink>
+        You can browse and register for upcoming events on the
         {' '}
-        or head to the
-        {' '}
-        <RadixLink asChild><Link to="/practice">practice area</Link></RadixLink>
-        {' '}
-        to hone your skills!
+        <RadixLink asChild><Link to="/events">events page</Link></RadixLink>
+        .
       </InfoCallout>
     );
   }

--- a/frontend/src/routes/dashboard/index.tsx
+++ b/frontend/src/routes/dashboard/index.tsx
@@ -17,7 +17,7 @@ import UpcomingEvents from 'routes/dashboard/UpcomingEvents';
 import EventCard from './EventCard';
 
 export default function Dashboard() {
-  const { data, error, isLoading } = useMyEvents();
+  const { data, error } = useMyEvents();
   const { data : announcements, error : announcementError } = useMyAnnouncements();
 
   const liveEvents = data?.filter(

--- a/frontend/src/routes/dashboard/index.tsx
+++ b/frontend/src/routes/dashboard/index.tsx
@@ -1,5 +1,5 @@
-import { useMyEvents } from '@/hooks/events';
 import { useMyAnnouncements } from '@/hooks/announcements';
+import { useMyEvents } from '@/hooks/events';
 
 import { AnnouncementIcon, COLOR_WARNING } from '@/constants';
 import {
@@ -7,10 +7,9 @@ import {
   Container,
   Flex,
   Heading,
-  Skeleton,
   Text,
 } from '@radix-ui/themes';
-import { ErrorCallout, InfoCallout } from 'components/Callouts';
+import { ErrorCallout } from 'components/Callouts';
 import HeaderContainer from 'components/HeaderContainer';
 import { isEmpty, map } from 'lodash';
 import PastEvents from 'routes/dashboard/PastEvents';
@@ -65,18 +64,13 @@ export default function Dashboard() {
           }
           </Flex>
         )}
-        {isEmpty(liveEvents) && (
-          <Skeleton loading={isLoading}>
-            <InfoCallout>
-              No events are currently running. This should eventually be something more interesting, i.e. the first upcoming event or practice area.
-            </InfoCallout>
-          </Skeleton>
+        {liveEvents && liveEvents.length > 0 && (
+          <Flex direction="column" gap="3">
+            {liveEvents.map((event) => (
+              <EventCard key={event.id} event={event} />
+            ))}
+          </Flex>
         )}
-        <Flex direction="column" gap="3">
-          {liveEvents?.map((event) => (
-            <EventCard key={event.id} event={event} />
-          ))}
-        </Flex>
       </HeaderContainer>
 
       <Container size="4">


### PR DESCRIPTION
- Removed reference to practice area in not registered message - only directs to event page now.
- Removed placeholder callout for no events running. The header now goes away if nothing is up there.