### PR TITLE
Admin user update modal

### DIFF
--- a/frontend/src/hooks/permissions.ts
+++ b/frontend/src/hooks/permissions.ts
@@ -1,5 +1,6 @@
+import { apiMutation } from '@/fetchers';
 import type { User } from '@/types';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 
 /*
   Gets users with Admin or Support roles
@@ -45,4 +46,14 @@ export function useEventPermission(permission: string, eventId : number | null) 
     isLoading,
     error,
   };
+}
+
+// Admin endpoints:
+export function adminUpdateUserRoles(userId: number, roles: string[]) {
+  return apiMutation(`/admin/permissions/${userId}/roles`, { roles }, {
+    method : 'PUT',
+  }).then(() => {
+    mutate('/admin/users');
+    mutate(`/admin/users/${userId}`);
+  });
 }

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -148,6 +148,15 @@ export function useWorkspaceStatus(userId : number) {
   });
 }
 
+export function adminUpdateUser(userId: number, user: Pick<User, 'name' | 'email'>) {
+  return apiMutation(`/admin/users/${userId}`, user, {
+    method : 'PUT',
+  }).then(() => {
+    mutate(`/admin/users`);
+    mutate(`/admin/users/${userId}`);
+  });
+}
+
 export function restartWorkspace(userId : number) {
   return apiMutation(`/admin/users/${userId}/container/restart`, undefined, {
     method : 'POST',

--- a/frontend/src/routes/admin/users/AdminUpdateUserModal.tsx
+++ b/frontend/src/routes/admin/users/AdminUpdateUserModal.tsx
@@ -1,0 +1,118 @@
+import { COLOR_WARNING } from '@/constants';
+import { adminUpdateUserRoles } from '@/hooks/permissions';
+import { adminUpdateUser } from '@/hooks/users';
+import type { User } from '@/types';
+import {
+  Box,
+  Button,
+  Flex,
+  Switch,
+  TextField,
+} from '@radix-ui/themes';
+import FormField from 'components/FormField';
+import Modal from 'components/Modal';
+import { Controller } from 'react-hook-form';
+import { TbPencil } from 'react-icons/tb';
+
+export default function AdminUpdateUserModal({ user }: {user: User}) {
+  return (
+    <Modal
+      title="Edit User"
+      trigger={(
+        <Button variant="soft" color={COLOR_WARNING}>
+          <TbPencil />
+          Edit
+        </Button>
+      )}
+      onSubmit={async (data) => {
+        const roles = [];
+        if (data.admin) {
+          roles.push('admin');
+        }
+        if (data.support) {
+          roles.push('support');
+        }
+
+        return Promise.all([
+          adminUpdateUser(user.id, data),
+          adminUpdateUserRoles(user.id, roles),
+        ]);
+      }}
+      submitVerb="Update"
+      submitColor={COLOR_WARNING}
+      defaultValues={{
+        name : user.name,
+        email : user.email,
+        admin : user.roles.includes('admin'),
+        support : user.roles.includes('support'),
+      }}
+    >
+      {({ register, control, formState : { errors } }) => (
+        <>
+          <FormField label="Name" error={errors.name}>
+            {(injected) => (
+              <TextField.Root {...register('name', { required : 'Name is required', maxLength : { value : 128, message : 'Name cannot be longer than 128 characters' } })} {...injected} />
+            )}
+          </FormField>
+          <FormField label="Email" error={errors.email}>
+            {(injected) => (
+              <TextField.Root {...register('email', { required : 'Email is required', maxLength : { value : 128, message : 'Name cannot be longer than 128 characters' } })} {...injected} />
+            )}
+          </FormField>
+
+          <Flex direction="row" gap="2" className="*:grow *:basis-0">
+
+            <FormField label="Is Admin" error={errors.admin}>
+              {(injected) => (
+                <Controller
+                  control={control}
+                  name="admin"
+                  rules={{}}
+                  render={({ field }) => (
+                    <Box>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={(checked) => {
+                          field.onChange(checked);
+                        }}
+                        name={field.name}
+                        ref={field.ref}
+                        size="3"
+                        {...injected}
+                      />
+                    </Box>
+                  )}
+                />
+              )}
+            </FormField>
+
+            <FormField label="Is Support" error={errors.support}>
+              {(injected) => (
+                <Controller
+                  control={control}
+                  name="support"
+                  rules={{}}
+                  render={({ field }) => (
+                    <Box>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={(checked) => {
+                          field.onChange(checked);
+                        }}
+                        name={field.name}
+                        ref={field.ref}
+                        size="3"
+                        {...injected}
+                      />
+                    </Box>
+                  )}
+                />
+              )}
+            </FormField>
+
+          </Flex>
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/routes/admin/users/AdminUpdateUserModal.tsx
+++ b/frontend/src/routes/admin/users/AdminUpdateUserModal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@radix-ui/themes';
 import FormField from 'components/FormField';
 import Modal from 'components/Modal';
+import { pick } from 'lodash';
 import { Controller } from 'react-hook-form';
 import { TbPencil } from 'react-icons/tb';
 
@@ -34,7 +35,7 @@ export default function AdminUpdateUserModal({ user }: {user: User}) {
         }
 
         return Promise.all([
-          adminUpdateUser(user.id, data),
+          adminUpdateUser(user.id, pick(data, [ 'name', 'email' ])),
           adminUpdateUserRoles(user.id, roles),
         ]);
       }}

--- a/frontend/src/routes/admin/users/AdminUpdateUserModal.tsx
+++ b/frontend/src/routes/admin/users/AdminUpdateUserModal.tsx
@@ -51,12 +51,24 @@ export default function AdminUpdateUserModal({ user }: {user: User}) {
         <>
           <FormField label="Name" error={errors.name}>
             {(injected) => (
-              <TextField.Root {...register('name', { required : 'Name is required', maxLength : { value : 128, message : 'Name cannot be longer than 128 characters' } })} {...injected} />
+              <TextField.Root
+                {...register(
+                  'name',
+                  { required : 'Name is required', maxLength : { value : 128, message : 'Name cannot be longer than 128 characters' } },
+                )}
+                {...injected}
+              />
             )}
           </FormField>
           <FormField label="Email" error={errors.email}>
             {(injected) => (
-              <TextField.Root {...register('email', { required : 'Email is required', maxLength : { value : 128, message : 'Name cannot be longer than 128 characters' } })} {...injected} />
+              <TextField.Root
+                {...register(
+                  'email',
+                  { required : 'Email is required', maxLength : { value : 128, message : 'Name cannot be longer than 128 characters' } },
+                )}
+                {...injected}
+              />
             )}
           </FormField>
 

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -18,6 +18,7 @@ import RoleBadge from 'components/RoleBadge';
 import { keyBy } from 'lodash';
 import { useId } from 'react';
 import AdminRegisterUserModal from './AdminRegisterUserModal';
+import AdminUpdateUserModal from './AdminUpdateUserModal';
 import ImpersonateUserButton from './ImpersonateUserButton';
 import RecycleWorkspaceModal from './RecycleWorkspaceModal';
 import RestartWorkspaceModal from './RestartWorkspaceModal';
@@ -71,6 +72,7 @@ export default function UserSidebar({ entity }: { entity: User }) {
     <AdminSidebar labelId={headerId}>
       <AdminSidebarHeader title={entity.name} icon={<UserIcon />} id={headerId}>
         <ImpersonateUserButton user={entity} />
+        <AdminUpdateUserModal user={entity} />
       </AdminSidebarHeader>
 
       <AdminDataList data={{ ...entity }} />


### PR DESCRIPTION
Resolves #330.

Modal for updating users and their associated roles. This is a bit weird since it has to hit two endpoints - it's theoretically possible for one to succeed but not the other, but we don't have a way of doing both atomically at the moment.

Eventually I'd like to allow configuring a user's sponsor through here as well, but that's not a priority and the endpoints for doing so don't exist yet. Dynamically populating the roles with a better interface to assign them would also be nice long-term.

While the role update UI is present, its functionality is currently blocked on #420 - the endpoint doesn't currently work. Once #422 merges, it will work.

<img width="642" height="351" alt="image" src="https://github.com/user-attachments/assets/d2a176dc-daab-4b42-8d8a-c841b71180ba" />
