### PR TITLE
S3 fileuploads updates

### DIFF
--- a/backend/ng/config.py
+++ b/backend/ng/config.py
@@ -47,6 +47,10 @@ PUBLIC_FILE_ALLOWED_FOLDERS = {
 # Maximum number to try when auto-numbering duplicate filenames (e.g., file_1.png, file_2.png, etc)
 PUBLIC_FILE_AUTO_NUMBER_MAX_ATTEMPTS = 999
 
+# S3 URL expiration configuration
+S3_UPLOAD_URL_EXPIRATION = 3600
+S3_DOWNLOAD_URL_EXPIRATION = 600
+
 # Scoring Cache Config & Model Length Limits
 LEADERBOARD_CACHE_TIMEOUT = 60  # Seconds
 MAX_SUBMISSION_LENGTH = 4096

--- a/backend/ng/config.py
+++ b/backend/ng/config.py
@@ -31,7 +31,6 @@ TICKET_ATTACHMENT_BUCKET_NAME_MAX_LENGTH = 256
 TICKET_ATTACHMENT_FILENAME_MAX_LENGTH = 256
 TICKET_ATTACHMENT_CONTENT_TYPE_MAX_LENGTH = 128
 S3_TICKET_ATTACHMENTS_PREFIX = "support-tickets"
-S3_DOWNLOAD_CHUNK_SIZE = 8192  # 8KB chunks for streaming downloads
 
 # Support ticket attachment download endpoints
 TICKET_ATTACHMENT_USER_DOWNLOAD_PATH = "/ng/support/me/attachments"
@@ -40,9 +39,13 @@ TICKET_ATTACHMENT_ADMIN_DOWNLOAD_PATH = "/ng/admin/support/attachments"
 # Public file upload configuration
 PUBLIC_FILE_ALLOWED_FOLDERS = {
     'sponsor-logos': ['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml'],
-    'event-cards': ['image/png', 'image/jpeg', 'image/webp'],
-    'favicons': ['image/x-icon', 'image/png', 'image/svg+xml']
+    'event-cards': ['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml'],
+    'favicons': ['image/x-icon', 'image/png', 'image/jpeg', 'image/webp', 'image/svg+xml']
 }
+
+# Auto-numbering configuration for file uploads
+# Maximum number to try when auto-numbering duplicate filenames (e.g., file_1.png, file_2.png, etc)
+PUBLIC_FILE_AUTO_NUMBER_MAX_ATTEMPTS = 999
 
 # Scoring Cache Config & Model Length Limits
 LEADERBOARD_CACHE_TIMEOUT = 60  # Seconds

--- a/backend/ng/core/services/s3_service.py
+++ b/backend/ng/core/services/s3_service.py
@@ -4,6 +4,8 @@ from typing import Any
 import logging
 from werkzeug.datastructures import FileStorage
 
+from ... import config
+
 logger = logging.getLogger(__name__)
 
 # Global S3 service instance
@@ -65,7 +67,7 @@ class S3Service:
                     'Key': object_key,
                     'ContentType': content_type,
                 },
-                ExpiresIn=3600,  # 1 hour
+                ExpiresIn=config.S3_UPLOAD_URL_EXPIRATION,
                 HttpMethod='PUT'
             )
 

--- a/backend/ng/fileuploads/controllers/public_files.py
+++ b/backend/ng/fileuploads/controllers/public_files.py
@@ -90,7 +90,8 @@ def generate_upload_url(args):
         # Optionally include download URL
         include_urls = args.get('include_urls', False)
         if include_urls:
-            download_url = s3_service.generate_download_url(folder, final_filename)
+            object_key = f"{folder}/{final_filename}"
+            download_url = s3_service.generate_download_url(object_key, expires_in=config.S3_DOWNLOAD_URL_EXPIRATION)
             uploaded_file["download_url"] = download_url
 
         return success_response(uploaded_file)
@@ -116,10 +117,11 @@ def get_public_file(args):
         if not s3_service or not s3_service.is_configured():
             return error_response("File storage not configured", "s3_service", 503)
 
+        object_key = f"{folder}/{filename}"
         if not s3_service.object_exists(object_key):
             return error_response("File not found", "file", 404)
 
-        presigned_url = s3_service.generate_download_url(object_key, expires_in=86400)
+        presigned_url = s3_service.generate_download_url(object_key, expires_in=config.S3_DOWNLOAD_URL_EXPIRATION)
 
         logger.info(f"Generated download URL for {object_key}")
 
@@ -162,7 +164,7 @@ def list_public_files(args):
                 # Add presigned download URL if requested
                 if include_urls:
                     try:
-                        presigned_url = s3_service.generate_download_url(obj['key'], expires_in=86400)
+                        presigned_url = s3_service.generate_download_url(obj['key'], expires_in=config.S3_DOWNLOAD_URL_EXPIRATION)
                         file_info['download_url'] = presigned_url
                     except Exception as e:
                         logger.warning(f"Failed to generate download URL for {obj['key']}: {e}")
@@ -172,6 +174,7 @@ def list_public_files(args):
         return success_response({
             "folder": folder,
             "files": files,
+            "count": len(files)
         })
 
     except Exception as e:
@@ -204,7 +207,7 @@ def search_public_files(args):
                 # Add download URL if requested
                 if include_urls:
                     try:
-                        download_url = s3_service.generate_download_url(object_key, expires_in=86400)
+                        download_url = s3_service.generate_download_url(object_key, expires_in=config.S3_DOWNLOAD_URL_EXPIRATION)
                         file_info['download_url'] = download_url
                     except Exception as e:
                         logger.warning(f"Failed to generate download URL for {object_key}: {e}")
@@ -240,7 +243,7 @@ def search_public_files(args):
                 # Add download URL if requested
                 if include_urls:
                     try:
-                        download_url = s3_service.generate_download_url(obj['key'], expires_in=86400)
+                        download_url = s3_service.generate_download_url(obj['key'], expires_in=config.S3_DOWNLOAD_URL_EXPIRATION)
                         file_info['download_url'] = download_url
                     except Exception as e:
                         logger.warning(f"Failed to generate download URL for {obj['key']}: {e}")
@@ -325,10 +328,11 @@ def direct_upload_file(args):
         include_urls = args.get('include_urls', False)  # Default to False for upload endpoints
         if include_urls:
             try:
-                download_url = s3_service.generate_download_url(folder, final_filename)
+                download_url = s3_service.generate_download_url(object_key, expires_in=config.S3_DOWNLOAD_URL_EXPIRATION)
                 uploaded_file["download_url"] = download_url
+                logger.info(f"Generated download URL for newly uploaded file: {object_key}")
             except Exception as e:
-                logger.warning(f"Failed to generate download URL for {final_filename}: {e}")
+                logger.error(f"Failed to generate download URL for {final_filename}: {e}")
                 uploaded_file["download_url"] = None
 
         return success_response(uploaded_file)

--- a/backend/ng/fileuploads/controllers/public_files.py
+++ b/backend/ng/fileuploads/controllers/public_files.py
@@ -1,7 +1,6 @@
 """
 Public file operations for sponsor-logos, event-cards, favicons
 """
-import uuid
 import logging
 import requests
 from ...core.utils import success_response, error_response
@@ -13,45 +12,92 @@ from ... import config
 logger = logging.getLogger(__name__)
 
 ALLOWED_FOLDERS = config.PUBLIC_FILE_ALLOWED_FOLDERS
+MAX_AUTO_NUMBER_ATTEMPTS = config.PUBLIC_FILE_AUTO_NUMBER_MAX_ATTEMPTS
+
+def generate_unique_filename(s3_service, folder, original_filename, allow_overwrite=False):
+    """Generate unique filename by appending numbers if file exists"""
+    if allow_overwrite:
+        return original_filename
+    
+    object_key = f"{folder}/{original_filename}"
+    exists = s3_service.object_exists(object_key)
+
+    if not exists:
+        return original_filename
+    
+    if '.' in original_filename:
+        name, ext = original_filename.rsplit('.', 1)
+        ext = '.' + ext
+    else:
+        name = original_filename
+        ext = ''
+    
+    counter = 1
+    while counter <= MAX_AUTO_NUMBER_ATTEMPTS:
+        numbered_filename = f"{name}_{counter}{ext}"
+        numbered_key = f"{folder}/{numbered_filename}"
+        if not s3_service.object_exists(numbered_key):
+            return numbered_filename
+        counter += 1
+    
+    raise ValueError(f"Could not generate unique filename for '{original_filename}' after {MAX_AUTO_NUMBER_ATTEMPTS} attempts. Too many files with similar names exist.")
 
 def generate_upload_url(args):
     """Generate presigned URL for direct client-side upload to S3"""
     try:
         folder = args.get('folder')
         content_type = args.get('content_type')
+        filename = args.get('filename')
+        allow_overwrite = args.get('allow_overwrite', False)
 
         if not folder or folder not in ALLOWED_FOLDERS:
-            return {
-                "error": f"Invalid folder. Must be one of: {', '.join(ALLOWED_FOLDERS.keys())}"
-            }, 400
+            return error_response(
+                f"Invalid folder. Must be one of: {', '.join(ALLOWED_FOLDERS.keys())}",
+                "folder", 400
+            )
 
         if not content_type or content_type not in ALLOWED_FOLDERS[folder]:
-            return {
-                "error": f"Invalid content type for {folder}. Allowed: {', '.join(ALLOWED_FOLDERS[folder])}"
-            }, 400
+            return error_response(
+                f"Invalid content type for {folder}. Allowed: {', '.join(ALLOWED_FOLDERS[folder])}",
+                "content_type", 400
+            )
+
+        if not filename:
+            return error_response("Filename is required", "filename", 400)
 
         from ...core.services.s3_service import get_s3_service
         s3_service = get_s3_service()
         if not s3_service or not s3_service.is_configured():
-            return {"error": "File storage not configured"}, 503
+            return error_response("File storage not configured", "s3_service", 503)
 
-        file_extension = get_file_extension(content_type)
-        filename = f"{uuid.uuid4().hex}.{file_extension}"
-        object_key = f"{folder}/{filename}"
+        # Generate unique filename or allow overwrite
+        try:
+            final_filename = generate_unique_filename(s3_service, folder, filename, allow_overwrite)
+        except ValueError as e:
+            logger.warning(f"Filename generation failed for '{filename}' in folder '{folder}': {e}")
+            return error_response(str(e), "filename_generation", 409)
 
-        result = s3_service.generate_upload_url(folder, filename, content_type)
+        result = s3_service.generate_upload_url(folder, final_filename, content_type)
 
-        return {
-            "presigned_url": result['presigned_url'],
-            "filename": filename,
-            "object_key": object_key,
-            "content_type": content_type,
-            "upload_method": "PUT"
+        uploaded_file = {
+            "filename": final_filename,
+            "folder": folder,
         }
+
+        uploaded_file["upload_url"] = result['presigned_url']
+        uploaded_file["upload_method"] = "PUT"
+
+        # Optionally include download URL
+        include_urls = args.get('include_urls', False)
+        if include_urls:
+            download_url = s3_service.generate_download_url(folder, final_filename)
+            uploaded_file["download_url"] = download_url
+
+        return success_response(uploaded_file)
 
     except Exception as e:
         logger.error(f"Upload URL generation error: {e}")
-        return {"error": "Internal server error"}, 500
+        return error_response("Internal server error", "upload", 500)
 
 def get_public_file(args):
     """Get presigned download URL for public file access"""
@@ -60,48 +106,46 @@ def get_public_file(args):
         filename = args.get('filename')
 
         if not folder or not filename:
-            return error_response("Folder and filename are required", 400)
+            return error_response("Folder and filename are required", "parameters", 400)
 
         if folder not in ALLOWED_FOLDERS:
-            return error_response("Invalid folder", 404)
+            return error_response("Invalid folder", "folder", 404)
 
         from ...core.services.s3_service import get_s3_service
         s3_service = get_s3_service()
         if not s3_service or not s3_service.is_configured():
-            return error_response("File storage not configured", 503)
-
-        object_key = f"{folder}/{filename}"
+            return error_response("File storage not configured", "s3_service", 503)
 
         if not s3_service.object_exists(object_key):
-            return error_response("File not found", 404)
+            return error_response("File not found", "file", 404)
 
         presigned_url = s3_service.generate_download_url(object_key, expires_in=86400)
 
         logger.info(f"Generated download URL for {object_key}")
 
         return success_response({
-            "url": presigned_url,
+            "download_url": presigned_url,
             "filename": filename,
             "folder": folder,
-            "object_key": object_key
         })
 
     except Exception as e:
         logger.error(f"Get public file error: {e}")
-        return error_response("File not found", 404)
+        return error_response("File not found", "file", 404)
 
 def list_public_files(args):
     """List all files in a specified public folder"""
     try:
         folder = args.get('folder')
+        include_urls = args.get('include_urls', False)
 
         if not folder or folder not in ALLOWED_FOLDERS:
-            return error_response("Valid folder parameter required", 400)
+            return error_response("Valid folder parameter required", "folder", 400)
 
         from ...core.services.s3_service import get_s3_service
         s3_service = get_s3_service()
         if not s3_service or not s3_service.is_configured():
-            return error_response("File storage not configured", 503)
+            return error_response("File storage not configured", "s3_service", 503)
 
         objects = s3_service.list_objects(prefix=folder)
         files = []
@@ -109,53 +153,72 @@ def list_public_files(args):
         for obj in objects:
             key_parts = obj['key'].split('/')
             if len(key_parts) > 1 and key_parts[0] == folder:
-                files.append({
+                file_info = {
                     'filename': key_parts[1],
-                    'size': obj['size'],
-                    'last_modified': obj['last_modified'],
-                    'key': obj['key']
-                })
+                    'folder': folder,
+                    'last_modified': obj['last_modified']
+                }
+
+                # Add presigned download URL if requested
+                if include_urls:
+                    try:
+                        presigned_url = s3_service.generate_download_url(obj['key'], expires_in=86400)
+                        file_info['download_url'] = presigned_url
+                    except Exception as e:
+                        logger.warning(f"Failed to generate download URL for {obj['key']}: {e}")
+                        file_info['download_url'] = None
+                files.append(file_info)
 
         return success_response({
             "folder": folder,
             "files": files,
-            "count": len(files)
         })
 
     except Exception as e:
         logger.error(f"List public files error: {e}")
-        return {"error": "Internal server error"}, 500
+        return error_response("Internal server error", "list", 500)
 
-def search_public_files():
+def search_public_files(args):
     """Search files across folders or within specific folder"""
     try:
-        folder = request.args.get('folder')
-        filename = request.args.get('filename')
+        folder = args.get('folder')
+        filename = args.get('filename')
+        include_urls = args.get('include_urls', False)
 
         from ...core.services.s3_service import get_s3_service
         s3_service = get_s3_service()
         if not s3_service or not s3_service.is_configured():
-            return {"error": "File storage not configured"}, 503
+            return error_response("File storage not configured", "s3_service", 503)
 
         if folder and folder not in ALLOWED_FOLDERS:
-            return {"error": "Invalid folder"}, 400
+            return error_response("Invalid folder", "folder", 400)
 
         if folder and filename:
             object_key = f"{folder}/{filename}"
             if s3_service.object_exists(object_key):
-                return {
-                    "files": [{
-                        'filename': filename,
-                        'folder': folder,
-                        'key': object_key
-                    }],
-                    "count": 1
+                file_info = {
+                    'filename': filename,
+                    'folder': folder
                 }
+                
+                # Add download URL if requested
+                if include_urls:
+                    try:
+                        download_url = s3_service.generate_download_url(object_key, expires_in=86400)
+                        file_info['download_url'] = download_url
+                    except Exception as e:
+                        logger.warning(f"Failed to generate download URL for {object_key}: {e}")
+                        file_info['download_url'] = None
+                
+                return success_response({
+                    "files": [file_info],
+                    "count": 1
+                })
             else:
-                return {
+                return success_response({
                     "files": [],
                     "count": 0
-                }
+                })
 
         if folder:
             prefix = folder
@@ -168,36 +231,32 @@ def search_public_files():
         for obj in objects:
             key_parts = obj['key'].split('/')
             if len(key_parts) > 1 and key_parts[0] in ALLOWED_FOLDERS:
-                files.append({
+                file_info = {
                     'filename': key_parts[1],
                     'folder': key_parts[0],
-                    'size': obj['size'],
-                    'last_modified': obj['last_modified'],
-                    'key': obj['key']
-                })
+                    'last_modified': obj['last_modified']
+                }
+                
+                # Add download URL if requested
+                if include_urls:
+                    try:
+                        download_url = s3_service.generate_download_url(obj['key'], expires_in=86400)
+                        file_info['download_url'] = download_url
+                    except Exception as e:
+                        logger.warning(f"Failed to generate download URL for {obj['key']}: {e}")
+                        file_info['download_url'] = None
+                
+                files.append(file_info)
 
-        return {
+        return success_response({
             "folder": folder,
             "files": files,
             "count": len(files)
-        }
+        })
 
     except Exception as e:
         logger.error(f"Search public files error: {e}")
-        return {"error": "Internal server error"}, 500
-
-def get_file_extension(content_type: str) -> str:
-    """Get file extension from MIME content type"""
-    extension_map = {
-        'image/png': 'png',
-        'image/jpeg': 'jpg',
-        'image/jpg': 'jpg',
-        'image/webp': 'webp',
-        'image/svg+xml': 'svg',
-        'image/x-icon': 'ico',
-        'application/octet-stream': 'bin'
-    }
-    return extension_map.get(content_type, 'bin')
+        return error_response("Internal server error", "search", 500)
 
 def direct_upload_file(args):
     """Upload file directly to S3 using server-side presigned URL generation"""
@@ -206,32 +265,43 @@ def direct_upload_file(args):
         file = args.get('file')
 
         if not folder or folder not in ALLOWED_FOLDERS:
-            return error_response(f"Invalid folder. Must be one of: {', '.join(ALLOWED_FOLDERS.keys())}", 400)
+            return error_response(f"Invalid folder. Must be one of: {', '.join(ALLOWED_FOLDERS.keys())}", "folder", 400)
 
         if not file or not isinstance(file, FileStorage) or not file.filename:
-            return error_response("Valid file is required", 400)
+            return error_response("Valid file is required", "file", 400)
 
         content_type = file.content_type or 'application/octet-stream'
         if content_type not in ALLOWED_FOLDERS[folder]:
-            return error_response(f"Invalid content type for {folder}. Allowed: {', '.join(ALLOWED_FOLDERS[folder])}", 400)
+            return error_response(
+                f"Invalid content type for {folder}. Allowed: {', '.join(ALLOWED_FOLDERS[folder])}",
+                "content_type", 400
+            )
 
-        presigned_response = generate_upload_url({
-            'folder': folder,
-            'content_type': content_type
-        })
+        original_filename = file.filename
+        allow_overwrite = args.get('allow_overwrite', False)
+        
+        from ...core.services.s3_service import get_s3_service
+        s3_service = get_s3_service()
+        if not s3_service or not s3_service.is_configured():
+            return error_response("File storage not configured", "s3_service", 503)
 
-        if isinstance(presigned_response, tuple):
-            return presigned_response
+        # Generate unique filename or allow overwrite
+        try:
+            final_filename = generate_unique_filename(s3_service, folder, original_filename, allow_overwrite)
+        except ValueError as e:
+            logger.warning(f"Filename generation failed for '{original_filename}' in folder '{folder}': {e}")
+            return error_response(str(e), "filename_generation", 409)
 
-        presigned_url = presigned_response.get('presigned_url')
-        object_key = presigned_response.get('object_key')
+        # Generate presigned URL for the actual upload
+        result = s3_service.generate_upload_url(folder, final_filename, content_type)
+        presigned_url = result['presigned_url']
+        object_key = f"{folder}/{final_filename}"
 
         if not presigned_url:
-            return error_response("Failed to generate presigned URL", 500)
+            return error_response("Failed to generate presigned URL", "presigned_url", 500)
 
         file.stream.seek(0)
         file_data = file.stream.read()
-        file_size = len(file_data)
 
         upload_response = requests.put(
             presigned_url,
@@ -242,19 +312,27 @@ def direct_upload_file(args):
 
         if upload_response.status_code not in [200, 204]:
             logger.error(f"S3 upload failed: HTTP {upload_response.status_code}")
-            return error_response("Failed to upload file to S3", 500)
+            return error_response("Failed to upload file to S3", "s3_upload", 500)
 
         logger.info(f"Successfully uploaded file to S3: {object_key}")
 
-        return success_response({
-            "object_key": object_key,
-            "filename": presigned_response.get('filename'),
-            "original_filename": file.filename,
+        uploaded_file = {
+            "filename": final_filename,
             "folder": folder,
-            "content_type": content_type,
-            "file_size": file_size
-        })
+        }
+
+        # Optionally include download URL
+        include_urls = args.get('include_urls', False)  # Default to False for upload endpoints
+        if include_urls:
+            try:
+                download_url = s3_service.generate_download_url(folder, final_filename)
+                uploaded_file["download_url"] = download_url
+            except Exception as e:
+                logger.warning(f"Failed to generate download URL for {final_filename}: {e}")
+                uploaded_file["download_url"] = None
+
+        return success_response(uploaded_file)
 
     except Exception as e:
         logger.error(f"Upload error: {e}")
-        return {"error": "Upload failed"}, 500
+        return error_response("Upload failed", "upload", 500)

--- a/backend/ng/fileuploads/controllers/public_files.py
+++ b/backend/ng/fileuploads/controllers/public_files.py
@@ -247,9 +247,7 @@ def search_public_files(args):
                 files.append(file_info)
 
         return success_response({
-            "folder": folder,
             "files": files,
-            "count": len(files)
         })
 
     except Exception as e:

--- a/backend/ng/fileuploads/controllers/public_files.py
+++ b/backend/ng/fileuploads/controllers/public_files.py
@@ -4,7 +4,6 @@ Public file operations for sponsor-logos, event-cards, favicons
 import logging
 import requests
 from ...core.utils import success_response, error_response
-from flask import request
 from werkzeug.datastructures import FileStorage
 
 from ... import config
@@ -18,20 +17,20 @@ def generate_unique_filename(s3_service, folder, original_filename, allow_overwr
     """Generate unique filename by appending numbers if file exists"""
     if allow_overwrite:
         return original_filename
-    
+
     object_key = f"{folder}/{original_filename}"
     exists = s3_service.object_exists(object_key)
 
     if not exists:
         return original_filename
-    
+
     if '.' in original_filename:
         name, ext = original_filename.rsplit('.', 1)
         ext = '.' + ext
     else:
         name = original_filename
         ext = ''
-    
+
     counter = 1
     while counter <= MAX_AUTO_NUMBER_ATTEMPTS:
         numbered_filename = f"{name}_{counter}{ext}"
@@ -39,7 +38,7 @@ def generate_unique_filename(s3_service, folder, original_filename, allow_overwr
         if not s3_service.object_exists(numbered_key):
             return numbered_filename
         counter += 1
-    
+
     raise ValueError(f"Could not generate unique filename for '{original_filename}' after {MAX_AUTO_NUMBER_ATTEMPTS} attempts. Too many files with similar names exist.")
 
 def generate_upload_url(args):
@@ -203,7 +202,7 @@ def search_public_files(args):
                     'filename': filename,
                     'folder': folder
                 }
-                
+
                 # Add download URL if requested
                 if include_urls:
                     try:
@@ -212,7 +211,7 @@ def search_public_files(args):
                     except Exception as e:
                         logger.warning(f"Failed to generate download URL for {object_key}: {e}")
                         file_info['download_url'] = None
-                
+
                 return success_response({
                     "files": [file_info],
                     "count": 1
@@ -239,7 +238,7 @@ def search_public_files(args):
                     'folder': key_parts[0],
                     'last_modified': obj['last_modified']
                 }
-                
+
                 # Add download URL if requested
                 if include_urls:
                     try:
@@ -248,7 +247,7 @@ def search_public_files(args):
                     except Exception as e:
                         logger.warning(f"Failed to generate download URL for {obj['key']}: {e}")
                         file_info['download_url'] = None
-                
+
                 files.append(file_info)
 
         return success_response({
@@ -282,7 +281,7 @@ def direct_upload_file(args):
 
         original_filename = file.filename
         allow_overwrite = args.get('allow_overwrite', False)
-        
+
         from ...core.services.s3_service import get_s3_service
         s3_service = get_s3_service()
         if not s3_service or not s3_service.is_configured():

--- a/backend/ng/fileuploads/controllers/public_files.py
+++ b/backend/ng/fileuploads/controllers/public_files.py
@@ -171,9 +171,7 @@ def list_public_files(args):
                 files.append(file_info)
 
         return success_response({
-            "folder": folder,
             "files": files,
-            "count": len(files)
         })
 
     except Exception as e:
@@ -214,12 +212,10 @@ def search_public_files(args):
 
                 return success_response({
                     "files": [file_info],
-                    "count": 1
                 })
             else:
                 return success_response({
                     "files": [],
-                    "count": 0
                 })
 
         if folder:

--- a/backend/ng/fileuploads/routes/public_files.py
+++ b/backend/ng/fileuploads/routes/public_files.py
@@ -81,7 +81,7 @@ class FileList(Resource):
                 'example': 'sponsor-logos'
             },
             'include_urls': {
-                'description': 'Include presigned download URLs for each file (24 hour expiration)',
+                'description': 'Include presigned download URLs for each file',
                 'type': 'boolean',
                 'required': False,
                 'default': False,
@@ -143,7 +143,6 @@ class FileAccess(Resource):
         """Get presigned URL for file access
 
         Generate a presigned download URL for a specific file in a public folder.
-        The URL is valid for 24 hours and allows direct access to the file.
         """
         folder = request.args.get('folder')
         filename = request.args.get('filename')

--- a/backend/ng/fileuploads/routes/public_files.py
+++ b/backend/ng/fileuploads/routes/public_files.py
@@ -1,5 +1,8 @@
 from flask_restx import Namespace, Resource
 from flask import request
+
+from ...core.middleware import user_endpoint, admin_endpoint
+from ...user.models import User
 from ..controllers.public_files import (
     generate_upload_url,
     get_public_file,
@@ -14,6 +17,7 @@ fileuploads_namespace = Namespace('fileuploads', description='File upload operat
 
 @fileuploads_namespace.route('/upload/url')
 class FileUploadURL(Resource):
+    @admin_endpoint(json_required=True)
     @fileuploads_namespace.doc(
         description='Generate a presigned URL for direct client-side upload to S3',
         params={
@@ -31,6 +35,20 @@ class FileUploadURL(Resource):
                 'required': True,
                 'in': 'body',
                 'example': 'image/png'
+            },
+            'filename': {
+                'description': 'Original filename to use in S3',
+                'type': 'string',
+                'required': True,
+                'in': 'body',
+                'example': 'my-logo.png'
+            },
+            'allow_overwrite': {
+                'description': 'Allow overwriting existing files (default: false, will auto-number)',
+                'type': 'boolean',
+                'required': False,
+                'in': 'body',
+                'example': False
             }
         },
         responses={
@@ -40,33 +58,18 @@ class FileUploadURL(Resource):
             503: 'Service Unavailable - S3 storage not configured'
         }
     )
-    def post(self):
+    def post(self, current_user: User, json_data, **kwargs):
         """Generate presigned URL for client-side upload
 
         This endpoint generates a presigned URL that allows clients to upload files
         directly to S3 without going through the server. Supports sponsor logos,
         event cards, and favicon uploads.
         """
-        data = request.get_json()
-        if not data:
-            return {"error": "JSON data required"}, 400
-
-        folder = data.get('folder')
-        content_type = data.get('content_type')
-
-        if not folder:
-            return {"error": "Folder is required"}, 400
-        if not content_type:
-            return {"error": "Content type is required"}, 400
-
-        return generate_upload_url({
-            'folder': folder,
-            'content_type': content_type
-        })
-
+        return generate_upload_url(json_data)
 
 @fileuploads_namespace.route('/list')
 class FileList(Resource):
+    @admin_endpoint()
     @fileuploads_namespace.doc(
         description='List all files in a specified public folder',
         params={
@@ -76,10 +79,17 @@ class FileList(Resource):
                 'enum': ['sponsor-logos', 'event-cards', 'favicons'],
                 'required': True,
                 'example': 'sponsor-logos'
+            },
+            'include_urls': {
+                'description': 'Include presigned download URLs for each file (24 hour expiration)',
+                'type': 'boolean',
+                'required': False,
+                'default': False,
+                'example': True
             }
         },
         responses={
-            200: 'Success - Returns list of files in the folder',
+            200: 'Success - Returns list of files in the folder, optionally with download URLs',
             400: 'Bad Request - Invalid or missing folder parameter',
             500: 'Internal Server Error',
             503: 'Service Unavailable - S3 storage not configured'
@@ -90,18 +100,20 @@ class FileList(Resource):
 
         Retrieve a list of all files in the specified public folder.
         Returns file metadata including size, last modified date, and S3 key.
+        Optionally includes presigned download URLs when include_urls=true.
         """
         folder = request.args.get('folder')
-        if not folder:
-            return {"error": "Folder parameter is required"}, 400
+        include_urls = request.args.get('include_urls', 'false').lower() == 'true'
 
         return list_public_files({
-            'folder': folder
+            'folder': folder,
+            'include_urls': include_urls
         })
 
 
 @fileuploads_namespace.route('/file')
 class FileAccess(Resource):
+    @user_endpoint()
     @fileuploads_namespace.doc(
         description='Get a presigned download URL for a specific file',
         params={
@@ -136,11 +148,6 @@ class FileAccess(Resource):
         folder = request.args.get('folder')
         filename = request.args.get('filename')
 
-        if not folder:
-            return {"error": "Folder parameter is required"}, 400
-        if not filename:
-            return {"error": "Filename parameter is required"}, 400
-
         return get_public_file({
             'folder': folder,
             'filename': filename
@@ -149,6 +156,7 @@ class FileAccess(Resource):
 
 @fileuploads_namespace.route('/search')
 class FileSearch(Resource):
+    @admin_endpoint()
     @fileuploads_namespace.doc(
         description='Search for files across folders or within a specific folder',
         params={
@@ -173,6 +181,13 @@ class FileSearch(Resource):
                 'minimum': 1,
                 'maximum': 50,
                 'example': 10
+            },
+            'include_urls': {
+                'description': 'Include presigned download URLs for each file (24 hour expiration)',
+                'type': 'boolean',
+                'required': False,
+                'default': False,
+                'example': True
             }
         },
         responses={
@@ -192,11 +207,20 @@ class FileSearch(Resource):
 
         Results are limited to 50 maximum and sorted by filename.
         """
-        return search_public_files()
+        folder = request.args.get('folder')
+        filename = request.args.get('filename')
+        include_urls = request.args.get('include_urls', 'false').lower() == 'true'
+        
+        return search_public_files({
+            'folder': folder,
+            'filename': filename,
+            'include_urls': include_urls
+        })
 
 
 @fileuploads_namespace.route('/upload/direct')
 class DirectFileUpload(Resource):
+    @admin_endpoint()
     @fileuploads_namespace.doc(
         description='Upload a file directly to S3 (server-side upload with automatic presigned URL generation)',
         params={
@@ -213,6 +237,13 @@ class DirectFileUpload(Resource):
                 'type': 'file',
                 'required': True,
                 'in': 'formData'
+            },
+            'allow_overwrite': {
+                'description': 'Allow overwriting existing files (default: false, will auto-number)',
+                'type': 'string',
+                'required': False,
+                'in': 'formData',
+                'example': 'false'
             }
         },
         responses={
@@ -223,21 +254,26 @@ class DirectFileUpload(Resource):
         },
         consumes=['multipart/form-data']
     )
-    def post(self):
+    def post(self, current_user: User, **kwargs):
         """Upload a file directly to S3 using presigned URLs
 
         This endpoint handles server-side file upload by:
         1. Validating the file and folder
-        2. Generating a presigned upload URL
-        3. Uploading the file to S3
+        2. Generating a presigned upload URL using the original filename
+        3. Uploading the file to S3 (will overwrite if filename exists)
         4. Returning file metadata
 
-        Supports image files in sponsor-logos, event-cards, and favicons folders.
+        Files maintain their original names in S3. Supports image files in
+        sponsor-logos, event-cards, and favicons folders.
         """
         folder = request.form.get('folder')
         file = request.files.get('file')
+        allow_overwrite = request.form.get('allow_overwrite', 'false').lower() == 'true'
+        include_urls = request.form.get('include_urls', 'false').lower() == 'true'
 
         return direct_upload_file({
             'folder': folder,
-            'file': file
+            'file': file,
+            'allow_overwrite': allow_overwrite,
+            'include_urls': include_urls
         })

--- a/backend/ng/fileuploads/routes/public_files.py
+++ b/backend/ng/fileuploads/routes/public_files.py
@@ -95,7 +95,7 @@ class FileList(Resource):
             503: 'Service Unavailable - S3 storage not configured'
         }
     )
-    def get(self):
+    def get(self, current_user: User, **kwargs):
         """List files in a public folder
 
         Retrieve a list of all files in the specified public folder.
@@ -139,7 +139,7 @@ class FileAccess(Resource):
             503: 'Service Unavailable - S3 storage not configured'
         }
     )
-    def get(self):
+    def get(self, current_user: User, **kwargs):
         """Get presigned URL for file access
 
         Generate a presigned download URL for a specific file in a public folder.
@@ -197,7 +197,7 @@ class FileSearch(Resource):
             503: 'Service Unavailable - S3 storage not configured'
         }
     )
-    def get(self):
+    def get(self, current_user: User, **kwargs):
         """Search files across folders or within specific folder
 
         Flexible file search supporting multiple modes:

--- a/backend/ng/fileuploads/routes/public_files.py
+++ b/backend/ng/fileuploads/routes/public_files.py
@@ -209,7 +209,7 @@ class FileSearch(Resource):
         folder = request.args.get('folder')
         filename = request.args.get('filename')
         include_urls = request.args.get('include_urls', 'false').lower() == 'true'
-        
+
         return search_public_files({
             'folder': folder,
             'filename': filename,

--- a/backend/ng/fileuploads/routes/public_files.py
+++ b/backend/ng/fileuploads/routes/public_files.py
@@ -99,7 +99,7 @@ class FileList(Resource):
         """List files in a public folder
 
         Retrieve a list of all files in the specified public folder.
-        Returns file metadata including size, last modified date, and S3 key.
+        Returns file metadata including filename, folder, and last modified date.
         Optionally includes presigned download URLs when include_urls=true.
         """
         folder = request.args.get('folder')


### PR DESCRIPTION
- moved URL expiration to config
- preserving filenames on upload
- optional file overwriting or number appending
- switched to success_response and error_response wrappers for responses
- better output standardization on endpoints
- optional download url generation on more endpoints
- decorated endpoints (everything except file download)
Closes issues #430 and #435 