### PR TITLE
Bugfix/support redirect

### DIFF
--- a/backend/ng/notifications/models/Notification.py
+++ b/backend/ng/notifications/models/Notification.py
@@ -39,6 +39,7 @@ class SerializedNotification(TypedDict):
     read_at: str | None
     created_at: str
     expires_at: str | None
+    link: NotRequired[str | None]
     # Optional reference fields
     ticket_id: NotRequired[int | None]
     team_id: NotRequired[int | None]
@@ -203,6 +204,9 @@ class Notification(db.Model):
             data["event_name"] = self.event.name
         if self.challenge_id and self.challenge:
             data["challenge_name"] = self.challenge.name
+
+        from ..services.notification_service import generate_notification_link
+        data["link"] = generate_notification_link(self)
 
         return SerializedNotification(**data)
 

--- a/backend/ng/notifications/services/notification_service.py
+++ b/backend/ng/notifications/services/notification_service.py
@@ -78,7 +78,7 @@ class NotificationService:
         notification = Notification.create_notification(
             notification_type=NotificationType.TICKET_MESSAGE,
             title="Support Ticket Update",
-            message=f"{'Admin' if is_admin_reply else 'User'} replied to your ticket",
+            message=f"{'Admin' if is_admin_reply else 'User'} replied to ticket #{ticket_id}",
             recipient_id=recipient_id,
             sender_id=author_id,
             ticket_id=ticket_id,
@@ -104,7 +104,7 @@ class NotificationService:
         notification = Notification.create_notification(
             notification_type=NotificationType.TICKET_STATUS_CHANGE,
             title="Ticket Status Changed",
-            message=f"Your ticket was {new_status}",
+            message=f"Ticket #{ticket_id} was {new_status}",
             recipient_id=recipient_id,
             sender_id=changed_by_id,
             ticket_id=ticket_id,
@@ -144,7 +144,7 @@ class NotificationService:
             notification = Notification.create_notification(
                 notification_type=NotificationType.TICKET_MESSAGE,
                 title="Support Ticket Update",
-                message="User replied to unassigned ticket",
+                message=f"User replied to unassigned ticket #{ticket_id}",
                 recipient_id=support_user.ctfd_user.id,
                 sender_id=author_id,
                 ticket_id=ticket_id,
@@ -218,7 +218,7 @@ class NotificationService:
         notification = Notification.create_notification(
             notification_type=NotificationType.TICKET_ASSIGNED,
             title="Ticket Assigned",
-            message="A support ticket has been assigned to you",
+            message=f"Ticket #{ticket_id} has been assigned to you",
             recipient_id=assigned_to_id,
             sender_id=assigned_by_id,
             ticket_id=ticket_id,
@@ -314,3 +314,32 @@ class NotificationService:
             event_id=event_id,
             kicked_by_id=kicked_by_id,
         )
+
+
+def generate_notification_link(notification: Notification) -> str | None:
+    """
+    Generate navigation link based on notification type and recipient role
+
+    Args:
+        notification: Notification instance with recipient relationship loaded
+
+    """
+    if not notification.recipient:
+        return None
+
+    is_admin = notification.recipient.type == "admin"
+
+    if notification.type in [NotificationType.TICKET_MESSAGE,
+                             NotificationType.TICKET_STATUS_CHANGE,
+                             NotificationType.TICKET_ASSIGNED]:
+        if notification.ticket_id:
+            if is_admin:
+                return f"/ctf/admin/tickets?id={notification.ticket_id}"
+            else:
+                return f"/ctf/support/{notification.ticket_id}"
+
+    if notification.type == NotificationType.TEAM_MEMBER_KICKED:
+        if notification.event_id:
+            return f"/ctf/events/{notification.event_id}"
+
+    return None

--- a/backend/ng/notifications/services/notification_service.py
+++ b/backend/ng/notifications/services/notification_service.py
@@ -334,12 +334,12 @@ def generate_notification_link(notification: Notification) -> str | None:
                              NotificationType.TICKET_ASSIGNED]:
         if notification.ticket_id:
             if is_admin:
-                return f"/ctf/admin/tickets?id={notification.ticket_id}"
+                return f"/admin/tickets?id={notification.ticket_id}"
             else:
-                return f"/ctf/support/{notification.ticket_id}"
+                return f"/support/{notification.ticket_id}"
 
     if notification.type == NotificationType.TEAM_MEMBER_KICKED:
         if notification.event_id:
-            return f"/ctf/events/{notification.event_id}"
+            return f"/events/{notification.event_id}"
 
     return None

--- a/backend/ng/notifications/tests/test_notification_links.py
+++ b/backend/ng/notifications/tests/test_notification_links.py
@@ -34,7 +34,7 @@ class TestNotificationLinkGeneration:
 
         link = generate_notification_link(notification)
 
-        assert link == f"/ctf/admin/tickets?id={ticket.id}"
+        assert link == f"/admin/tickets?id={ticket.id}"
 
     def test_user_receives_user_ticket_link(
         self,
@@ -57,7 +57,7 @@ class TestNotificationLinkGeneration:
 
         link = generate_notification_link(notification)
 
-        assert link == f"/ctf/support/{ticket.id}"
+        assert link == f"/support/{ticket.id}"
 
     def test_ticket_message_includes_ticket_number(
         self,
@@ -101,7 +101,7 @@ class TestNotificationLinkGeneration:
         serialized = notification.serialize()
 
         assert "link" in serialized
-        assert serialized["link"] == f"/ctf/admin/tickets?id={ticket.id}"
+        assert serialized["link"] == f"/admin/tickets?id={ticket.id}"
 
     def test_notification_without_recipient_returns_none(
         self,
@@ -144,7 +144,7 @@ class TestNotificationLinkGeneration:
 
         link = generate_notification_link(notification)
 
-        assert link == f"/ctf/events/{event.id}"
+        assert link == f"/events/{event.id}"
 
     def test_ticket_assigned_notification_for_admin(
         self,
@@ -166,7 +166,7 @@ class TestNotificationLinkGeneration:
 
         link = generate_notification_link(notification)
 
-        assert link == f"/ctf/admin/tickets?id={ticket.id}"
+        assert link == f"/admin/tickets?id={ticket.id}"
         assert f"#{ticket.id}" in notification.message
 
     def test_ticket_status_change_notification(
@@ -191,4 +191,4 @@ class TestNotificationLinkGeneration:
         serialized = notification.serialize()
 
         assert f"#{ticket.id}" in notification.message
-        assert serialized["link"] == f"/ctf/support/{ticket.id}"
+        assert serialized["link"] == f"/support/{ticket.id}"

--- a/backend/ng/notifications/tests/test_notification_links.py
+++ b/backend/ng/notifications/tests/test_notification_links.py
@@ -1,0 +1,194 @@
+"""
+Tests for notification link generation based on recipient role
+"""
+
+import pytest
+
+from ..models.Notification import (
+    Notification,
+    NotificationType,
+)
+from ..services.notification_service import(
+    generate_notification_link,
+)
+
+
+class TestNotificationLinkGeneration:
+    def test_admin_receives_admin_ticket_link(
+        self,
+        notification_factory,
+        admin,
+        ticket_factory
+    ):
+        """
+        Test that admin users receive admin panel ticket links
+        """
+        ticket = ticket_factory()
+        notification = notification_factory(
+            type=NotificationType.TICKET_MESSAGE,
+            recipient_id=admin.id,
+            ticket_id=ticket.id,
+            title="Ticket Update",
+            message=f"User replied to ticket #{ticket.id}"
+        )
+
+        link = generate_notification_link(notification)
+
+        assert link == f"/ctf/admin/tickets?id={ticket.id}"
+
+    def test_user_receives_user_ticket_link(
+        self,
+        notification_factory,
+        user_factory,
+        ticket_factory
+    ):
+        """
+        Test that regular users receive user side ticket links
+        """
+        user = user_factory()
+        ticket = ticket_factory(author_id=user.id)
+        notification = notification_factory(
+            type=NotificationType.TICKET_MESSAGE,
+            recipient_id=user.ctfd_user.id,
+            ticket_id=ticket.id,
+            title="Ticket Update",
+            message=f"Admin replied to ticket #{ticket.id}"
+        )
+
+        link = generate_notification_link(notification)
+
+        assert link == f"/ctf/support/{ticket.id}"
+
+    def test_ticket_message_includes_ticket_number(
+        self,
+        notification_factory,
+        user_factory,
+        ticket_factory
+    ):
+        """
+        Test that ticket notifications include ticket number in message
+        """
+        user = user_factory()
+        ticket = ticket_factory(author_id=user.id)
+        notification = notification_factory(
+            type=NotificationType.TICKET_MESSAGE,
+            recipient_id=user.ctfd_user.id,
+            ticket_id=ticket.id,
+            title="Support Ticket Update",
+            message=f"Admin replied to ticket #{ticket.id}"
+        )
+
+        assert f"#{ticket.id}" in notification.message
+
+    def test_serialized_notification_includes_link(
+        self,
+        notification_factory,
+        admin,
+        ticket_factory
+    ):
+        """
+        Test that serialized notification includes the link field
+        """
+        ticket = ticket_factory()
+        notification = notification_factory(
+            type=NotificationType.TICKET_MESSAGE,
+            recipient_id=admin.id,
+            ticket_id=ticket.id,
+            title="Ticket Update",
+            message=f"User replied to ticket #{ticket.id}"
+        )
+
+        serialized = notification.serialize()
+
+        assert "link" in serialized
+        assert serialized["link"] == f"/ctf/admin/tickets?id={ticket.id}"
+
+    def test_notification_without_recipient_returns_none(
+        self,
+        ticket_factory
+    ):
+        """
+        Test that notification without recipient returns None for link
+        """
+        ticket = ticket_factory()
+        notification = Notification(
+            type=NotificationType.TICKET_MESSAGE,
+            recipient_id=99999,
+            ticket_id=ticket.id,
+            title="Test",
+            message="Test message"
+        )
+
+        link = generate_notification_link(notification)
+
+        assert link is None
+
+    def test_team_kicked_notification_links_to_event(
+        self,
+        notification_factory,
+        user_factory,
+        event_factory
+    ):
+        """
+        Test that team kicked notifications link to event page
+        """
+        user = user_factory()
+        event = event_factory()
+        notification = notification_factory(
+            type=NotificationType.TEAM_MEMBER_KICKED,
+            recipient_id=user.ctfd_user.id,
+            event_id=event.id,
+            title="Removed from Team",
+            message="You have been removed from a team"
+        )
+
+        link = generate_notification_link(notification)
+
+        assert link == f"/ctf/events/{event.id}"
+
+    def test_ticket_assigned_notification_for_admin(
+        self,
+        notification_factory,
+        admin,
+        ticket_factory
+    ):
+        """
+        Test ticket assigned notification links to admin panel
+        """
+        ticket = ticket_factory()
+        notification = notification_factory(
+            type=NotificationType.TICKET_ASSIGNED,
+            recipient_id=admin.id,
+            ticket_id=ticket.id,
+            title="Ticket Assigned",
+            message=f"Ticket #{ticket.id} has been assigned to you"
+        )
+
+        link = generate_notification_link(notification)
+
+        assert link == f"/ctf/admin/tickets?id={ticket.id}"
+        assert f"#{ticket.id}" in notification.message
+
+    def test_ticket_status_change_notification(
+        self,
+        notification_factory,
+        user_factory,
+        ticket_factory
+    ):
+        """
+        Test ticket status change notification includes number and link
+        """
+        user = user_factory()
+        ticket = ticket_factory(author_id=user.id)
+        notification = notification_factory(
+            type=NotificationType.TICKET_STATUS_CHANGE,
+            recipient_id=user.ctfd_user.id,
+            ticket_id=ticket.id,
+            title="Ticket Status Changed",
+            message=f"Ticket #{ticket.id} was closed"
+        )
+
+        serialized = notification.serialize()
+
+        assert f"#{ticket.id}" in notification.message
+        assert serialized["link"] == f"/ctf/support/{ticket.id}"


### PR DESCRIPTION
  - Admins now link to /ctf/admin/tickets?id={id}
  - Regular users link to /ctf/support/{id}
  - Include ticket number in notification messages

Closes issue: **https://github.com/CyberSkyline/ctf-ng/issues/469**