### PR TITLE
User banning frontend and fixes

### DIFF
--- a/backend/ng/admin/routes/admin.py
+++ b/backend/ng/admin/routes/admin.py
@@ -135,6 +135,9 @@ class AdminImpersonate(Resource):
         if get_user_roles(user_id) != []:
             return error_response("You cannot impersonate privileged users", "impersonation", 403)
 
+        if user.ctfd_user.banned:
+            return error_response("You cannot impersonate a banned user.", "impersonation", 403)
+
         if session.get("impersonated"):
             # Should never be able to get here but just in case
             return error_response("You are already impersonating another user.", "impersonation", 403)

--- a/backend/ng/core/routes/__init__.py
+++ b/backend/ng/core/routes/__init__.py
@@ -133,7 +133,7 @@ def remove_registered_helpers(app):
 
     _remove_appwide_handler(
         app.before_request_funcs,
-        lambda f: f.__name__ in {"needs_setup", "needs_setup_safe"}
+        lambda f: f.__name__ in {"needs_setup", "needs_setup_safe", "banned"}
     )
 
 def remove_registered_errorhandlers(app):

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -1,6 +1,7 @@
 import { ROUTEPREFIX } from '@/constants';
 import { apiMutation } from '@/fetchers';
 import type {
+  AdminUser,
   Event,
   Team,
   User,
@@ -113,7 +114,7 @@ export function useUserTeams(userId: number | null) {
  * This is an admin-only endpoint.
  */
 export function useAllUsers() {
-  return useSWR<User[], Error>(
+  return useSWR<AdminUser[], Error>(
     '/admin/users',
   );
 }
@@ -124,7 +125,7 @@ export function useAllUsers() {
  * @param userId The ID of the user to fetch, or null if this should not be fetched.
  */
 export function useUser(userId: number | null) {
-  return useSWR<User, Error>(
+  return useSWR<AdminUser, Error>(
     userId ? `/admin/users/${userId}` : null,
   );
 }
@@ -176,5 +177,23 @@ export function stopImpersonation() {
   }).then((data: unknown) => {
     // On success, redirect to the admin user page
     window.location.href = `${ROUTEPREFIX}/admin/users?id=${data}`;
+  });
+}
+
+export function banUser(userId: number) {
+  return apiMutation(`/admin/users/${userId}/ban`, {}, {
+    method : 'POST',
+  }).then(() => {
+    mutate(`/admin/users/${userId}`);
+    mutate('/admin/users');
+  });
+}
+
+export function unbanUser(userId: number) {
+  return apiMutation(`/admin/users/${userId}/unban`, {}, {
+    method : 'POST',
+  }).then(() => {
+    mutate(`/admin/users/${userId}`);
+    mutate('/admin/users');
   });
 }

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -197,21 +197,3 @@ export function unbanUser(userId: number) {
     mutate('/admin/users');
   });
 }
-
-export function banUser(userId: number) {
-  return apiMutation(`/admin/users/${userId}/ban`, {}, {
-    method : 'POST',
-  }).then(() => {
-    mutate(`/admin/users/${userId}`);
-    mutate('/admin/users');
-  });
-}
-
-export function unbanUser(userId: number) {
-  return apiMutation(`/admin/users/${userId}/unban`, {}, {
-    method : 'POST',
-  }).then(() => {
-    mutate(`/admin/users/${userId}`);
-    mutate('/admin/users');
-  });
-}

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -1,5 +1,6 @@
 import { apiMutation } from '@/fetchers';
 import type {
+  AdminUser,
   Event,
   Team,
   User,
@@ -112,7 +113,7 @@ export function useUserTeams(userId: number | null) {
  * This is an admin-only endpoint.
  */
 export function useAllUsers() {
-  return useSWR<User[], Error>(
+  return useSWR<AdminUser[], Error>(
     '/admin/users',
   );
 }
@@ -123,7 +124,7 @@ export function useAllUsers() {
  * @param userId The ID of the user to fetch, or null if this should not be fetched.
  */
 export function useUser(userId: number | null) {
-  return useSWR<User, Error>(
+  return useSWR<AdminUser, Error>(
     userId ? `/admin/users/${userId}` : null,
   );
 }
@@ -175,5 +176,23 @@ export function stopImpersonation() {
   }).then((data: unknown) => {
     // On success, redirect to the admin user page
     window.location.href = `/admin/users?id=${data}`;
+  });
+}
+
+export function banUser(userId: number) {
+  return apiMutation(`/admin/users/${userId}/ban`, {}, {
+    method : 'POST',
+  }).then(() => {
+    mutate(`/admin/users/${userId}`);
+    mutate('/admin/users');
+  });
+}
+
+export function unbanUser(userId: number) {
+  return apiMutation(`/admin/users/${userId}/unban`, {}, {
+    method : 'POST',
+  }).then(() => {
+    mutate(`/admin/users/${userId}`);
+    mutate('/admin/users');
   });
 }

--- a/frontend/src/routes/admin/users/BanUserModal.tsx
+++ b/frontend/src/routes/admin/users/BanUserModal.tsx
@@ -1,0 +1,37 @@
+import { COLOR_NEGATIVE } from '@/constants';
+import { banUser, unbanUser } from '@/hooks/users';
+import type { AdminUser } from '@/types';
+import { Button } from '@radix-ui/themes';
+import Modal from 'components/Modal';
+import { TbHammer, TbHammerOff } from 'react-icons/tb';
+
+export default function BanUserModal({ user }: {user: AdminUser}) {
+  const unban = user.banned;
+  const Icon = unban ? TbHammerOff : TbHammer;
+
+  const handleSubmit = async () => {
+    if (unban) {
+      return unbanUser(user.id);
+    }
+    return banUser(user.id);
+  };
+
+  return (
+    <Modal
+      title={unban ? 'Unban User?' : 'Ban User?'}
+      trigger={(
+        <Button color={COLOR_NEGATIVE} variant="soft">
+          <Icon />
+          {unban ? 'Unban' : 'Ban'}
+        </Button>
+    )}
+      description={
+        `${user.name} will ${unban ? '' : 'no longer '}be able to access the platform${unban ? ' again' : ''}.
+        ${unban ? '' : 'They will not be removed from any teams unless done manually by an admin.'}`
+      }
+      onSubmit={handleSubmit}
+      submitVerb={unban ? 'Unban' : 'Ban'}
+      submitColor={COLOR_NEGATIVE}
+    />
+  );
+}

--- a/frontend/src/routes/admin/users/ImpersonateUserButton.tsx
+++ b/frontend/src/routes/admin/users/ImpersonateUserButton.tsx
@@ -1,9 +1,9 @@
 import { COLOR_HINT, ImpersonateIcon } from '@/constants';
 import { impersonateUser, useCurrentUser } from '@/hooks/users';
-import type { User } from '@/types';
+import type { AdminUser } from '@/types';
 import { Button } from '@radix-ui/themes';
 
-export default function ImpersonateUserButton({ user }: {user: User}) {
+export default function ImpersonateUserButton({ user }: {user: AdminUser}) {
   const { data : currentUser } = useCurrentUser();
   const handleImpersonate = () => impersonateUser(user.id);
 
@@ -12,7 +12,7 @@ export default function ImpersonateUserButton({ user }: {user: User}) {
       variant="soft"
       color={COLOR_HINT}
       onClick={handleImpersonate}
-      disabled={currentUser?.id === user.id || user.roles.length > 0} // Disable for disallowed impersonation targets
+      disabled={currentUser?.id === user.id || user.roles.length > 0 || user.banned} // Disable for disallowed impersonation targets
     >
       <ImpersonateIcon />
       Impersonate

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -6,18 +6,19 @@ import {
   useUserWorkspace,
   useWorkspaceStatus,
 } from '@/hooks/users';
-import type { Event, Team, User } from '@/types';
+import type { AdminUser, Event, Team } from '@/types';
 import { utf8ToBase64 } from '@/util';
 import { Table } from '@radix-ui/themes';
 import AdminDataList from 'components/AdminDataList';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
-import { ErrorCallout } from 'components/Callouts';
+import { ErrorCallout, WarningCallout } from 'components/Callouts';
 import Entity from 'components/Entity';
 import RoleBadge from 'components/RoleBadge';
 import { keyBy } from 'lodash';
 import { useId } from 'react';
 import AdminRegisterUserModal from './AdminRegisterUserModal';
+import BanUserModal from './BanUserModal';
 import ImpersonateUserButton from './ImpersonateUserButton';
 import RecycleWorkspaceModal from './RecycleWorkspaceModal';
 import RestartWorkspaceModal from './RestartWorkspaceModal';
@@ -58,7 +59,7 @@ function RegistrationRow({ userId, team, event }: { userId: number, team: Team, 
   );
 }
 
-export default function UserSidebar({ entity }: { entity: User }) {
+export default function UserSidebar({ entity }: { entity: AdminUser }) {
   const { data : teamsData, error : teamsError } = useUserTeams(entity.id);
   const { data : eventsData, error : eventsError } = useUserEvents(entity.id);
   const { data : workspaceData, error : workspaceError } = useUserWorkspace(entity.id);
@@ -71,7 +72,10 @@ export default function UserSidebar({ entity }: { entity: User }) {
     <AdminSidebar labelId={headerId}>
       <AdminSidebarHeader title={entity.name} icon={<UserIcon />} id={headerId}>
         <ImpersonateUserButton user={entity} />
+        <BanUserModal user={entity} />
       </AdminSidebarHeader>
+
+      {entity.banned && (<WarningCallout>This user is banned.</WarningCallout>)}
 
       <AdminDataList data={{ ...entity }} />
 

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -1,12 +1,12 @@
 import { useAllUsers } from '@/hooks/users';
-import type { User } from '@/types';
+import type { AdminUser } from '@/types';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
 import RoleBadge from 'components/RoleBadge';
 import UserSidebar from './UserSidebar';
 
-const colDefs: ColDef<User>[] = [
+const colDefs: ColDef<AdminUser>[] = [
   {
     field : 'id',
     width : 100,
@@ -43,6 +43,19 @@ const colDefs: ColDef<User>[] = [
     headerName : 'Registered At',
     width : 220,
     valueFormatter : (params) => params.value && params.value.toLocaleString(),
+    filter : true,
+    floatingFilter : true,
+  },
+  {
+    field : 'affiliation.name',
+    headerName : 'Affiliation',
+    filter : true,
+    floatingFilter : true,
+    width : 200,
+  },
+  {
+    field : 'banned',
+    width : 100,
     filter : true,
     floatingFilter : true,
   },

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -48,7 +48,7 @@ const colDefs: ColDef<AdminUser>[] = [
   },
   {
     field : 'affiliation.name',
-    headerName : 'Affiliation',
+    headerName : 'Sponsor',
     filter : true,
     floatingFilter : true,
     width : 200,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -38,6 +38,10 @@ export interface User {
   affiliation: Sponsor | null;
 }
 
+export interface AdminUser extends User {
+  banned: boolean;
+}
+
 export interface Team {
   id: number;
   name: string;


### PR DESCRIPTION
- Adds ban/unban modal to users on the frontend
- Adds missing table columns (`banned` and `affiliation`)
- Backend fixes
    - Deregister CTFd's `before_request_func` for ban checking (previously resulted in a 500 for banned users) to instead fall through to our ban logic/message
    - Disallow impersonating banned users (banned user can't do anything and can't exit impersonation, so you end up getting stuck and having to clear cookies to escape)

Closes #358
