### PR TITLE
User sidebar/grid cleanup

### DIFF
--- a/frontend/src/components/RoleBadge.tsx
+++ b/frontend/src/components/RoleBadge.tsx
@@ -1,7 +1,8 @@
 import { ROLES } from '@/constants';
 import { Badge } from '@radix-ui/themes';
+import type { Responsive } from '@radix-ui/themes/props';
 
-export default function RoleBadge({ value }: { value: string }) {
+export default function RoleBadge({ value, size = '1' }: { value: string, size?: Responsive<'1' | '2' | '3'> }) {
   const color = ROLES[value]?.color || 'gray';
   const Icon = ROLES[value]?.icon;
 
@@ -10,7 +11,7 @@ export default function RoleBadge({ value }: { value: string }) {
   }
 
   return (
-    <Badge color={color} variant="soft">
+    <Badge color={color} variant="soft" size={size}>
       {Icon && <Icon />}
       {' '}
       {value.charAt(0).toUpperCase() + value.slice(1)}

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -8,13 +8,20 @@ import {
 } from '@/hooks/users';
 import type { AdminUser, Event, Team } from '@/types';
 import { utf8ToBase64 } from '@/util';
-import { Table } from '@radix-ui/themes';
-import AdminDataList from 'components/AdminDataList';
+import {
+  Box,
+  Flex,
+  Grid,
+  Heading,
+  Table,
+  Text,
+} from '@radix-ui/themes';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout, WarningCallout } from 'components/Callouts';
 import Entity from 'components/Entity';
 import RoleBadge from 'components/RoleBadge';
+import Statistic from 'components/Statistic';
 import { keyBy } from 'lodash';
 import { useId } from 'react';
 import AdminRegisterUserModal from './AdminRegisterUserModal';
@@ -80,7 +87,44 @@ export default function UserSidebar({ entity }: { entity: AdminUser }) {
 
       {entity.banned && (<WarningCallout>This user is banned.</WarningCallout>)}
 
-      <AdminDataList data={{ ...entity }} />
+      <Grid columns="2" gap="4" align="center" justify="between">
+        <Statistic
+          label="Name"
+          value={entity.name}
+          size="5"
+        />
+        <Statistic
+          label="ID"
+          value={entity.id}
+          size="5"
+        />
+
+        <Statistic
+          label="Email"
+          value={entity.email}
+          size="5"
+        />
+        <Statistic
+          label="Sponsor"
+          value={entity.affiliation?.name || 'N/A'}
+          size="5"
+        />
+        <Statistic
+          label="Registered At"
+          value={entity.registered_at.toLocaleString()}
+          size="5"
+        />
+        <Box>
+          <Text size="2" color="gray">Roles</Text>
+          <Flex direction="row" wrap="wrap">
+            {entity.roles.length === 0 && <Heading asChild size="5" weight="bold"><span>None</span></Heading>}
+            {entity.roles.map((role) => (
+              <RoleBadge key={role} value={role} size="2" />
+            ))}
+          </Flex>
+        </Box>
+
+      </Grid>
 
       <AdminSidebarHeader title="Registrations">
         <AdminRegisterUserModal userId={entity.id} />

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -4,6 +4,7 @@ import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
 import RoleBadge from 'components/RoleBadge';
+import { Fragment } from 'react/jsx-runtime';
 import UserSidebar from './UserSidebar';
 
 const colDefs: ColDef<AdminUser>[] = [
@@ -28,11 +29,12 @@ const colDefs: ColDef<AdminUser>[] = [
   },
   {
     field : 'roles',
+    valueFormatter : (params) => params.value.join(', '),
     cellRenderer : ({ value }: {value: string[]}) => value.map((role) => (
-      <>
-        <RoleBadge key={role} value={role} />
+      <Fragment key={role}>
+        <RoleBadge value={role} />
         &nbsp;
-      </>
+      </Fragment>
     )),
     filter : true,
     floatingFilter : true,


### PR DESCRIPTION
Better display of data on user sidebar, including not showing sponsor as `[object Object]`
<img width="1162" height="284" alt="image" src="https://github.com/user-attachments/assets/42a4fb35-e814-4096-802b-b14f7291cb63" />

This also sets the groundwork for eventually making these inline fields.

Also resolves some grid warnings regarding keying and object data.