### PR TITLE
Countdown timer for team end

### DIFF
--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -1,0 +1,86 @@
+import {
+  Box,
+  Flex,
+  Heading,
+  Text,
+} from '@radix-ui/themes';
+import { useEffect, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+export default function Timer(
+  {
+    target,
+    size = '6',
+    onEnd,
+  } : {
+    target: Date | null,
+    size?: React.ComponentProps<typeof Heading>['size'],
+    onEnd?: () => void
+  },
+) {
+  const [ timerString, setTimerString ] = useState('');
+  const [ hidden, setHidden ] = useState(false);
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | undefined;
+
+    const updateTimer = () => {
+      if (!target) {
+        setTimerString('0:00:00');
+        return;
+      }
+
+      const now = new Date();
+      const diff = target.getTime() - now.getTime();
+
+      if (diff <= 0) {
+        setTimerString('0:00:00');
+        clearInterval(interval);
+        if (onEnd) onEnd();
+        return;
+      }
+
+      const hours = `${String(Math.floor(diff / (1000 * 60 * 60))).padStart(1, '0')}`;
+      const minutes = `:${String(Math.floor((diff / (1000 * 60)) % 60)).padStart(2, '0')}`;
+      const seconds = `:${String(Math.floor((diff / 1000) % 60)).padStart(2, '0')}`;
+
+      setTimerString(`${hours}${minutes}${seconds}`);
+    };
+
+    updateTimer();
+
+    // if there's no target date, do not set interval
+    if (!target) return () => {};
+
+    // if hidden, do not set interval
+    if (hidden) return () => {};
+
+    // set interval to update periodically
+    // we update more than once a second for better accuracy and to avoid skipped seconds
+    interval = setInterval(updateTimer, 250);
+    return () => clearInterval(interval);
+  }, [ target, hidden, onEnd ]);
+
+  return (
+    <button type="button" onClick={() => setHidden(!hidden)} aria-label="Toggle timer display" className="block group">
+      <Flex direction="row" gap="1" align="center">
+        { timerString.split('').map((part, index) => (
+          <Box
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+            className={
+              twMerge(
+                part !== ':' && 'bg-(--gray-a3) group-hover:bg-(--gray-a5) px-1.5 font-bold',
+                'py-0.5 rounded select-none',
+              )
+            }
+          >
+            <Text size={size} className="tabular-nums">
+              {hidden && part !== ':' ? '-' : part}
+            </Text>
+          </Box>
+        ))}
+      </Flex>
+    </button>
+  );
+}

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -40,11 +40,11 @@ export default function Timer(
         return;
       }
 
-      const hours = `${String(Math.floor(diff / (1000 * 60 * 60))).padStart(1, '0')}`;
-      const minutes = `:${String(Math.floor((diff / (1000 * 60)) % 60)).padStart(2, '0')}`;
-      const seconds = `:${String(Math.floor((diff / 1000) % 60)).padStart(2, '0')}`;
+      const hours = String(Math.floor(diff / (1000 * 60 * 60))).padStart(1, '0');
+      const minutes = String(Math.floor((diff / (1000 * 60)) % 60)).padStart(2, '0');
+      const seconds = String(Math.floor((diff / 1000) % 60)).padStart(2, '0');
 
-      setTimerString(`${hours}${minutes}${seconds}`);
+      setTimerString(`${hours}:${minutes}:${seconds}`);
     };
 
     updateTimer();

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -80,7 +80,7 @@ export default function Overview() {
         }}
         activationMode="manual"
       >
-        <Container size="2" mb="4">
+        <Container size="2" mb="3">
           <Tabs.List className="*:!basis-0 *:!grow" loop={false}>
             {challengesTabAvailable && (
               <Tabs.Trigger value="challenges">

--- a/frontend/src/routes/events/RegistrationCard.tsx
+++ b/frontend/src/routes/events/RegistrationCard.tsx
@@ -2,16 +2,19 @@ import { useEventStatus, useMyEligibility } from '@/hooks/events';
 import { useMySponsor, useRegistration } from '@/hooks/users';
 import type { Event } from '@/types';
 import {
+  Box,
   Card,
   Flex,
   Link as RadixLink,
   Text,
 } from '@radix-ui/themes';
-import { Link } from 'react-router';
 import { ErrorCallout, WarningCallout } from 'components/Callouts';
 import RequireEventPermission from 'components/RequireEventPermission';
 import Statistic from 'components/Statistic';
+import Timer from 'components/Timer';
 import { isNil } from 'lodash';
+import { Link } from 'react-router';
+import { mutate } from 'swr';
 import LeaveTeamModal from './LeaveTeamModal';
 import RegistrationModal from './RegistrationModal';
 import RenameTeamModal from './RenameTeamModal';
@@ -50,6 +53,20 @@ export default function RegistrationCard({ event }: {event: Event}) {
             value={`${team!.name}`}
             size="6"
           />
+          {team?.end_time && (
+            <Box>
+              <Text color="gray" size="2">Time remaining:</Text>
+              <Timer
+                target={team.end_time}
+                onEnd={() => {
+                  // Refresh SWR state on timer end
+                  mutate(`/permissions/${event.id}/me`);
+                  mutate(`/events/${event.id}/me/team`);
+                  mutate(`/users/me/teams`);
+                }}
+              />
+            </Box>
+          )}
           <Flex direction="row" gap="4" align="center" className="empty:!hidden">
             <RequireEventPermission eventId={event.id} permission="CAN_LEAVE_TEAM" permissionDeniedPlaceholder={null}>
               <LeaveTeamModal event={event} />

--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -1,5 +1,5 @@
 import { useChallenge } from '@/hooks/challenge';
-import { useEvent } from '@/hooks/events';
+import { useEvent, useMyTeam } from '@/hooks/events';
 import { useEventPermission } from '@/hooks/permissions';
 import {
   Box,
@@ -14,9 +14,11 @@ import {
 import { ErrorCallout } from 'components/Callouts';
 import ChallengeIcon from 'components/ChallengeIcon';
 import RadixMarkdown from 'components/RadixMarkdown';
+import Timer from 'components/Timer';
 import { groupBy } from 'lodash';
 import { TbArrowLeft } from 'react-icons/tb';
 import { Link, useParams } from 'react-router';
+import { mutate } from 'swr';
 import ChallengeHeader from './ChallengeHeader';
 import ChallengeQuestion from './ChallengeQuestion';
 import ConnectModal from './ConnectModal';
@@ -27,6 +29,7 @@ export default function ChallengeSidebar() {
   const { idEvent, idChallenge } = useParams();
 
   const { data : event, isLoading : isEventLoading } = useEvent(Number(idEvent));
+  const { data : team } = useMyTeam(Number(idEvent));
   const { data, error } = useChallenge(
     Number(idEvent),
     Number(idChallenge),
@@ -46,7 +49,7 @@ export default function ChallengeSidebar() {
       <Card className="shrink-0">
         <Inset side="all" className="shrink-0">
           <ChallengeHeader>
-            <Flex gap="3" direction="row" align="start" justify="between" mb="3">
+            <Flex gap="3" direction="row" align="center" justify="between" mb="3">
 
               <Button variant="ghost" className="!m-0 !shrink" asChild>
                 <Link to={`/events/${idEvent}?tab=challenges`}>
@@ -59,10 +62,18 @@ export default function ChallengeSidebar() {
                 </Link>
               </Button>
 
-              <Box flexShrink="0">
-                {hints && hints.length > 0 && <HintsModal eventId={Number(idEvent)} challengeId={Number(idChallenge)} />}
-                {event && attempts && <HistoryModal isTeam={event.max_team_size > 1} attempts={attempts} />}
-              </Box>
+              {team && team.end_time && (
+                <Timer
+                  target={team.end_time}
+                  size="3"
+                  onEnd={() => {
+                    // Refresh SWR state on timer end
+                    mutate(`/permissions/${idEvent}/me`);
+                    mutate(`/events/${idEvent}/me/team`);
+                    mutate(`/users/me/teams`);
+                  }}
+                />
+              ) }
             </Flex>
 
             {error ? (
@@ -88,8 +99,12 @@ export default function ChallengeSidebar() {
             )}
 
             {challenge && event && granted && (
-              <Flex direction="row" gap="2" mt="3" align="center">
+              <Flex direction="row" gap="2" mt="3" align="center" justify="between">
                 <ConnectModal eventId={event.id} challengeId={challenge.id} isTeam={event.max_team_size > 1} />
+                <Box flexShrink="0">
+                  {hints && hints.length > 0 && <HintsModal eventId={Number(idEvent)} challengeId={Number(idChallenge)} />}
+                  {event && attempts && <HistoryModal isTeam={event.max_team_size > 1} attempts={attempts} />}
+                </Box>
               </Flex>
             )}
           </ChallengeHeader>

--- a/frontend/src/routes/events/challenge/ConnectModal.tsx
+++ b/frontend/src/routes/events/challenge/ConnectModal.tsx
@@ -1,6 +1,6 @@
 import { COLOR_NEGATIVE, COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
 import { connectWorkspace, recycleChallengeContainers, useCurrentChallengeId } from '@/hooks/container';
-import { Button } from '@radix-ui/themes';
+import { Button, Flex } from '@radix-ui/themes';
 import { ErrorCallout } from 'components/Callouts';
 import Modal from 'components/Modal';
 import { useState } from 'react';
@@ -32,7 +32,7 @@ export default function ConnectModal({ eventId, challengeId, isTeam }: {
 
   if (currentChallenge === challengeId) {
     return (
-      <>
+      <Flex gap="1" align="center">
         <Button variant="soft" disabled m="0">
           <TbCheck />
           Connected
@@ -50,7 +50,7 @@ export default function ConnectModal({ eventId, challengeId, isTeam }: {
           submitColor={COLOR_NEGATIVE}
           onSubmit={handleReset}
         />
-      </>
+      </Flex>
     );
   }
 


### PR DESCRIPTION
Show countdown timer for team end time on event/challenge pages, and refresh state when it reaches 0. Can click to toggle hiding the display (shows as `--:--:--` when hidden so it can still be clicked to unhide)

Resolves #382 and #471

<img width="1515" height="650" alt="image" src="https://github.com/user-attachments/assets/c66da4b8-e11f-45fd-a962-c32e69a7bb00" />
<img width="546" height="255" alt="image" src="https://github.com/user-attachments/assets/67be9659-feec-4a90-b9d0-1120e721b1eb" />
