### PR TITLE
Standardize game card aspect ratio

### DIFF
--- a/frontend/src/components/EventGraphic.tsx
+++ b/frontend/src/components/EventGraphic.tsx
@@ -6,7 +6,7 @@ import { ErrorCallout } from './Callouts';
 
 export default function EventGraphic({ event, className }: {event: Event, className ?: string}) {
   // aspect ratio for event card graphics
-  const RATIO = 1 / 1.446015424;
+  const RATIO = 2 / 3;
 
   const { data : fileUrl, error : fileUrlError, isLoading } = useFileUrl('event-cards', event.image ?? undefined);
 
@@ -22,7 +22,7 @@ export default function EventGraphic({ event, className }: {event: Event, classN
         <AspectRatio ratio={RATIO}>
           {fileUrl?.download_url && (
             <img
-              className="object-contain h-full w-full"
+              className="object-cover h-full w-full"
               src={fileUrl?.download_url}
               alt="" // Event graphic is always accompanied by event name which will already be read out
             />


### PR DESCRIPTION
Use a sensible 2:3 ratio for game cards instead of the exact ratio of the old card assets (which is no longer accurate given the new ones) Cards will be scaled/cropped to 2:3 instead of having transparent whitespace if ratios don't line up, which guarantees that variances in aspect ratio year-over-year won't cause layout inconsistencies or unexpected whitespace.