### PR TITLE
Fix pixelated game cards in chromium

### DIFF
--- a/frontend/src/components/EventGraphic.tsx
+++ b/frontend/src/components/EventGraphic.tsx
@@ -22,7 +22,7 @@ export default function EventGraphic({ event, className }: {event: Event, classN
         <AspectRatio ratio={RATIO}>
           {fileUrl?.download_url && (
             <img
-              className="object-cover h-full w-full"
+              className="object-cover h-full w-full overflow-visible"
               src={fileUrl?.download_url}
               alt="" // Event graphic is always accompanied by event name which will already be read out
             />


### PR DESCRIPTION
Resolves #508.

CSS fix to prevent bad scaling on game card graphics.

Before:
<img width="219" height="318" alt="image" src="https://github.com/user-attachments/assets/bbb2f596-652d-4bb6-9f82-783197fb828a" />


After:
<img width="219" height="318" alt="image" src="https://github.com/user-attachments/assets/aca413fa-df17-4a38-8bae-8121a1f67e61" />

Chromium doesn't like images inheriting overflow: clip from their parent