### PR TITLE
Always follow system theme for favicon

### DIFF
--- a/frontend/src/components/Favicon.tsx
+++ b/frontend/src/components/Favicon.tsx
@@ -3,7 +3,7 @@ import faviconLight from '@/assets/favicons/favicon-light.png';
 import { useTheme } from 'next-themes';
 
 export default function Favicon() {
-  const { resolvedTheme } = useTheme();
+  const { systemTheme } = useTheme();
 
-  return <link rel="icon" href={resolvedTheme === 'dark' ? faviconDark : faviconLight} />;
+  return <link rel="icon" href={systemTheme === 'dark' ? faviconDark : faviconLight} />;
 }


### PR DESCRIPTION
Reduces situations where light-on-light and dark-on-dark favicons are possible, i.e. setting the application theme to dark in a light browser.

This is consistent with the behavior of https://presidentscup.cisa.gov/ 's favicon.