### PR TITLE
Create database with utf8mb4 during populate

### DIFF
--- a/backend/ng/scripts/default_ctfd_setup.py
+++ b/backend/ng/scripts/default_ctfd_setup.py
@@ -24,7 +24,7 @@ if database_exists(database_url):
     drop_database(database_url)
 
 # Recreate the database
-create_database(database_url)
+create_database(database_url, encoding="utf8mb4")
 
 # Now create the app - it won't try to create tables in an existing database
 app = create_app()

--- a/backend/ng/scripts/populate_sample_data.py
+++ b/backend/ng/scripts/populate_sample_data.py
@@ -23,7 +23,7 @@ if database_exists(database_url):
     drop_database(database_url)
 
 # Recreate the database
-create_database(database_url)
+create_database(database_url, encoding="utf8mb4")
 
 # Now create the app - it won't try to create tables in an existing database
 app = create_app()


### PR DESCRIPTION
When setup scripts drop the database and recreate it, pass the `utf8mb4` charset to ensure the db and its tables are created with support for 4-byte UTF-8.

Even though we already specify it as part of the db container's command, the container sets up before those options are considered so the initial db is created as `utf8mb3`. Now, running the setup script will drop that db and create a new one with `utf8mb4`.