### PR TITLE
Disable flex shrink for dashboard game cards

### DIFF
--- a/frontend/src/routes/dashboard/EventCard.tsx
+++ b/frontend/src/routes/dashboard/EventCard.tsx
@@ -20,7 +20,7 @@ export default function EventCard({ event }: { event: Event }) {
     <Card asChild>
       <Link to={`/events/${event.id}`}>
         <Flex direction="row" gap="4">
-          <Inset side="left" className="empty:hidden">
+          <Inset side="left" className="empty:hidden shrink-0">
             <EventGraphic event={event} className="w-32 shadow !rounded-none" />
           </Inset>
           <Flex direction="column" gap="2" className="flex-grow" justify="between">


### PR DESCRIPTION
Prevent shrinking the cards to keep their expected aspect ratio. Previously, cards were cropped asymmetrically due to flex behavior:
<img width="430" height="248" alt="image" src="https://github.com/user-attachments/assets/d0495e0e-664d-4e0f-97c7-a49a0fb4aa8e" />
