### PR TITLE
Fix admin ticket sidebar stale state and UI bugs

### DIFF
--- a/frontend/src/routes/admin/tickets/MessagesSidebar.tsx
+++ b/frontend/src/routes/admin/tickets/MessagesSidebar.tsx
@@ -45,17 +45,24 @@ import {
   map,
   without,
 } from 'lodash';
-import { useId, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { TbMessage, TbX } from 'react-icons/tb';
 
 export default function MessagesSidebar({ entity : selectedRow }: { entity: AdminTicket }) {
   // Dropdowns
   const [ actionError, setActionError ] = useState<string | null>(null);
   const [ actionLoading, setActionLoading ] = useState<boolean>(false);
-  const [ assignedUser, setAssignedUser ] = useState<string>(String(selectedRow.assigned_to));
-  const [ selectedEvent, setSelectedEvent ] = useState<string | undefined>(String(selectedRow.event_id));
-  const [ selectedChallenge, setSelectedChallenge ] = useState<string | undefined>(String(selectedRow.challenge_id));
+  const [ assignedUser, setAssignedUser ] = useState<string>(selectedRow.assigned_to ? String(selectedRow.assigned_to) : '');
+  const [ selectedEvent, setSelectedEvent ] = useState<string | undefined>(selectedRow.event_id ? String(selectedRow.event_id) : '');
+  const [ selectedChallenge, setSelectedChallenge ] = useState<string | undefined>(selectedRow.challenge_id ? String(selectedRow.challenge_id) : '');
   const [ selectedTag, setSelectedTag ] = useState<string | undefined>('');
+
+  useEffect(() => {
+    setAssignedUser(selectedRow.assigned_to ? String(selectedRow.assigned_to) : '');
+    setSelectedEvent(selectedRow.event_id ? String(selectedRow.event_id) : '');
+    setSelectedChallenge(selectedRow.challenge_id ? String(selectedRow.challenge_id) : '');
+    setSelectedTag('');
+  }, [selectedRow.id]);
 
   // Rich Text Reply Messages
   const [ version, setVersion ] = useState<number>(0); // To reinit the RichTextEditor

--- a/frontend/src/routes/admin/tickets/MessagesSidebar.tsx
+++ b/frontend/src/routes/admin/tickets/MessagesSidebar.tsx
@@ -62,7 +62,7 @@ export default function MessagesSidebar({ entity : selectedRow }: { entity: Admi
     setSelectedEvent(selectedRow.event_id ? String(selectedRow.event_id) : '');
     setSelectedChallenge(selectedRow.challenge_id ? String(selectedRow.challenge_id) : '');
     setSelectedTag('');
-  }, [selectedRow.id]);
+  }, [ selectedRow.id, selectedRow.assigned_to, selectedRow.event_id, selectedRow.challenge_id ]);
 
   // Rich Text Reply Messages
   const [ version, setVersion ] = useState<number>(0); // To reinit the RichTextEditor

--- a/frontend/src/routes/admin/tickets/index.tsx
+++ b/frontend/src/routes/admin/tickets/index.tsx
@@ -137,10 +137,10 @@ export default function AdminTickets() {
         getRowId={(params) => params.data.id.toString()}
         sidebarComponent={MessagesSidebar}
         stopCellSelection={[
-          'author_id',
-          'event_id',
-          'team_id',
-          'challenge_id',
+          'author_name',
+          'event_name',
+          'team_name',
+          'challenge_name',
         ]}
       />
     </>


### PR DESCRIPTION
*(Note: Reason I took this issue is becuase I initially assumed this was a backend issue, but after investigating I found
  the bug was in the frontend, so I thought might as well take care of it)*

- Reset sidebar dropdown states when switching between tickets using useEffect to sync state with selectedRow.id changes
- Fix stopCellSelection using wrong field names (author_id -> author_name, etc.) which caused navigation flicker when clicking entity links in grid rows
- Handle null values properly for assigned_to, event_id, and challenge_id to fix Unassign button incorrectly being enabled on unassigned tickets

Closes issue: https://github.com/CyberSkyline/ctf-ng/issues/533


https://github.com/user-attachments/assets/02cd81a5-1211-498b-b788-66c7f377c8d8


