### PR TITLE
Fix email ticket links to use correct URL for recipient type

### DIFF
--- a/backend/ng/config.py
+++ b/backend/ng/config.py
@@ -83,3 +83,4 @@ CONTAINER_REGISTRY_PASSWORD = ""
 
 # Email notification URL paths - Frontend routes
 TICKET_URL_PATH = "/support"
+ADMIN_TICKET_URL_PATH = "/admin/tickets"

--- a/backend/ng/emails/services/email_templates.py
+++ b/backend/ng/emails/services/email_templates.py
@@ -104,12 +104,13 @@ class TicketEmailTemplates:
         return f"{server_domain}{route_prefix}"
 
     @staticmethod
-    def new_ticket(ticket_data: TicketData) -> tuple[str, str, str]:
+    def new_ticket(ticket_data: TicketData, is_admin_recipient: bool = True) -> tuple[str, str, str]:
         """
         Generate new ticket notification email
 
         Args:
             ticket_data: Serialized ticket data
+            is_admin_recipient: Whether recipient is admin (uses admin URL path)
 
         Returns:
             Tuple of (subject, html_body, text_body)
@@ -118,7 +119,10 @@ class TicketEmailTemplates:
         if not base_url:
             raise ValueError("SERVER_DOMAIN not configured")
 
-        ticket_url = f"{base_url}{config.TICKET_URL_PATH}/{ticket_data['id']}"
+        if is_admin_recipient:
+            ticket_url = f"{base_url}{config.ADMIN_TICKET_URL_PATH}?id={ticket_data['id']}"
+        else:
+            ticket_url = f"{base_url}{config.TICKET_URL_PATH}/{ticket_data['id']}"
 
         subject = f"New Support Ticket: {ticket_data['subject']}"
 
@@ -158,7 +162,10 @@ class TicketEmailTemplates:
         if not base_url:
             raise ValueError("SERVER_DOMAIN not configured")
 
-        ticket_url = f"{base_url}{config.TICKET_URL_PATH}/{ticket_data['id']}"
+        if is_admin_reply:
+            ticket_url = f"{base_url}{config.TICKET_URL_PATH}/{ticket_data['id']}"
+        else:
+            ticket_url = f"{base_url}{config.ADMIN_TICKET_URL_PATH}?id={ticket_data['id']}"
 
         reply_type = "Admin" if is_admin_reply else "User"
         subject = f"Support Ticket Reply: {ticket_data['subject']}"

--- a/backend/ng/emails/services/email_templates.py
+++ b/backend/ng/emails/services/email_templates.py
@@ -104,13 +104,12 @@ class TicketEmailTemplates:
         return f"{server_domain}{route_prefix}"
 
     @staticmethod
-    def new_ticket(ticket_data: TicketData, is_admin_recipient: bool = True) -> tuple[str, str, str]:
+    def new_ticket(ticket_data: TicketData) -> tuple[str, str, str]:
         """
         Generate new ticket notification email
 
         Args:
             ticket_data: Serialized ticket data
-            is_admin_recipient: Whether recipient is admin (uses admin URL path)
 
         Returns:
             Tuple of (subject, html_body, text_body)
@@ -119,10 +118,7 @@ class TicketEmailTemplates:
         if not base_url:
             raise ValueError("SERVER_DOMAIN not configured")
 
-        if is_admin_recipient:
-            ticket_url = f"{base_url}{config.ADMIN_TICKET_URL_PATH}?id={ticket_data['id']}"
-        else:
-            ticket_url = f"{base_url}{config.TICKET_URL_PATH}/{ticket_data['id']}"
+        ticket_url = f"{base_url}{config.ADMIN_TICKET_URL_PATH}?id={ticket_data['id']}"
 
         subject = f"New Support Ticket: {ticket_data['subject']}"
 


### PR DESCRIPTION
- Add ADMIN_TICKET_URL_PATH config for admin ticket routes
- New ticket emails (to admin inbox) now link to /admin/tickets?id=X
- Reply emails use recipient-appropriate URLs:
  - Admin reply → user gets /support/{id}
  - User reply → admin gets /admin/tickets?id={id}

closes issue: https://github.com/CyberSkyline/ctf-ng/issues/510