### PR TITLE
Display error for non-modal challenge provisioning

### DIFF
--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -16,6 +16,7 @@ import ChallengeIcon from 'components/ChallengeIcon';
 import RadixMarkdown from 'components/RadixMarkdown';
 import Timer from 'components/Timer';
 import { groupBy } from 'lodash';
+import { useState } from 'react';
 import { TbArrowLeft } from 'react-icons/tb';
 import { Link, useParams } from 'react-router';
 import { mutate } from 'swr';
@@ -34,6 +35,8 @@ export default function ChallengeSidebar() {
     Number(idEvent),
     Number(idChallenge),
   );
+
+  const [ provisioningError, setProvisioningError ] = useState<Error | undefined>();
 
   const {
     challenge, questions, hints, attempts,
@@ -99,13 +102,21 @@ export default function ChallengeSidebar() {
             )}
 
             {challenge && event && granted && (
-              <Flex direction="row" gap="2" mt="3" align="center" justify="between">
-                <ConnectModal eventId={event.id} challengeId={challenge.id} isTeam={event.max_team_size > 1} />
-                <Box flexShrink="0">
-                  {hints && hints.length > 0 && <HintsModal eventId={Number(idEvent)} challengeId={Number(idChallenge)} />}
-                  {event && attempts && <HistoryModal isTeam={event.max_team_size > 1} attempts={attempts} />}
-                </Box>
-              </Flex>
+              <>
+                {provisioningError && <ErrorCallout className="mt-3">{provisioningError.message}</ErrorCallout>}
+                <Flex direction="row" gap="2" mt="3" align="center" justify="between">
+                  <ConnectModal
+                    eventId={event.id}
+                    challengeId={challenge.id}
+                    isTeam={event.max_team_size > 1}
+                    onError={setProvisioningError}
+                  />
+                  <Box flexShrink="0">
+                    {hints && hints.length > 0 && <HintsModal eventId={Number(idEvent)} challengeId={Number(idChallenge)} />}
+                    {event && attempts && <HistoryModal isTeam={event.max_team_size > 1} attempts={attempts} />}
+                  </Box>
+                </Flex>
+              </>
             )}
           </ChallengeHeader>
         </Inset>

--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -112,8 +112,8 @@ export default function ChallengeSidebar() {
                     onError={setProvisioningError}
                   />
                   <Box flexShrink="0">
-                    {hints && hints.length > 0 && <HintsModal eventId={Number(idEvent)} challengeId={Number(idChallenge)} />}
-                    {event && attempts && <HistoryModal isTeam={event.max_team_size > 1} attempts={attempts} />}
+                    {hints && hints.length > 0 && <HintsModal eventId={event.id} challengeId={challenge.id} />}
+                    {attempts && <HistoryModal isTeam={event.max_team_size > 1} attempts={attempts} />}
                   </Box>
                 </Flex>
               </>

--- a/frontend/src/routes/events/challenge/ConnectModal.tsx
+++ b/frontend/src/routes/events/challenge/ConnectModal.tsx
@@ -6,10 +6,13 @@ import Modal from 'components/Modal';
 import { useState } from 'react';
 import { TbCheck, TbPlayerPlay, TbRotateClockwise } from 'react-icons/tb';
 
-export default function ConnectModal({ eventId, challengeId, isTeam }: {
+export default function ConnectModal({
+  eventId, challengeId, isTeam, onError,
+}: {
   eventId: number;
   challengeId: number;
   isTeam: boolean;
+  onError?: (error: Error | undefined) => void;
 }) {
   const {
     data : currentChallenge, isValidating, error,
@@ -18,16 +21,20 @@ export default function ConnectModal({ eventId, challengeId, isTeam }: {
 
   const handleConnect = async () => {
     setLoading(true);
+    onError?.(undefined);
     return connectWorkspace(eventId, challengeId).finally(() => {
       setLoading(false);
     });
   };
 
-  const handleReset = async () => recycleChallengeContainers(eventId, challengeId);
+  const handleReset = async () => {
+    onError?.(undefined);
+    return recycleChallengeContainers(eventId, challengeId);
+  };
 
   if (error) {
     // if we can't get the current challenge, show an error where the button would otherwise go
-    return <ErrorCallout>{error.message}</ErrorCallout>;
+    return <ErrorCallout>{error}</ErrorCallout>;
   }
 
   if (currentChallenge === challengeId) {
@@ -57,7 +64,16 @@ export default function ConnectModal({ eventId, challengeId, isTeam }: {
   if (currentChallenge === null) {
     // If the workspace isn't connected to anything, don't require confirmation
     return (
-      <Button onClick={handleConnect} loading={loading || isValidating} color={COLOR_POSITIVE} className="pulsate">
+      <Button
+        // For starting without modal, pass errors to the parent for display
+        onClick={
+            () => handleConnect()
+              .catch(onError)
+        }
+        loading={loading || isValidating}
+        color={COLOR_POSITIVE}
+        className="pulsate"
+      >
         <TbPlayerPlay />
         Start Challenge
       </Button>


### PR DESCRIPTION
Previously, errors during challenge start were only displayed on the challenge switch modal, not when starting from a fresh disconnected workspace:

<img width="528" height="249" alt="image" src="https://github.com/user-attachments/assets/18b5ef4f-ecff-4e66-95cc-f5891f970937" />
