### PR TITLE
Optimistically add attempt to challenge data on successful submit

### DIFF
--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -76,9 +76,20 @@ export function submitFlag(
     submission : flag,
   }, {
     method : 'POST',
-  }).then(() => {
+  }).then((att) => {
     // refresh the challenge data after submitting a flag
-    mutate(`/events/${eventId}/challenges/${challengeId}`);
+    mutate(`/events/${eventId}/challenges/${challengeId}`, (data: undefined | {
+        challenge: Challenge;
+        questions: Question[];
+        hints: Hint[];
+        attempts: Attempt[];
+      }) => {
+      if (!data) return data;
+      return {
+        ...data,
+        attempts : [ ...data.attempts, att as Attempt ],
+      };
+    }, false);
   });
 }
 

--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -78,18 +78,22 @@ export function submitFlag(
     method : 'POST',
   }).then((att) => {
     // refresh the challenge data after submitting a flag
-    mutate(`/events/${eventId}/challenges/${challengeId}`, (data: undefined | {
+    mutate(
+      `/events/${eventId}/challenges/${challengeId}`,
+      (data: undefined | {
         challenge: Challenge;
         questions: Question[];
         hints: Hint[];
         attempts: Attempt[];
       }) => {
-      if (!data) return data;
-      return {
-        ...data,
-        attempts : [ ...data.attempts, att as Attempt ],
-      };
-    }, false);
+        if (!data) return data;
+        return {
+          ...data,
+          attempts : [ ...data.attempts, att as Attempt ],
+        };
+      },
+      false,
+    );
   });
 }
 


### PR DESCRIPTION
Removes lag between submission going through and correct/incorrect showing. As soon as the submitted attempt comes back, we add it to the attempts list on the frontend via SWR instead of waiting for another fetch cycle to get that data.