### PR TITLE
Expose admin counts endpoint in frontend

### DIFF
--- a/frontend/src/hooks/stats.ts
+++ b/frontend/src/hooks/stats.ts
@@ -1,0 +1,6 @@
+import useSWR from 'swr';
+
+// eslint-disable-next-line import/prefer-default-export
+export function useCounts() {
+  return useSWR<{ users: number; events: number; teams: number; }>('/admin/stats/counts');
+}

--- a/frontend/src/routes/admin/dashboard/AdminCountsCard.tsx
+++ b/frontend/src/routes/admin/dashboard/AdminCountsCard.tsx
@@ -1,0 +1,38 @@
+import { useCounts } from '@/hooks/stats';
+import { Card, Flex, Heading } from '@radix-ui/themes';
+import { ErrorCallout } from 'components/Callouts';
+import Statistic from 'components/Statistic';
+
+export default function AdminCountsCard() {
+  const { data, error } = useCounts();
+
+  if (error) {
+    return (
+      <ErrorCallout>
+        Failed to load totals.
+        <br />
+        {error.message}
+      </ErrorCallout>
+    );
+  }
+
+  return (
+    <Card>
+      <Heading>Totals</Heading>
+      <Flex gap="4" mt="3">
+        <Statistic
+          label="Events"
+          value={data?.events || ''}
+        />
+        <Statistic
+          label="Users"
+          value={data?.users || ''}
+        />
+        <Statistic
+          label="Teams"
+          value={data?.teams || ''}
+        />
+      </Flex>
+    </Card>
+  );
+}

--- a/frontend/src/routes/admin/dashboard/AdminProvisionerCard.tsx
+++ b/frontend/src/routes/admin/dashboard/AdminProvisionerCard.tsx
@@ -19,7 +19,7 @@ export default function AdminProvisionerCard() {
   return (
     <Card>
       <Heading>Provisioner</Heading>
-      <Flex gap="4" my="4">
+      <Flex gap="4" mt="3">
         <Statistic
           label="Containers Running"
           value={data?.containers_running || 0}

--- a/frontend/src/routes/admin/dashboard/index.tsx
+++ b/frontend/src/routes/admin/dashboard/index.tsx
@@ -1,4 +1,5 @@
 import { Flex } from '@radix-ui/themes';
+import AdminCountsCard from './AdminCountsCard';
 import AdminProvisionerCard from './AdminProvisionerCard';
 
 export default function AdminDashboard() {
@@ -6,6 +7,7 @@ export default function AdminDashboard() {
     <>
       <title>Admin Dashboard</title>
       <Flex direction="column" gap="4" className="flex-grow basis-1/2 h-full">
+        <AdminCountsCard />
         <AdminProvisionerCard />
       </Flex>
     </>


### PR DESCRIPTION
We've had a counts endpoint to get the totals of various objects on the system for a while. Expose this on the admin dashboard so we can easily see those totals without manual counting/queries.
<img width="615" height="193" alt="image" src="https://github.com/user-attachments/assets/70f11cc1-bd75-4359-8af2-9814850d610b" />
