### PR TITLE
Don't force li children to be inline in markdown

### DIFF
--- a/frontend/src/components/RadixMarkdown.tsx
+++ b/frontend/src/components/RadixMarkdown.tsx
@@ -50,7 +50,7 @@ const Components: Components = {
   h6 : ({ children }) => <Heading size="3" as="h6">{children}</Heading>,
   ul : ({ children }) => <ul className="list-disc list-inside mb-2 ms-2">{children}</ul>,
   ol : ({ children }) => <ol className="list-decimal list-inside mb-2 ms-2">{children}</ol>,
-  li : ({ children }) => <Text asChild color="gray" mb="1"><li className="*:inline">{children}</li></Text>,
+  li : ({ children }) => <Text asChild color="gray" mb="1"><li>{children}</li></Text>,
   table : ({ children }) => <Table.Root className="w-fit max-w-full mb-2">{children}</Table.Root>,
   thead : ({ children }) => <Table.Header>{children}</Table.Header>,
   tbody : ({ children }) => <Table.Body>{children}</Table.Body>,


### PR DESCRIPTION
Fix list nesting in markdown. Resolves #546.

For list nesting to work, 4-space indentation in markdown is required. Commonmark treats anything less as not being indented.