### PR TITLE
Change validation errors to display more nicely for users

### DIFF
--- a/backend/ng/core/exceptions.py
+++ b/backend/ng/core/exceptions.py
@@ -42,9 +42,14 @@ class ValidationError(APIException):
     def __init__(self, message: str, errors: dict[str, str] | None = None):
         """Initialize with a message and optional detailed errors dictionary."""
         if errors is None:
-            errors = {}
-
-        super().__init__(f"{message}: {str(errors)}")
+            super().__init__(message)
+        else:
+            if len(errors) == 1:
+                # If only one error, set the main message to that error
+                key, val = next(iter(errors.items()))
+                super().__init__(val, key)
+            else:
+                super().__init__(f"{message}: {str(errors)}")
         self.errors = errors
 
     def to_dict(self) -> dict:

--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -742,8 +742,7 @@ class Test_Event_Registration:
         data = response.get_json()
         assert data["success"] is False
         assert "errors" in data
-        print(data["errors"])
-        assert "Team name contains disallowed characters" in data["errors"]["validation"]
+        assert "Team name contains disallowed characters" in data["errors"]["name"]
 
 class Test_Event_Team_Lookup:
     def get_endpoint(self, event_id: int) -> str:
@@ -1582,7 +1581,6 @@ class Test_Event_Admin_Create:
         data = response.get_json()
         assert data["success"] is False
         assert "errors" in data
-        assert "validation" in data["errors"]
 
     def test_admin_create_event_with_domain_restrictions(self, admin_client):
         new_event_data = {

--- a/backend/ng/permissions/tests/test_permission_api.py
+++ b/backend/ng/permissions/tests/test_permission_api.py
@@ -47,7 +47,6 @@ def test_change_role_invalid_permissions(admin_client, role_with_permissions):
     data = response.get_json()
     assert not data["success"]
     assert "errors" in data
-    assert "validation" in data["errors"]
 
 
 def test_get_user_roles(admin_client, user_with_roles):
@@ -99,7 +98,6 @@ def test_update_user_roles_invalid_role(admin_client, user_with_roles):
     data = response.get_json()
     assert not data["success"]
     assert "errors" in data
-    assert "validation" in data["errors"]
 
 def test_get_user_permissions(team_captain_client, user_with_roles):
     """Check that a user can get their own permissions."""

--- a/backend/ng/support/tests/test_ticket_attachment_model.py
+++ b/backend/ng/support/tests/test_ticket_attachment_model.py
@@ -155,7 +155,7 @@ class TestTicketAttachment:
                 content_type = "image/webp",
                 uploaded_by = 999999,  # Non existent user
             )
-        assert "User" in str(exc_info.value) or "uploaded_by" in str(
+        assert "User" in str(exc_info.value) or "uploaded by" in str(
             exc_info.value
         ).lower()
 

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -156,7 +156,7 @@ class Team(db.Model):
                     exclude_team_id=data.get("id", 0),  # Exclude current team if updating
                 )
                 if res:
-                    raise ValidationError(f"Team name '{data['name']}' already exists in event ID {data['event_id']}.")
+                    raise ValidationError(f"Team name '{data['name']}' already exists in this event.")
         if "start_timestamp" in data and "end_time" in data and data["start_timestamp"] is not None and data["end_time"] is not None:
             validator.validate_time_window(data, start_field="start_timestamp", end_field="end_time")
         else:

--- a/backend/ng/team/tests/test_admin_routes.py
+++ b/backend/ng/team/tests/test_admin_routes.py
@@ -75,7 +75,7 @@ def test_teamdetail_update_timestamps_must_have_continuity(admin_client, event, 
     )
     assert response.status_code == 400
     data = response.get_json()
-    assert data['errors']['validation'] ==  "Validation failed: {'end_time': 'End Time must be after start timestamp.'}"
+    assert data['errors'] ==  {'end_time': 'End Time must be after start timestamp.'}
 
 def test_teamdetail_update_just_start(admin_client, event, team_factory, user):
     """Test that the team detail endpoint allows updating just start timestamp."""


### PR DESCRIPTION
Fixes #494

Validation errors will now by displayed to the user as a more readable error message instead of json
Old
<img width="594" height="213" alt="image" src="https://github.com/user-attachments/assets/4d4a705e-b06c-4a95-a051-51f88d122cfd" />
New
<img width="607" height="151" alt="image" src="https://github.com/user-attachments/assets/f0ae207f-6cb3-47b8-86e9-91fdae8c6a7d" />
****
