### PR TITLE
Connect YAML editor to challenge lint functionality

### DIFF
--- a/backend/ng/challenge/controllers/admin/lint_challenge.py
+++ b/backend/ng/challenge/controllers/admin/lint_challenge.py
@@ -139,7 +139,7 @@ def lint_challenge(yaml_content: str) -> SerializedLint | None:
         compose_file = parse_compose_string(yaml_content)
         warnings = compose_file.warnings()
 
-        if warnings is not None and (warnings.self_warnings or warnings.field_warnings):
+        if warnings is not None:
             return {
                 "warnings": serialize_warnings(warnings),
             }

--- a/backend/ng/challenge/controllers/admin/lint_challenge.py
+++ b/backend/ng/challenge/controllers/admin/lint_challenge.py
@@ -139,7 +139,7 @@ def lint_challenge(yaml_content: str) -> SerializedLint | None:
         compose_file = parse_compose_string(yaml_content)
         warnings = compose_file.warnings()
 
-        if warnings.self_warnings or warnings.field_warnings:
+        if warnings is not None and (warnings.self_warnings or warnings.field_warnings):
             return {
                 "warnings": serialize_warnings(warnings),
             }

--- a/backend/ng/challenge/routes/admin_routes.py
+++ b/backend/ng/challenge/routes/admin_routes.py
@@ -56,6 +56,7 @@ class ChallengeList(Resource): # Feels like I should rename this but I'm not sur
         challenge = import_challenge_from_yaml(event, payload)
         return success_response(challenge)
 
+@challenge_admin_namespace.route("/lint")
 class ChallengeLint(Resource):
     @challenge_admin_namespace.doc(
         description="Lint a challenge YAML configuration without creating the challenge",

--- a/frontend/src/components/ChallengeForm.tsx
+++ b/frontend/src/components/ChallengeForm.tsx
@@ -1,11 +1,6 @@
 import { lintChallenge } from '@/hooks/challenge';
 import type { LintResult } from '@/types';
-import {
-  Box,
-  Flex,
-  Strong,
-  Text,
-} from '@radix-ui/themes';
+import { Flex, Strong, Text } from '@radix-ui/themes';
 import { throttle } from 'lodash';
 import { useEffect, useRef, useState } from 'react';
 import { Controller, type UseFormReturn } from 'react-hook-form';
@@ -55,18 +50,20 @@ export default function ChallengeForm({ rhf }: {rhf: UseFormReturn<{yaml: string
     }
       />
       {lintResult && ('errors' in lintResult || 'warnings' in lintResult) && (
-        <CalloutType>
-          <Flex gap="3" direction="column">
-            {('errors' in lintResult ? lintResult.errors : lintResult.warnings)
-              .map((msg) => (
-                <Box key={msg.field + msg.message}>
-                  <Strong>{msg.field}</Strong>
-                  <br />
-                  <Text>{msg.message}</Text>
-                </Box>
-              ))}
-          </Flex>
-        </CalloutType>
+        <Flex direction="column" gap="3">
+          {('errors' in lintResult ? lintResult.errors : lintResult.warnings)
+            .map((msg) => (
+              <CalloutType key={msg.message + msg.field}>
+                <Strong>{msg.message}</Strong>
+                <Text>
+                  {' '}
+                  at
+                  {' '}
+                  {msg.field}
+                </Text>
+              </CalloutType>
+            ))}
+        </Flex>
       )}
     </>
   );

--- a/frontend/src/components/ChallengeForm.tsx
+++ b/frontend/src/components/ChallengeForm.tsx
@@ -1,0 +1,73 @@
+import { lintChallenge } from '@/hooks/challenge';
+import type { LintResult } from '@/types';
+import {
+  Box,
+  Flex,
+  Strong,
+  Text,
+} from '@radix-ui/themes';
+import { throttle } from 'lodash';
+import { useEffect, useRef, useState } from 'react';
+import { Controller, type UseFormReturn } from 'react-hook-form';
+import { ErrorCallout, WarningCallout } from './Callouts';
+import YamlEditor from './YamlEditor';
+
+export default function ChallengeForm({ rhf }: {rhf: UseFormReturn<{yaml: string}>}) {
+  const {
+    control, getValues, trigger,
+  } = rhf;
+  const [ lintResult, setLintResult ] = useState<LintResult>(null);
+
+  const lintRef = useRef(throttle(async (y: string) => {
+    const result = await lintChallenge(y);
+    setLintResult(result);
+  }, 1000));
+
+  const CalloutType = (lintResult && 'errors' in lintResult) ? ErrorCallout : WarningCallout;
+
+  useEffect(() => {
+    const yaml = getValues('yaml');
+    if (yaml && yaml.length > 0) {
+      lintRef.current(yaml);
+    }
+  }, [ getValues ]);
+
+  useEffect(() => {
+    trigger('yaml');
+  }, [ lintResult, trigger ]);
+
+  return (
+    <>
+      <Controller
+        control={control}
+        rules={{
+          validate : () => !(lintResult && 'errors' in lintResult),
+        }}
+        name="yaml"
+        render={
+      ({ field }) => (
+        <YamlEditor
+          value={field.value}
+          onChange={(v) => { field.onChange(v); lintRef.current(v); }}
+          ref={field.ref}
+        />
+      )
+    }
+      />
+      {lintResult && ('errors' in lintResult || 'warnings' in lintResult) && (
+        <CalloutType>
+          <Flex gap="3" direction="column">
+            {('errors' in lintResult ? lintResult.errors : lintResult.warnings)
+              .map((msg) => (
+                <Box key={msg.field + msg.message}>
+                  <Strong>{msg.field}</Strong>
+                  <br />
+                  <Text>{msg.message}</Text>
+                </Box>
+              ))}
+          </Flex>
+        </CalloutType>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/ChallengeForm.tsx
+++ b/frontend/src/components/ChallengeForm.tsx
@@ -18,7 +18,10 @@ export default function ChallengeForm({ rhf }: {rhf: UseFormReturn<{yaml: string
     setLintResult(result);
   }, 1000));
 
-  const CalloutType = (lintResult && 'errors' in lintResult) ? ErrorCallout : WarningCallout;
+  const hasErrors = !!(lintResult && 'errors' in lintResult);
+  const hasWarnings = !!(lintResult && 'warnings' in lintResult);
+
+  const CalloutType = hasErrors ? ErrorCallout : WarningCallout;
 
   useEffect(() => {
     const yaml = getValues('yaml');
@@ -35,9 +38,7 @@ export default function ChallengeForm({ rhf }: {rhf: UseFormReturn<{yaml: string
     <>
       <Controller
         control={control}
-        rules={{
-          validate : () => !(lintResult && 'errors' in lintResult),
-        }}
+        rules={{ validate : () => !hasErrors }}
         name="yaml"
         render={
       ({ field }) => (
@@ -49,9 +50,9 @@ export default function ChallengeForm({ rhf }: {rhf: UseFormReturn<{yaml: string
       )
     }
       />
-      {lintResult && ('errors' in lintResult || 'warnings' in lintResult) && (
+      {(hasErrors || hasWarnings) && (
         <Flex direction="column" gap="3">
-          {('errors' in lintResult ? lintResult.errors : lintResult.warnings)
+          {(hasErrors ? lintResult.errors : lintResult.warnings)
             .map((msg) => (
               <CalloutType key={msg.message + msg.field}>
                 <Strong>{msg.message}</Strong>

--- a/frontend/src/hooks/challenge.ts
+++ b/frontend/src/hooks/challenge.ts
@@ -6,6 +6,7 @@ import type {
   ChallengeVariable,
   ContainerBlueprint,
   Hint,
+  LintResult,
   MeChallenge,
   Question,
 } from '@/types';
@@ -151,6 +152,12 @@ export function createChallenge(eventId: number, yaml: string) {
     // refresh the challenges list when a new challenge is created
     mutate(`/admin/events/${eventId}/challenges`);
   });
+}
+
+export function lintChallenge(yaml: string) {
+  return apiMutation('/admin/challenges/lint', { yaml : utf8ToBase64(yaml) }, {
+    method : 'POST',
+  }) as Promise<LintResult>;
 }
 
 export function updateChallenge(challengeId: number, yaml: string) {

--- a/frontend/src/routes/admin/challenges/ChallengeUpdateModal.tsx
+++ b/frontend/src/routes/admin/challenges/ChallengeUpdateModal.tsx
@@ -1,9 +1,8 @@
 import { COLOR_WARNING } from '@/constants';
 import { updateChallenge, useAdminChallengeYaml } from '@/hooks/challenge';
 import { Button } from '@radix-ui/themes';
+import ChallengeForm from 'components/ChallengeForm';
 import Modal from 'components/Modal';
-import YamlEditor from 'components/YamlEditor';
-import { Controller } from 'react-hook-form';
 import { TbPencil } from 'react-icons/tb';
 
 export default function ChallengeUpdateModal({ challengeId }: { challengeId: number }) {
@@ -32,20 +31,8 @@ export default function ChallengeUpdateModal({ challengeId }: { challengeId: num
       }}
       className="!max-w-[80ch]"
     >
-      {({ control }) => (
-        <Controller
-          control={control}
-          name="yaml"
-          render={
-            ({ field }) => (
-              <YamlEditor
-                value={field.value}
-                onChange={field.onChange}
-                ref={field.ref}
-              />
-            )
-          }
-        />
+      {(rhf) => (
+        <ChallengeForm rhf={rhf} />
       )}
     </Modal>
   );

--- a/frontend/src/routes/admin/events/ChallengeUploadModal.tsx
+++ b/frontend/src/routes/admin/events/ChallengeUploadModal.tsx
@@ -1,9 +1,8 @@
 import { COLOR_POSITIVE } from '@/constants';
 import { createChallenge } from '@/hooks/challenge';
 import { Button } from '@radix-ui/themes';
+import ChallengeForm from 'components/ChallengeForm';
 import Modal from 'components/Modal';
-import YamlEditor from 'components/YamlEditor';
-import { Controller } from 'react-hook-form';
 import { TbPlus } from 'react-icons/tb';
 
 export default function ChallengeUploadModal({ eventId }: { eventId: number }) {
@@ -24,20 +23,8 @@ export default function ChallengeUploadModal({ eventId }: { eventId: number }) {
       }}
       className="!max-w-[80ch]"
     >
-      {({ control }) => (
-        <Controller
-          control={control}
-          name="yaml"
-          render={
-            ({ field }) => (
-              <YamlEditor
-                value={field.value}
-                onChange={field.onChange}
-                ref={field.ref}
-              />
-            )
-          }
-        />
+      {(rhf) => (
+        <ChallengeForm rhf={rhf} />
       )}
     </Modal>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -309,3 +309,10 @@ export interface ChallengeVariable {
   default: string;
   template: string;
 }
+
+export interface LintItem {
+  message: string;
+  field: string;
+}
+
+export type LintResult = null | {warnings: LintItem[]} | {errors: LintItem[]};


### PR DESCRIPTION
<img width="830" height="785" alt="image" src="https://github.com/user-attachments/assets/15328643-dc55-4492-b67a-6b5d11f9eb99" />

<img width="830" height="785" alt="image" src="https://github.com/user-attachments/assets/7b6109aa-ddab-49d2-a715-14a88accb5ab" />

Challenge upload/update YAML editors now lint (throttled to at most once per second) as the user types or if a file is uploaded. Form submission is blocked if the lint has errors.

Note that valid challenges will lint as invalid currently - @johnmarsden-edu is working on a fix for that.