### PR TITLE
Fix error type for current challenge

### DIFF
--- a/frontend/src/hooks/container.ts
+++ b/frontend/src/hooks/container.ts
@@ -3,7 +3,7 @@ import type { ContainerInstance, ContainerStatus, Deployment } from '@/types';
 import useSWR, { mutate } from 'swr';
 
 export function useCurrentChallengeId() {
-  return useSWR<number | null>('/container/me/current_challenge');
+  return useSWR<number | null, Error>('/container/me/current_challenge');
 }
 
 export function connectWorkspace(eventId: number, challengeId: number) {

--- a/frontend/src/routes/events/challenge/ConnectModal.tsx
+++ b/frontend/src/routes/events/challenge/ConnectModal.tsx
@@ -34,7 +34,7 @@ export default function ConnectModal({
 
   if (error) {
     // if we can't get the current challenge, show an error where the button would otherwise go
-    return <ErrorCallout>{error}</ErrorCallout>;
+    return <ErrorCallout>{error.message}</ErrorCallout>;
   }
 
   if (currentChallenge === challengeId) {


### PR DESCRIPTION
If current_challenge failed, it would previously result in a page crash, since error objects can't be rendered in JSX. Correctly sets the error type and displays error.message instead.