### PR TITLE
Permission updates for feedback system

### DIFF
--- a/backend/ng/feedback/routes/user_routes.py
+++ b/backend/ng/feedback/routes/user_routes.py
@@ -2,7 +2,6 @@
 User Routes for Feedback Operations
 """
 
-from datetime import datetime
 from flask_restx import Namespace, Resource
 
 

--- a/backend/ng/feedback/routes/user_routes.py
+++ b/backend/ng/feedback/routes/user_routes.py
@@ -2,17 +2,24 @@
 User Routes for Feedback Operations
 """
 
+from datetime import datetime
 from flask_restx import Namespace, Resource
+
 
 from ...core.middleware.loaders import (
     LoaderType,
     load_event,
     load_challenge,
+    load_team_by_user_and_event,
 )
-from ...core.utils import success_response
+from ...core.utils import error_response, success_response, utc_now
 from ...core.middleware import user_endpoint
+from ...core.middleware.permission_middleware import check_permissions
+from ...permissions.models.enums import PermissionEnum
 
 from ...user.models.User import User
+from ...team.models.Team import Team
+
 from ..controllers import (
     get_my_event_feedback,
     upsert_event_feedback,
@@ -31,6 +38,7 @@ feedback_user_namespace = Namespace(
 class EventFeedback(Resource):
     @user_endpoint()
     @load_event(source = LoaderType.PARAM)
+    @load_team_by_user_and_event()
     @feedback_user_namespace.doc(
         description = "Get my feedback for an event",
         responses = {
@@ -51,6 +59,8 @@ class EventFeedback(Resource):
 
     @user_endpoint(json_required = True)
     @load_event(source = LoaderType.PARAM)
+    @load_team_by_user_and_event()
+    @check_permissions(PermissionEnum.CAN_VIEW_CHALLENGES, "You may not leave feedback at this time.")
     @feedback_user_namespace.doc(
         description = "Submit or update my event feedback",
         params = {
@@ -67,10 +77,13 @@ class EventFeedback(Resource):
             404: "Not found - Event does not exist",
         },
     )
-    def post(self, event_id: int, event, current_user: User, json_data, **kwargs):
+    def post(self, event_id: int, event, team: Team, current_user: User, json_data, **kwargs):
         """
         Submit or update my event feedback
         """
+        if team.end_time is not None and team.end_time > utc_now().replace(tzinfo = None):
+          return error_response("You cannot submit event feedback until you have finished the event.", "feedback", 403)
+
         feedback = upsert_event_feedback(
             user_id = current_user.id,
             event_id = event_id,
@@ -87,6 +100,7 @@ class ChallengeFeedback(Resource):
     @user_endpoint()
     @load_event(source = LoaderType.PARAM)
     @load_challenge(source = LoaderType.PARAM)
+    @load_team_by_user_and_event()
     @feedback_user_namespace.doc(
         description = "Get my feedback for a challenge",
         responses = {
@@ -115,6 +129,8 @@ class ChallengeFeedback(Resource):
 
     @user_endpoint(json_required = True)
     @load_event(source = LoaderType.PARAM)
+    @load_team_by_user_and_event()
+    @check_permissions(PermissionEnum.CAN_VIEW_CHALLENGES, "You may not leave feedback at this time.")
     @load_challenge(source = LoaderType.PARAM)
     @feedback_user_namespace.doc(
         description = "Submit or update my challenge feedback",

--- a/backend/ng/feedback/tests/test_feedback_api.py
+++ b/backend/ng/feedback/tests/test_feedback_api.py
@@ -2,6 +2,7 @@
 Tests for feedback API endpoints
 """
 
+from ...team.models.Team import Team
 import pytest
 from datetime import timedelta
 
@@ -12,10 +13,15 @@ class TestUserFeedbackEndpoints:
     """
     Tests for user feedback API endpoints
     """
-    def test_submit_event_feedback_new(self, logged_in_client, user, event):
+    def test_submit_event_feedback_new(self, logged_in_client, user, event, team_with_member: Team):
         """
         Test submitting new event feedback
         """
+
+        # team finished 30 minutes ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+        team_with_member.end_timestamp = utc_now() - timedelta(minutes = 30)
+
         response = logged_in_client.post(
             f"/ng/events/{event.id}/feedback",
             json = {
@@ -41,11 +47,16 @@ class TestUserFeedbackEndpoints:
         logged_in_client,
         user,
         event,
+        team_with_member: Team,
         feedback_factory
     ):
         """
         Test updating existing event feedback
         """
+        # team finished 30 minutes ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+        team_with_member.end_timestamp = utc_now() - timedelta(minutes = 30)
+
         existing_feedback = feedback_factory(
             user_id = user.id,
             event_id = event.id,
@@ -73,16 +84,61 @@ class TestUserFeedbackEndpoints:
         assert data["data"]["feedback_data"]["rating"] == 5
         assert data["data"]["feedback_data"]["comments"] == "Actually, great event!"
 
+    def test_submit_event_feedback_too_early(self, logged_in_client, user, event, team_with_member: Team):
+        """
+        Test submitting feedback before team has finished (end_timestamp in future) returns 403
+        """
+        # team finishes 30 minutes in the future
+        from ...core.utils import utc_now
+        from datetime import timedelta
+
+        team_with_member.start_timestamp = utc_now() - timedelta(hours=1)
+        team_with_member.end_time = utc_now() + timedelta(minutes=30)
+
+        response = logged_in_client.post(
+            f"/ng/events/{event.id}/feedback",
+            json={
+                "feedback_data": {
+                    "rating": 5,
+                    "comments": "Too early!",
+                },
+            },
+        )
+
+        assert response.status_code == 403
+
+    def test_submit_event_feedback_not_registered(self, logged_in_client, user, event):
+        """
+        Test that submitting feedback for an event the user is not registered for produces an error
+        """
+        # User is not registered for this event (no team_with_member fixture)
+        response = logged_in_client.post(
+            f"/ng/events/{event.id}/feedback",
+            json={
+                "feedback_data": {
+                    "rating": 5,
+                    "comments": "Should not be allowed",
+                },
+            },
+        )
+
+        assert response.status_code == 404
+
     def test_get_my_event_feedback(
         self,
         logged_in_client,
         user,
         event,
+        team_with_member: Team,
         feedback_factory
     ):
         """
         Test getting my event feedback
         """
+        # team finished 30 minutes ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+        team_with_member.end_timestamp = utc_now() - timedelta(minutes = 30)
+
         feedback_factory(
             user_id = user.id,
             event_id = event.id,
@@ -99,10 +155,14 @@ class TestUserFeedbackEndpoints:
         assert data["data"]["event_id"] == event.id
         assert data["data"]["feedback_data"]["rating"] == 4
 
-    def test_get_my_event_feedback_not_submitted(self, logged_in_client, event):
+    def test_get_my_event_feedback_not_submitted(self, logged_in_client, user, team_with_member: Team, event):
         """
         Test getting event feedback when none submitted
         """
+        # team finished 30 minutes ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+        team_with_member.end_timestamp = utc_now() - timedelta(minutes = 30)
+
         response = logged_in_client.get(f"/ng/events/{event.id}/feedback")
 
         assert response.status_code == 200
@@ -115,11 +175,15 @@ class TestUserFeedbackEndpoints:
         logged_in_client,
         user,
         event,
+        team_with_member: Team,
         challenge
     ):
         """
         Test submitting new challenge feedback
         """
+        # team started 1 hour ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+
         response = logged_in_client.post(
             f"/ng/events/{event.id}/challenges/{challenge.id}/feedback",
             json = {
@@ -145,12 +209,16 @@ class TestUserFeedbackEndpoints:
         logged_in_client,
         user,
         event,
+        team_with_member: Team,
         challenge,
         feedback_factory
     ):
         """
         Test updating existing challenge feedback
         """
+        # team started 1 hour ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+
         existing_feedback = feedback_factory(
             user_id = user.id,
             event_id = event.id,
@@ -179,17 +247,70 @@ class TestUserFeedbackEndpoints:
         assert data["data"]["feedback_data"]["difficulty"] == "hard"
         assert data["data"]["feedback_data"]["quality"] == 5
 
+    def test_submit_challenge_feedback_too_early(
+        self,
+        logged_in_client,
+        user,
+        event,
+        team_with_member: Team,
+        challenge
+    ):
+        """
+        Test submitting challenge feedback before team has started returns 403
+        """
+        # team has no start time (not started)
+        response = logged_in_client.post(
+            f"/ng/events/{event.id}/challenges/{challenge.id}/feedback",
+            json={
+                "feedback_data": {
+                    "difficulty": "hard",
+                    "quality": 5,
+                    "comments": "Trying to submit too early!",
+                },
+            },
+        )
+
+        assert response.status_code == 403
+
+    def test_submit_challenge_feedback_not_registered(
+        self,
+        logged_in_client,
+        user,
+        event,
+        challenge
+    ):
+        """
+        Test that submitting challenge feedback for an event the user is not registered for produces a 404
+        """
+        # User is not registered for this event (no team_with_member fixture)
+        response = logged_in_client.post(
+            f"/ng/events/{event.id}/challenges/{challenge.id}/feedback",
+            json={
+                "feedback_data": {
+                    "difficulty": "medium",
+                    "quality": 4,
+                    "comments": "Should not be allowed",
+                },
+            },
+        )
+
+        assert response.status_code == 404
+
     def test_get_my_challenge_feedback(
         self,
         logged_in_client,
         user,
         event,
+        team_with_member: Team,
         challenge,
         feedback_factory
     ):
         """
         Test getting my challenge feedback
         """
+        # team started 1 hour ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+
         feedback_factory(
             user_id = user.id,
             event_id = event.id,
@@ -211,12 +332,17 @@ class TestUserFeedbackEndpoints:
     def test_get_my_challenge_feedback_not_submitted(
         self,
         logged_in_client,
+        user,
         event,
+        team_with_member: Team,
         challenge
     ):
         """
         Test getting challenge feedback when none submitted
         """
+        # team started 1 hour ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+
         response = logged_in_client.get(
             f"/ng/events/{event.id}/challenges/{challenge.id}/feedback"
         )
@@ -256,10 +382,14 @@ class TestUserFeedbackEndpoints:
 
         assert response.status_code == 404
 
-    def test_submit_feedback_empty_data(self, logged_in_client, event):
+    def test_submit_feedback_empty_data(self, logged_in_client, user, team_with_member, event):
         """
         Test submitting feedback with empty feedback_data
         """
+        # team finished 30 minutes ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+        team_with_member.end_timestamp = utc_now() - timedelta(minutes = 30)
+
         response = logged_in_client.post(
             f"/ng/events/{event.id}/feedback",
             json = {"feedback_data": {}},
@@ -270,10 +400,14 @@ class TestUserFeedbackEndpoints:
         assert data["success"] is True
         assert data["data"]["feedback_data"] == {}
 
-    def test_submit_feedback_missing_feedback_data(self, logged_in_client, event):
+    def test_submit_feedback_missing_feedback_data(self, logged_in_client, user, team_with_member, event):
         """
         Test submitting feedback without feedback_data field
         """
+        # team finished 30 minutes ago
+        team_with_member.start_timestamp = utc_now() - timedelta(hours = 1)
+        team_with_member.end_timestamp = utc_now() - timedelta(minutes = 30)
+
         response = logged_in_client.post(
             f"/ng/events/{event.id}/feedback",
             json = {},

--- a/backend/ng/feedback/tests/test_feedback_api.py
+++ b/backend/ng/feedback/tests/test_feedback_api.py
@@ -5,7 +5,6 @@ Tests for feedback API endpoints
 from ...team.models.Team import Team
 import pytest
 from datetime import timedelta
-
 from ...core.utils import utc_now
 
 
@@ -89,9 +88,6 @@ class TestUserFeedbackEndpoints:
         Test submitting feedback before team has finished (end_timestamp in future) returns 403
         """
         # team finishes 30 minutes in the future
-        from ...core.utils import utc_now
-        from datetime import timedelta
-
         team_with_member.start_timestamp = utc_now() - timedelta(hours=1)
         team_with_member.end_time = utc_now() + timedelta(minutes=30)
 

--- a/backend/ng/permissions/controllers/get_challenge_permissions.py
+++ b/backend/ng/permissions/controllers/get_challenge_permissions.py
@@ -25,7 +25,7 @@ def get_challenge_permissions(team: Team) -> PermissionCheck:
 
     if team.end_time is not None and team.end_time < now:
         reason = DenyReason.TIME_LIMIT_EXCEEDED
-        trace.add_denial(PermissionEnum.CAN_VIEW_CHALLENGES, reason)
+        trace.add_grant(PermissionEnum.CAN_VIEW_CHALLENGES)
         trace.add_denial(PermissionEnum.CAN_PLAY_CHALLENGES, reason)
         return trace
 

--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -1,6 +1,5 @@
 import { useChallenge } from '@/hooks/challenge';
 import { useEvent, useMyTeam } from '@/hooks/events';
-import { useEventPermission } from '@/hooks/permissions';
 import {
   Box,
   Button,
@@ -42,8 +41,6 @@ export default function ChallengeSidebar() {
   const {
     challenge, questions, hints, attempts,
   } = data || {};
-
-  const { granted } = useEventPermission('CAN_PLAY_CHALLENGES', Number(idEvent));
 
   const groupedAttempts = groupBy(attempts || [], 'question_id');
 
@@ -102,7 +99,7 @@ export default function ChallengeSidebar() {
               </Box>
             )}
 
-            {challenge && event && granted && (
+            {challenge && event && (
               <>
                 {provisioningError && <ErrorCallout className="mt-3">{provisioningError.message}</ErrorCallout>}
                 <Flex direction="row" gap="2" mt="3" align="center" justify="between">

--- a/frontend/src/routes/events/challenge/ConnectModal.tsx
+++ b/frontend/src/routes/events/challenge/ConnectModal.tsx
@@ -1,5 +1,6 @@
 import { COLOR_NEGATIVE, COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
 import { connectWorkspace, recycleChallengeContainers, useCurrentChallengeId } from '@/hooks/container';
+import { useEventPermission } from '@/hooks/permissions';
 import { Button, Flex } from '@radix-ui/themes';
 import { ErrorCallout } from 'components/Callouts';
 import Modal from 'components/Modal';
@@ -17,6 +18,8 @@ export default function ConnectModal({
   const {
     data : currentChallenge, isLoading, error,
   } = useCurrentChallengeId();
+  const { granted } = useEventPermission('CAN_PLAY_CHALLENGES', eventId);
+
   const [ loading, setLoading ] = useState(false);
 
   const handleConnect = async () => {
@@ -35,6 +38,12 @@ export default function ConnectModal({
   if (error) {
     // if we can't get the current challenge, show an error where the button would otherwise go
     return <ErrorCallout>{error.message}</ErrorCallout>;
+  }
+
+  if (!granted) {
+    // if we don't have permission to play, don't show anything.
+    // we return an empty div to not cause layout shift in the parent flex layout
+    return <div />;
   }
 
   if (currentChallenge === challengeId) {

--- a/frontend/src/routes/events/challenge/HintsModal.tsx
+++ b/frontend/src/routes/events/challenge/HintsModal.tsx
@@ -10,6 +10,7 @@ import {
 } from '@radix-ui/themes';
 import { ErrorCallout } from 'components/Callouts';
 import Modal from 'components/Modal';
+import RequireEventPermission from 'components/RequireEventPermission';
 import { useState } from 'react';
 import { TbBulb, TbLockOpen } from 'react-icons/tb';
 
@@ -33,42 +34,52 @@ function HintRow({ hint, eventId }: {hint: Hint, eventId: number}) {
         {hint.body
           ? <Text>{hint.body}</Text>
           : (
-            <Popover.Root>
-              <Popover.Trigger>
-                <Button variant="ghost" color={COLOR_HINT} type="button">
+            <RequireEventPermission
+              eventId={eventId}
+              permission="CAN_PLAY_CHALLENGES"
+              permissionDeniedPlaceholder={(
+                <Button variant="ghost" disabled type="button">
                   <TbLockOpen />
-                  {' '}
                   Redeem
                 </Button>
-              </Popover.Trigger>
-              <Popover.Content width="360px">
-                <Text>
-                  Are you sure you want to redeem
-                  {' '}
-                  {hint.preview}
-                  ?
-                </Text>
-                <br />
-                <Text color="gray" size="2">
-                  This will deduct
-                  {' '}
-                  {hint.deduction}
-                  {' '}
-                  points from your score.
-                </Text>
-
-                <Flex direction="row" gap="2" mt="2" className="*:!grow">
-                  <Popover.Close>
-                    <Button variant="soft" color="gray">
-                      Cancel
-                    </Button>
-                  </Popover.Close>
-                  <Button variant="soft" color={COLOR_HINT} onClick={handleRedeem} loading={loading}>
-                    Confirm
+              )}
+            >
+              <Popover.Root>
+                <Popover.Trigger>
+                  <Button variant="ghost" color={COLOR_HINT} type="button">
+                    <TbLockOpen />
+                    Redeem
                   </Button>
-                </Flex>
-              </Popover.Content>
-            </Popover.Root>
+                </Popover.Trigger>
+                <Popover.Content width="360px">
+                  <Text>
+                    Are you sure you want to redeem
+                    {' '}
+                    {hint.preview}
+                    ?
+                  </Text>
+                  <br />
+                  <Text color="gray" size="2">
+                    This will deduct
+                    {' '}
+                    {hint.deduction}
+                    {' '}
+                    points from your score.
+                  </Text>
+
+                  <Flex direction="row" gap="2" mt="2" className="*:!grow">
+                    <Popover.Close>
+                      <Button variant="soft" color="gray">
+                        Cancel
+                      </Button>
+                    </Popover.Close>
+                    <Button variant="soft" color={COLOR_HINT} onClick={handleRedeem} loading={loading}>
+                      Confirm
+                    </Button>
+                  </Flex>
+                </Popover.Content>
+              </Popover.Root>
+            </RequireEventPermission>
           )}
       </Table.Cell>
     </Table.Row>


### PR DESCRIPTION
**`CAN_VIEW_CHALLENGES` is now granted even after team end time**
Continue showing challenges after time is up to allow users to review their submission history and share feedback. Also makes time expiring while looking at a challenge more graceful - you no longer get a screen full of permission errors when time is up, since you can continue to get challenge data at that point (but can no longer submit anything.) Users will just see submit buttons disappear and answer fields lock. Also changes history/feedback UI to be available without CAN_PLAY_CHALLENGES permission, since they aren't tied to playing challenges. Hints may still be viewed, but cannot be redeemed in this state.

**Permission changes for feedback**
1. Users must now be registered for an event to get/set feedback. Users shouldn't be allowed to add feedback to things that they didn't participate in.
2. `CAN_VIEW_CHALLENGES` permission is required to submit feedback (user must have at least started the event.) Feedback shouldn't be allowed without having seen the challenges.
3. Event feedback can only be submitted after the team's end time as per requirements. (We do permit challenge feedback being submitted during the game though, but don't explicitly direct users towards it.) For events without a time bound, this restriction does not apply.