### PR TITLE
Standardize on connect terminology for challenges, warn when not

### DIFF
--- a/frontend/src/hooks/container.ts
+++ b/frontend/src/hooks/container.ts
@@ -11,7 +11,7 @@ export function connectWorkspace(eventId: number, challengeId: number) {
     method : 'POST',
   }).then(() => {
     // refresh the current challenge ID after connecting workspace
-    mutate('/container/me/current_challenge');
+    mutate('/container/me/current_challenge', challengeId);
   });
 }
 

--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -122,7 +122,7 @@ export default function ChallengeSidebar() {
           </ChallengeHeader>
         </Inset>
       </Card>
-      
+
       {challenge && <FeedbackPrompt eventId={challenge.event_id} challengeId={challenge.id} /> }
       {challenge && <NotConnectedWarning challenge={challenge} /> }
 

--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -25,6 +25,7 @@ import ConnectModal from './ConnectModal';
 import FeedbackModal from './FeedbackModal';
 import HintsModal from './HintsModal';
 import HistoryModal from './HistoryModal';
+import NotConnectedWarning from './NotConnectedWarning';
 
 export default function ChallengeSidebar() {
   const { idEvent, idChallenge } = useParams();
@@ -120,6 +121,8 @@ export default function ChallengeSidebar() {
           </ChallengeHeader>
         </Inset>
       </Card>
+
+      {challenge && <NotConnectedWarning challenge={challenge} /> }
 
       <Card className="!flex flex-col">
         <Inset side="all" className="shrink !overflow-y-auto">

--- a/frontend/src/routes/events/challenge/ConnectModal.tsx
+++ b/frontend/src/routes/events/challenge/ConnectModal.tsx
@@ -2,10 +2,10 @@ import { COLOR_NEGATIVE, COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
 import { connectWorkspace, recycleChallengeContainers, useCurrentChallengeId } from '@/hooks/container';
 import { useEventPermission } from '@/hooks/permissions';
 import { Button, Flex } from '@radix-ui/themes';
-import { ErrorCallout } from 'components/Callouts';
+import { ErrorCallout, WarningCallout } from 'components/Callouts';
 import Modal from 'components/Modal';
 import { useState } from 'react';
-import { TbCheck, TbPlayerPlay, TbRotateClockwise } from 'react-icons/tb';
+import { TbCheck, TbPlug, TbRotateClockwise } from 'react-icons/tb';
 
 export default function ConnectModal({
   eventId, challengeId, isTeam, onError,
@@ -83,8 +83,8 @@ export default function ConnectModal({
         color={COLOR_POSITIVE}
         className="pulsate"
       >
-        <TbPlayerPlay />
-        Start Challenge
+        <TbPlug />
+        Connect
       </Button>
     );
   }
@@ -95,13 +95,17 @@ export default function ConnectModal({
       description="Your workspace will be disconnected from your previous challenge and connected to this one."
       trigger={(
         <Button loading={loading || isLoading} color={COLOR_POSITIVE} className="pulsate">
-          <TbPlayerPlay />
-          Start Challenge
+          <TbPlug />
+          Connect
         </Button>
       )}
       onSubmit={handleConnect}
       submitVerb="Confirm"
       submitColor={COLOR_WARNING}
-    />
+    >
+      <WarningCallout>
+        Resources from the previously connected challenge will no longer be available unless you reconnect to it.
+      </WarningCallout>
+    </Modal>
   );
 }

--- a/frontend/src/routes/events/challenge/NotConnectedWarning.tsx
+++ b/frontend/src/routes/events/challenge/NotConnectedWarning.tsx
@@ -1,0 +1,25 @@
+import { useCurrentChallengeId } from '@/hooks/container';
+import type { Challenge } from '@/types';
+import { Strong } from '@radix-ui/themes';
+import { WarningCallout } from 'components/Callouts';
+import RequireEventPermission from 'components/RequireEventPermission';
+
+export default function NotConnectedWarning({ challenge }: {challenge: Challenge}) {
+  const {
+    data : currentChallenge, isLoading,
+  } = useCurrentChallengeId();
+
+  if (!isLoading && currentChallenge !== challenge.id) {
+    return (
+      <RequireEventPermission eventId={challenge.event_id} permission="CAN_PLAY_CHALLENGES" permissionDeniedPlaceholder={null}>
+        <WarningCallout>
+          <Strong>You are not currently connected to this challenge.</Strong>
+          {' '}
+          Its resources will not be available in your workspace until you connect.
+        </WarningCallout>
+      </RequireEventPermission>
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
1. Standardizes terminology for starting challenges - the user's mental model should just be that they are "connecting" to a challenge, and not require any knowledge of the container management going on behind the scenes. "Start" isn't a good term here, since it doesn't really represent what's actually happening from the perspective of the user and their workspace, and doesn't account for cases where a challenge may already be running and they're reconnecting to it later on. The idea here is to just have a simple binary of "connect to a challenge = can access, not connected = can't access".
2. Adds a warning to the challenge sidebar when not connected to a challenge - this serves as a reminder to connect before trying to access any resources in the challenge description below, reinforces the idea that "connect = can access this challenge", and distinguishes that the workspace is separate from any challenge since this is shown even when the workspace is up.
3. Explicitly warn that the previous challenge will no longer be accessible when switching challenges.
4. Optimistically set `current_challenge` if container start comes back OK to avoid UI jank/flicker during revalidation

<img width="533" height="476" alt="image" src="https://github.com/user-attachments/assets/bee426bc-9076-4bce-8baa-9d067e013287" />
