### PR TITLE
Add configurable cpu limits

### DIFF
--- a/backend/ng/challenge/models/ContainerBlueprint.py
+++ b/backend/ng/challenge/models/ContainerBlueprint.py
@@ -38,7 +38,7 @@ class ContainerBlueprint(db.Model):
     cap_add: Mapped[list[Literal['NET_ADMIN', 'SYS_PTRACE']] | None] = db.Column(db.PickleType, nullable=True)
     mem_limit: Mapped[int | str | None] = db.Column(db.String(MAX_CONTAINER_BLUEPRINT_MEM_LIMIT_LENGTH), nullable=True)
     memswap_limit: Mapped[int | str | None] = db.Column(db.String(MAX_CONTAINER_BLUEPRINT_MEMSWAP_LIMIT_LENGTH), nullable=True)
-    cpus: Mapped[float | None] = db.Column(db.Numeric, nullable=True)
+    cpus: Mapped[float | None] = db.Column(db.Numeric(10,2), nullable=True)
     user: Mapped[str | None] = db.Column(db.String(MAX_CONTAINER_BLUEPRINT_USER_LENGTH), nullable=True)
     challenge_id: Mapped[int] = db.Column(db.Integer, db.ForeignKey("ng_challenges.id"), nullable=False, index=True)
 

--- a/backend/ng/containers/constants.py
+++ b/backend/ng/containers/constants.py
@@ -4,3 +4,4 @@ DOCKER_RUNNING = "running"
 DOCKER_BRIDGE = "bridge"
 CHALLENGER_NET_NAME = "competitor_net"
 DOCKER_MEM_REGEX = re.compile(r"([1-9][0-9]*)([bkmg]?)")
+DOCKER_QUOTA_CONST = 100000

--- a/backend/ng/containers/models/ContainerInstance.py
+++ b/backend/ng/containers/models/ContainerInstance.py
@@ -10,7 +10,7 @@ import logging
 from ..utils.get_client import get_client
 from ..utils.Client import Client
 from CTFd.utils import get_app_config
-from .. constants import DOCKER_RUNNING, DOCKER_BRIDGE, DOCKER_MEM_REGEX
+from .. constants import DOCKER_RUNNING, DOCKER_BRIDGE, DOCKER_MEM_REGEX, DOCKER_QUOTA_CONST
 from ...challenge.models.ContainerBlueprint import ContainerBlueprint
 from ...team.models.Team import Team
 from ...core import BusinessLogicError
@@ -152,6 +152,13 @@ class ContainerInstance(db.Model):
     def run_container(client: Client, team: Team, blueprint_obj: ContainerBlueprint):
         ulimit = docker.types.Ulimit(name="nofile", soft=10000, hard=20000)
         mem_limit = blueprint_obj.mem_limit or "128m"
+        cpus = 0.1
+        if blueprint_obj.cpus:
+            if float(blueprint_obj.cpus) > 0.5:
+                raise BusinessLogicError("Please set cpus to a value under 0.5")
+
+            cpus = float(blueprint_obj.cpus)
+
 
         parsed_ram = DOCKER_MEM_REGEX.match(mem_limit)
         ram_number = int(parsed_ram.group(1))
@@ -168,8 +175,9 @@ class ContainerInstance(db.Model):
             environment=blueprint_obj.render_environment(team.seed),
             name=ContainerInstance.render_container_name(team.id, blueprint_obj.name, blueprint_obj.challenge_id),
             detach=True,
+            # Default period of o .1 second
             cpu_period=100000,
-            cpu_quota=10000,
+            cpu_quota=round(cpus * DOCKER_QUOTA_CONST),
             pids_limit=512,
             mem_limit=mem_limit,
             mem_reservation=mem_resv,


### PR DESCRIPTION
Allows for configurable cpu limits. We might need to make a db change as Sql alchemy defaulted Numeric to have no actual decimal precision on a type thats supposed to be used for floats. Its a pretty simple update at least.