### PR TITLE
Break event sidebar into tabs, add grid for event feedback

### DIFF
--- a/frontend/src/hooks/feedback.ts
+++ b/frontend/src/hooks/feedback.ts
@@ -39,6 +39,11 @@ export function submitChallengeFeedback(eventId: number, challengeId: number, fe
 }
 
 // ADMIN ROUTES
+export function useEventFeedback(eventId: number) {
+  return useSWR<Feedback[]>(
+    eventId ? `/admin/events/${eventId}/feedback` : null,
+  );
+}
 
 export function useChallengeFeedback(eventId: number, challengeId: number) {
   return useSWR<Feedback[]>(

--- a/frontend/src/routes/admin/events/EventSidebar.tsx
+++ b/frontend/src/routes/admin/events/EventSidebar.tsx
@@ -1,18 +1,20 @@
 import { DeploymentIcon, EventIcon, TeamIcon } from '@/constants';
-import { useAdminEventChallenges } from '@/hooks/challenge';
 import type { Event } from '@/types';
+import { Tabs } from '@radix-ui/themes';
 import AdminLink from 'components/AdminLink';
 import AdminSidebar from 'components/AdminSidebar';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
-import { ErrorCallout } from 'components/Callouts';
-import EventHeader from 'components/EventHeader';
 import { useId } from 'react';
-import AdminChallengeCard from './AdminChallengeCard';
-import ChallengeUploadModal from './ChallengeUploadModal';
+import { useSearchParams } from 'react-router';
 import EventModal from './EventModal';
+import EventChallengesTab from './SidebarTabs/EventChallengesTab';
+import EventDetailsTab from './SidebarTabs/EventDetailsTab';
+import EventFeedbackTab from './SidebarTabs/EventFeedbackTab';
+import EventGameplayTab from './SidebarTabs/EventGameplayTab';
+import EventRegistrationTab from './SidebarTabs/EventRegistrationTab';
 
 export default function EventSidebar({ entity }: { entity: Event }) {
-  const { data : challenges, error } = useAdminEventChallenges(entity.id);
+  const [ searchParams, setSearchParams ] = useSearchParams();
   const headerId = useId();
 
   return (
@@ -33,21 +35,53 @@ export default function EventSidebar({ entity }: { entity: Event }) {
         <EventModal eventToUpdate={entity} />
       </AdminSidebarHeader>
 
-      <EventHeader
-        event={entity}
-      />
-
-      <AdminSidebarHeader title="Challenges">
-        <ChallengeUploadModal eventId={entity.id} />
-      </AdminSidebarHeader>
-
-      {error && <ErrorCallout>{error.message}</ErrorCallout>}
-
-      {challenges && challenges.length > 0 && (
-        challenges.map((challenge) => (
-          <AdminChallengeCard key={challenge.id} challenge={challenge} />
-        ))
-      )}
+      <Tabs.Root
+        className="h-full flex flex-col"
+        value={searchParams.get('tab') || 'details'}
+        onValueChange={
+          (value) => {
+            if (value === searchParams.get('tab')) return;
+            setSearchParams((prev) => {
+              prev.set('tab', value);
+              return prev;
+            });
+          }
+        }
+        activationMode="manual"
+      >
+        <Tabs.List className="mb-3 shrink-0">
+          <Tabs.Trigger value="details">
+            Details
+          </Tabs.Trigger>
+          <Tabs.Trigger value="registration">
+            Registration
+          </Tabs.Trigger>
+          <Tabs.Trigger value="gameplay">
+            Gameplay
+          </Tabs.Trigger>
+          <Tabs.Trigger value="challenges">
+            Challenges
+          </Tabs.Trigger>
+          <Tabs.Trigger value="feedback">
+            Feedback
+          </Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="details">
+          <EventDetailsTab event={entity} />
+        </Tabs.Content>
+        <Tabs.Content value="registration">
+          <EventRegistrationTab event={entity} />
+        </Tabs.Content>
+        <Tabs.Content value="gameplay">
+          <EventGameplayTab event={entity} />
+        </Tabs.Content>
+        <Tabs.Content value="challenges">
+          <EventChallengesTab event={entity} />
+        </Tabs.Content>
+        <Tabs.Content value="feedback" className="flex-grow">
+          <EventFeedbackTab event={entity} />
+        </Tabs.Content>
+      </Tabs.Root>
     </AdminSidebar>
   );
 }

--- a/frontend/src/routes/admin/events/SidebarTabs/EventChallengesTab.tsx
+++ b/frontend/src/routes/admin/events/SidebarTabs/EventChallengesTab.tsx
@@ -1,0 +1,27 @@
+import { useAdminEventChallenges } from '@/hooks/challenge';
+import type { Event } from '@/types';
+import { Flex } from '@radix-ui/themes';
+import AdminSidebarHeader from 'components/AdminSidebarHeader';
+import { ErrorCallout } from 'components/Callouts';
+import AdminChallengeCard from '../AdminChallengeCard';
+import ChallengeUploadModal from '../ChallengeUploadModal';
+
+export default function EventChallengesTab({ event }: {event: Event}) {
+  const { data : challenges, error } = useAdminEventChallenges(event.id);
+
+  return (
+    <Flex direction="column" gap="3">
+      <AdminSidebarHeader title="Challenges">
+        <ChallengeUploadModal eventId={event.id} />
+      </AdminSidebarHeader>
+
+      {error && <ErrorCallout>{error.message}</ErrorCallout>}
+
+      {challenges && challenges.length > 0 && (
+        challenges.map((challenge) => (
+          <AdminChallengeCard key={challenge.id} challenge={challenge} />
+        ))
+      )}
+    </Flex>
+  );
+}

--- a/frontend/src/routes/admin/events/SidebarTabs/EventDetailsTab.tsx
+++ b/frontend/src/routes/admin/events/SidebarTabs/EventDetailsTab.tsx
@@ -1,0 +1,15 @@
+import type { Event } from '@/types';
+import { Flex } from '@radix-ui/themes';
+import EventGraphic from 'components/EventGraphic';
+import RadixMarkdown from 'components/RadixMarkdown';
+
+export default function EventDetailsTab({ event }: {event: Event}) {
+  return (
+    <Flex direction="column" gap="3">
+      <EventGraphic event={event} className="w-64 rounded-lg shadow-lg" />
+      <RadixMarkdown>
+        {event.description || ''}
+      </RadixMarkdown>
+    </Flex>
+  );
+}

--- a/frontend/src/routes/admin/events/SidebarTabs/EventFeedbackTab.tsx
+++ b/frontend/src/routes/admin/events/SidebarTabs/EventFeedbackTab.tsx
@@ -1,0 +1,74 @@
+import { radixTheme } from '@/grid';
+import { useEventFeedback } from '@/hooks/feedback';
+import type { Event, Feedback } from '@/types';
+import { Flex, Spinner } from '@radix-ui/themes';
+import type { ColDef } from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+
+const colDefs = [
+  {
+    field : 'user_name',
+    headerName : 'User',
+    sortable : true,
+    filter : true,
+    width : 200,
+  },
+  {
+    field : 'feedback_data.role',
+    headerName : 'NICE Role',
+    sortable : false,
+    filter : true,
+    width : 200,
+  },
+  {
+    field : 'feedback_data.education',
+    headerName : 'Education',
+    sortable : false,
+    filter : true,
+    width : 200,
+  },
+  {
+    field : 'feedback_data.cyber_experience',
+    headerName : 'Years of Experience',
+    sortable : false,
+    filter : true,
+    width : 200,
+  },
+  {
+    field : 'feedback_data.participation_reason',
+    headerName : 'Participation Reason',
+    sortable : false,
+    filter : true,
+    width : 300,
+  },
+  {
+    field : 'feedback_data.participation_again',
+    headerName : 'Future Participation',
+  },
+  {
+    field : 'feedback_data.additional_feedback',
+    headerName : 'Other Feedback',
+    sortable : false,
+    filter : true,
+    minWidth : 400,
+    autoHeight : true,
+    wrapText : true,
+    cellStyle : { lineHeight : '20px', paddingTop : '8px', paddingBottom : '8px' },
+  },
+] as ColDef<Feedback>[];
+
+export default function EventFeedbackTab({ event }: {event: Event}) {
+  const { data : feedback, isLoading } = useEventFeedback(event.id);
+
+  return (
+    <Flex direction="column" gap="3" className="h-full">
+      <AgGridReact
+        columnDefs={colDefs}
+        rowData={feedback}
+        loading={isLoading}
+        loadingOverlayComponent={Spinner}
+        theme={radixTheme}
+      />
+    </Flex>
+  );
+}

--- a/frontend/src/routes/admin/events/SidebarTabs/EventGameplayTab.tsx
+++ b/frontend/src/routes/admin/events/SidebarTabs/EventGameplayTab.tsx
@@ -1,0 +1,16 @@
+import type { Event } from '@/types';
+import { Flex } from '@radix-ui/themes';
+import Statistic from 'components/Statistic';
+
+export default function EventGameplayTab({ event }: {event: Event}) {
+  return (
+    <Flex direction="column" gap="3">
+      <Statistic label="Max Team Size" value={event.max_team_size} />
+      <Statistic label="Event Starts" value={event.start_time?.toLocaleString() || 'N/A'} />
+      <Statistic label="Event Ends" value={event.end_time?.toLocaleString() || 'N/A'} />
+      <Statistic label="Time Limit" value={event.time_limit_minutes ? `${event.time_limit_minutes} minutes` : 'N/A'} />
+      <Statistic label="Hints Enabled" value={event.hints_enabled ? 'Yes' : 'No'} />
+      <Statistic label="Leaderboard Visible" value={event.show_leaderboard ? 'Yes' : 'No'} />
+    </Flex>
+  );
+}

--- a/frontend/src/routes/admin/events/SidebarTabs/EventRegistrationTab.tsx
+++ b/frontend/src/routes/admin/events/SidebarTabs/EventRegistrationTab.tsx
@@ -1,0 +1,15 @@
+import type { Event } from '@/types';
+import { Flex } from '@radix-ui/themes';
+import Statistic from 'components/Statistic';
+
+export default function EventRegistrationTab({ event }: {event: Event}) {
+  return (
+    <Flex direction="column" gap="3">
+      <Statistic label="Visibility" value={event.public ? 'Public' : 'Private'} />
+      <Statistic label="Registration Open" value={event.registration_open ? 'Yes' : 'No'} />
+      <Statistic label="Registration Starts" value={event.registration_start_date?.toLocaleString() || 'N/A'} />
+      <Statistic label="Registration Ends" value={event.registration_end_date?.toLocaleString() || 'N/A'} />
+      <Statistic label="Allow Team Management" value={event.locked ? 'No' : 'Yes'} />
+    </Flex>
+  );
+}


### PR DESCRIPTION
<img width="1130" height="1284" alt="image" src="https://github.com/user-attachments/assets/880dc0b6-4034-4918-aa46-d7c08b6e3b33" />

Splits event admin sidebar into tabs. Challenge list has been moved to the challenges tab, and the Feedback tab contains a grid showing submitted event feedback (see #575)