### PR TITLE
Keep italic font consistent with other UI

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,6 +18,8 @@
 
 .radix-themes {
   --default-font-family: Inter, sans-serif;
+  --em-font-family: Inter, sans-serif;
+  --em-font-size-adjust: 1.0;
 }
 
 @supports (font-variation-settings: normal) {


### PR DESCRIPTION
Radix uses a serif font for italics by default, which looks a bit off when mixed with sans-serif text. Can also throw off line height in paragraph contexts due to the size modifier radix applies

<img width="354" height="52" alt="image" src="https://github.com/user-attachments/assets/51e79c3d-e386-48e5-b763-0a0547017875" />

The serif font can also vary based on font availability and OS, so it won't be consistent for everyone.

This PR updates it to match the rest of the UI, and ensures it's consistent across systems by using the Inter font that we serve:

<img width="354" height="52" alt="image" src="https://github.com/user-attachments/assets/d0118971-83f7-4580-b602-61cbf7f84454" />