### PR TITLE
Sort EventGrid by date, allow grouping by year

### DIFF
--- a/frontend/src/components/EventGrid.tsx
+++ b/frontend/src/components/EventGrid.tsx
@@ -1,29 +1,68 @@
 import type { Event } from '@/types';
-import { Grid, Skeleton } from '@radix-ui/themes';
+import {
+  Box,
+  Flex,
+  Grid,
+  Heading,
+  Skeleton,
+} from '@radix-ui/themes';
+import { groupBy } from 'lodash';
+import { useMemo } from 'react';
 import EventCard from 'routes/dashboard/EventCard';
 
-export default function EventGrid({ events, loading = false } : {events: Event[], loading?: boolean}) {
-  return (
-    <Grid
-      columns={{
-        initial : '1', xs : '1', sm : '2', lg : '3',
-      }}
-      gap="3"
-    >
-      {loading && (
-      <>
-        <Skeleton className="min-h-48 !rounded-lg" />
-        <Skeleton className="min-h-48 !rounded-lg" />
-        <Skeleton className="min-h-48 !rounded-lg" />
-      </>
-      )}
+export default function EventGrid({ events, loading = false, group = false } : { events: Event[], loading?: boolean, group?: boolean }) {
+  const sortedEvents = useMemo(() => events.slice().sort((a, b) => {
+    const dateA = a.start_time?.getTime() || 0;
+    const dateB = b.start_time?.getTime() || 0;
+    return dateA - dateB;
+  }), [ events ]);
 
-      {events?.map((event) => (
-        <EventCard
-          key={event.id}
-          event={event}
-        />
-      ))}
-    </Grid>
+  const groupedEvents = useMemo(() => {
+    if (!group) return { Unknown : sortedEvents };
+    return groupBy(sortedEvents, (event) => event.start_time?.getFullYear()?.toString() || 'Unknown');
+  }, [ sortedEvents, group ]);
+
+  return (
+    <Flex direction="column" gap="8">
+      {loading && (
+        <Box>
+          {group && <Heading className="!mb-3" size="4"><Skeleton>YYYY</Skeleton></Heading>}
+          <Grid
+            columns={{
+              initial : '1', xs : '1', sm : '2', lg : '3',
+            }}
+            gap="3"
+          >
+            <Skeleton className="min-h-48 !rounded-lg" />
+            <Skeleton className="min-h-48 !rounded-lg" />
+            <Skeleton className="min-h-48 !rounded-lg" />
+          </Grid>
+        </Box>
+      )}
+      {[ ...Object.entries(groupedEvents) ]
+        .reverse()
+        .map(([ year, eventsInYear ]) => (
+          <section key={year}>
+            {year !== 'Unknown' && (
+              <Heading key={year} className="!mb-3" size="4">
+                {year}
+              </Heading>
+            )}
+            <Grid
+              columns={{
+                initial : '1', xs : '1', sm : '2', lg : '3',
+              }}
+              gap="3"
+            >
+              {eventsInYear.map((event) => (
+                <EventCard
+                  key={event.id}
+                  event={event}
+                />
+              ))}
+            </Grid>
+          </section>
+        ))}
+    </Flex>
   );
 }

--- a/frontend/src/components/EventGrid.tsx
+++ b/frontend/src/components/EventGrid.tsx
@@ -44,7 +44,7 @@ export default function EventGrid({ events, loading = false, group = false } : {
         .map(([ year, eventsInYear ]) => (
           <section key={year}>
             {year !== 'Unknown' && (
-              <Heading key={year} className="!mb-3" size="4">
+              <Heading className="!mb-3" size="4">
                 {year}
               </Heading>
             )}

--- a/frontend/src/routes/dashboard/EventCard.tsx
+++ b/frontend/src/routes/dashboard/EventCard.tsx
@@ -19,7 +19,7 @@ export default function EventCard({ event }: { event: Event }) {
   return (
     <Card asChild>
       <Link to={`/events/${event.id}`}>
-        <Flex direction="row" gap="4">
+        <Flex direction="row" gap="4" className="h-full">
           <Inset side="left" className="empty:hidden shrink-0">
             <EventGraphic event={event} className="w-32 shadow !rounded-none" />
           </Inset>

--- a/frontend/src/routes/dashboard/PastEvents.tsx
+++ b/frontend/src/routes/dashboard/PastEvents.tsx
@@ -24,7 +24,7 @@ export default function PastEvents() {
   return (
     <>
       <Heading size="6">Your Past Events</Heading>
-      <EventGrid events={pastEvents || []} />
+      <EventGrid events={pastEvents || []} group />
     </>
   );
 }

--- a/frontend/src/routes/events/AvailableEvents.tsx
+++ b/frontend/src/routes/events/AvailableEvents.tsx
@@ -14,9 +14,9 @@ export default function AvailableEvents() {
         <Heading size="9">Events</Heading>
       </HeaderContainer>
 
-      <Container size="4">
+      <Container size="4" my="8">
         {error && (<ErrorCallout className="mb-3">{error.message}</ErrorCallout>)}
-        <EventGrid events={events || []} loading={isLoading} />
+        <EventGrid events={events || []} loading={isLoading} group />
       </Container>
     </>
   );


### PR DESCRIPTION
Resolves #587

<img width="1232" height="904" alt="image" src="https://github.com/user-attachments/assets/dc46a408-b7ac-4081-92ae-e29f897aafa4" />

Within each year, dates are sorted ascending to remain consistent with requested ordering, years themselves are sorted descending (so the most current set of events will show first.) Events without dates are in their own section at the top.