### PR TITLE
Disable banning admins on the frontend, matching #600

### DIFF
--- a/frontend/src/routes/admin/users/BanUserModal.tsx
+++ b/frontend/src/routes/admin/users/BanUserModal.tsx
@@ -20,7 +20,11 @@ export default function BanUserModal({ user }: {user: AdminUser}) {
     <Modal
       title={unban ? 'Unban User?' : 'Ban User?'}
       trigger={(
-        <Button color={COLOR_NEGATIVE} variant="soft">
+        <Button
+          color={COLOR_NEGATIVE}
+          variant="soft"
+          disabled={!unban && user.roles.includes('admin')}
+        >
           <Icon />
           {unban ? 'Unban' : 'Ban'}
         </Button>


### PR DESCRIPTION
Frontend change to reflect #600. Ban button is disabled for admin users:

<img width="1130" height="53" alt="image" src="https://github.com/user-attachments/assets/580722d8-4761-4053-ab70-f6c54a417853" />
