### PR TITLE
fix redis subscriber dying in prod by using socketio.start_background…

### DIFF
--- a/backend/ng/core/utils/redis_notifications.py
+++ b/backend/ng/core/utils/redis_notifications.py
@@ -103,11 +103,7 @@ class RedisNotificationManager:
             )
             return
 
-        self.subscriber_thread = threading.Thread(
-            target = self._subscriber_worker,
-            daemon = True
-        )
-        self.subscriber_thread.start()
+        self.socketio.start_background_task(self._subscriber_worker)
         logger.info("Redis notification subscriber started")
 
     def _subscriber_worker(self):

--- a/backend/ng/core/utils/redis_notifications.py
+++ b/backend/ng/core/utils/redis_notifications.py
@@ -3,7 +3,6 @@ Redis pub/sub system for inter-server notification communication
 """
 
 import json
-import threading
 import time
 import redis
 from flask import current_app


### PR DESCRIPTION
### Confirmed 
#### *tested with DEBUG=false to run gunicorn + gevent worker (prod mode)*
---
<img width="923" height="350" alt="Screenshot_20251228_005849" src="https://github.com/user-attachments/assets/60dade6d-6cb0-42f8-9ace-80803e1cfc9f" />
<img width="923" height="104" alt="Screenshot_20251228_005933" src="https://github.com/user-attachments/assets/076df4d8-5893-4e14-a039-b03839303e3d" />
--

Closes issue: https://github.com/CyberSkyline/ctf-ng/issues/461