### PR TITLE
Check role instead of type for manual award validator

### DIFF
--- a/backend/ng/core/tests/system/test_core_validation_generic.py
+++ b/backend/ng/core/tests/system/test_core_validation_generic.py
@@ -11,6 +11,7 @@ from CTFd.models import Users
 from ...exceptions import ValidationError
 from ...utils import utc_now
 from ...utils.validator import BaseValidator
+from ng.permissions.models.UserRole import UserRole
 
 class TestBaseValidator:
     """Test the base validator functionality."""
@@ -395,7 +396,7 @@ class TestAdminIdValidation:
         parsed_data = validator.validate()
         assert parsed_data["admin_id"] == admin.id
 
-        db_admin.type = "user"
+        UserRole.update_user_roles(admin.id, {"roles": []})
         db_session.commit()
 
         validator = BaseValidator()

--- a/backend/ng/core/utils/validator.py
+++ b/backend/ng/core/utils/validator.py
@@ -264,6 +264,10 @@ class BaseValidator:
         """
         Validate that a user ID belongs to an admin user
         """
+        # local imports needed here to avoid module dependency cycle
+        from ...permissions.controllers.get_user_roles import get_user_roles
+        from ...permissions.models.enums import RoleEnum
+
         try:
             user_id = int(value)
         except (ValueError, TypeError):
@@ -276,7 +280,7 @@ class BaseValidator:
             self.errors[field] = f"{friendly_name} with ID {user_id} does not exist"
             return
 
-        if user.type != "admin":
+        if RoleEnum.ADMIN not in get_user_roles(user_id):
             self.errors[field] = "User must be an admin to perform this action"
             return
 

--- a/backend/ng/scoring/tests/test_manual_point_award_model.py
+++ b/backend/ng/scoring/tests/test_manual_point_award_model.py
@@ -4,9 +4,7 @@ Tests for the ManualPointAward model
 
 import pytest
 from unittest.mock import patch
-from datetime import datetime, timezone, UTC
-
-from CTFd.models import Users
+from datetime import datetime, UTC
 
 from ...core.exceptions import ValidationError
 
@@ -275,13 +273,10 @@ class TestFindFilteredAwards:
         assert len(awards) == 1
         assert awards[0].team_id == team_with_member.id
 
-    def test_find_by_admin_id(self, db_session, admin, user, team_with_member, event):
+    def test_find_by_admin_id(self, db_session, admin, user, user_factory, team_with_member, event):
         """Test filtering awards by admin_id"""
         # Create another admin
-        other_admin = Users(name="admin2", email="admin2@example.com", password="password", type="admin")
-        other_admin.verified = True
-        db_session.add(other_admin)
-        db_session.commit()
+        other_admin = user_factory(name="admin2", email="admin2@example.com", admin=True)
 
         # Create awards by different admins
         ManualPointAward.create_award(admin_id=admin.id, team_id=team_with_member.id, points=100, reason="Award 1")


### PR DESCRIPTION
The code here was checking ctfd user type instead of our role field for determining whether a user is admin. Since our role update endpoints and other auth code don't touch this field, we should be using our role field here for consistency with the rest of the system and to ensure role changes in the UI are properly applied to everything. (This is the only spot where user.type is checked like this)