### PR TITLE
Improved efficiency with queries that yield large results

### DIFF
--- a/backend/ng/announcements/models/Announcement.py
+++ b/backend/ng/announcements/models/Announcement.py
@@ -7,16 +7,17 @@ from __future__ import annotations
 from enum import Enum
 from typing import (
     Any,
-    TypedDict,
     NotRequired,
+    TypedDict,
 )
 
 from CTFd.models import db
+from sqlalchemy.orm import joinedload
 
 from ... import config
 from ...core.utils import utc_now
-from ...core.utils.validator import BaseValidator
 from ...core.utils.sqlalchemy_types import EnumWithUnknown
+from ...core.utils.validator import BaseValidator
 from ...notifications.models import Notification
 
 
@@ -257,7 +258,14 @@ class Announcement(db.Model):
         """
         Get all announcements ordered by newest first
         """
-        return cls.query.order_by(cls.created_at.desc()).all()
+        return (cls.query
+            .order_by(cls.created_at.desc())
+            .options(
+                joinedload(cls.sender),
+                joinedload(cls.event)
+            )
+            .all()
+        )
 
     @classmethod
     def get_active_announcements(

--- a/backend/ng/challenge/models/Challenge.py
+++ b/backend/ng/challenge/models/Challenge.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from typing import Any, TypedDict, NotRequired, TYPE_CHECKING
-from sqlalchemy.orm import Mapped
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from CTFd.models import db
+from sqlalchemy.orm import Mapped, joinedload, selectinload
 
-from ...event.models import Event
 from ...core.utils.validator import BaseValidator
+from ...event.models import Event
 
 if TYPE_CHECKING:
-    from ..models import ChallengeTag, ChallengeVariable, ContainerBlueprint, Hint, Question, ChallengeYaml
+    from ..models import ChallengeTag, ChallengeVariable, ChallengeYaml, ContainerBlueprint, Hint, Question
 
 MAX_CHALLENGE_NAME_LENGTH = 128
 MAX_CHALLENGE_DESCRIPTION_LENGTH = 4096
@@ -158,7 +158,15 @@ class Challenge(db.Model):
 
     @classmethod
     def get_all_challenges(cls) -> list[Challenge]:
-        return cls.query.all()
+        return (
+            cls
+            .query
+            .options(
+                joinedload(cls.event),
+                selectinload(cls.questions),
+            )
+            .all()
+        )
 
     def render(self, team):
         """
@@ -166,20 +174,28 @@ class Challenge(db.Model):
         :param team: The team to render the challenge for.
         :return: A dictionary representation of the challenge for the team.
         """
+        from ...scoring.models import Attempt
         from .Hint import Hint
         from .Question import Question
-        from ...scoring.models import Attempt
 
-        hints = Hint.query.filter_by(challenge_id=self.id).all()
+        hints = Hint.query.filter_by(challenge_id=self.id).options(joinedload(Hint.challenge)).all()
 
         data = {
             "challenge": self.serialize(),
             "questions": Question.query.filter_by(challenge_id=self.id).all(),
             "hints": [hint.serialize(team=team) for hint in hints] if self.event.hints_enabled else [],
-            "attempts": Attempt.query.filter_by(
-                team_id=team.id,
-                challenge_id=self.id
-            ).all(),
+            "attempts": Attempt.query
+                .filter_by(
+                    team_id=team.id,
+                    challenge_id=self.id
+                )
+                .options(
+                    joinedload(Attempt.user),
+                    joinedload(Attempt.team),
+                    joinedload(Attempt.challenge),
+                    joinedload(Attempt.question),
+                )
+                .all()
         }
 
         return data

--- a/backend/ng/challenge/routes/admin_routes.py
+++ b/backend/ng/challenge/routes/admin_routes.py
@@ -1,13 +1,15 @@
 import base64
-from flask_restx import Namespace, Resource
 
-from ..controllers.admin import import_challenge_from_yaml, update_challenge_from_yaml, lint_challenge
-from ..models import Challenge, ContainerBlueprint
-from ...core.middleware.loaders import load_event, load_challenge
-from ...core.middleware.loaders._util import LoaderType
+from flask_restx import Namespace, Resource
+from sqlalchemy.orm import joinedload
+
 from ...core.middleware.auth import admin_endpoint
+from ...core.middleware.loaders import load_challenge, load_event
+from ...core.middleware.loaders._util import LoaderType
 from ...core.utils.api import success_response
 from ...event.models import Event
+from ..controllers.admin import import_challenge_from_yaml, lint_challenge, update_challenge_from_yaml
+from ..models import Challenge, ContainerBlueprint
 
 challenge_admin_namespace = Namespace("/admin/challenges", description="challenge management")
 
@@ -160,7 +162,16 @@ class ChallengeAttempts(Resource):
         """
         from ...scoring.models import Attempt
 
-        attempts = Attempt.query.filter_by(challenge_id=challenge.id).all()
+        attempts = (Attempt.query
+            .filter_by(challenge_id=challenge.id)
+            .options(
+                joinedload(Attempt.user),
+                joinedload(Attempt.team),
+                joinedload(Attempt.challenge),
+                joinedload(Attempt.question),
+            )
+            .all()
+        )
 
         return success_response(attempts)
 

--- a/backend/ng/event/models/Event.py
+++ b/backend/ng/event/models/Event.py
@@ -8,13 +8,13 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from CTFd.models import db
-from sqlalchemy import CheckConstraint, func, JSON
-from sqlalchemy.orm import Mapped
+from sqlalchemy import JSON, CheckConstraint, func
+from sqlalchemy.orm import Mapped, joinedload
 
 from ... import config
+from ...core import BusinessLogicError
 from ...core.utils.validator import BaseValidator
 from ...event.models.Demographic import Demographic
-from ...core import BusinessLogicError
 
 
 class Event(db.Model):
@@ -280,12 +280,12 @@ class Event(db.Model):
     def get_all_teams(self):
         from ...team.models.Team import Team
 
-        return Team.query.filter_by(event_id=self.id).all()
+        return Team.query.filter_by(event_id=self.id).options(joinedload(Team.event)).all()
 
     def get_all_challenges(self):
         from ...challenge.models.Challenge import Challenge
 
-        return Challenge.query.filter_by(event_id=self.id).all()
+        return Challenge.query.filter_by(event_id=self.id).options(joinedload(Challenge.event)).all()
 
     @classmethod
     def find_by_id(cls, event_id: int):
@@ -335,7 +335,7 @@ class Event(db.Model):
         from ...team.models.Team import Team
         from ...team.models.TeamMember import TeamMember
 
-        teams_in_event = Team.query.filter_by(event_id=self.id).all()
+        teams_in_event = Team.query.filter_by(event_id=self.id).options(joinedload(Team.event)).all()
 
         self.team_count = len(teams_in_event)
         self.total_members = TeamMember.query.filter_by(event_id=self.id).count()

--- a/backend/ng/feedback/controllers/admin_actions/list_event_feedback.py
+++ b/backend/ng/feedback/controllers/admin_actions/list_event_feedback.py
@@ -1,14 +1,18 @@
 """
 Get event feedback
 """
+from sqlalchemy.orm import joinedload
 
 from ...models import Feedback
 
 
 def list_event_feedback(event_id: int) -> list[Feedback]:
-    return (
-        Feedback.query.filter_by(
+    return (Feedback.query
+        .filter_by(
             event_id = event_id,
             challenge_id = None
-        ).order_by(Feedback.updated_at.desc()).all()
+        )
+        .order_by(Feedback.updated_at.desc())
+        .options(joinedload(Feedback.user))
+        .all()
     )

--- a/backend/ng/feedback/models/Feedback.py
+++ b/backend/ng/feedback/models/Feedback.py
@@ -8,12 +8,12 @@ from typing import Any, TypedDict
 
 from CTFd.models import db
 from sqlalchemy import JSON
+from sqlalchemy.orm import joinedload
 
-from ...core.utils import utc_now
-from ...core.exceptions import ValidationError
-from ...core.utils.validator import BaseValidator
 from ... import config
-
+from ...core.exceptions import ValidationError
+from ...core.utils import utc_now
+from ...core.utils.validator import BaseValidator
 
 
 class SerializedFeedback(TypedDict):
@@ -214,4 +214,10 @@ class Feedback(db.Model):
         if challenge_id is not None:
             query = query.filter_by(challenge_id = challenge_id)
 
-        return query.order_by(cls.updated_at.desc()).all()
+        return (query
+            .order_by(cls.updated_at.desc())
+            .options(
+                joinedload(cls.user)
+            )
+            .all()
+        )

--- a/backend/ng/notifications/models/Notification.py
+++ b/backend/ng/notifications/models/Notification.py
@@ -7,16 +7,17 @@ from __future__ import annotations
 from enum import Enum
 from typing import (
     Any,
-    TypedDict,
     NotRequired,
+    TypedDict,
 )
 
 from CTFd.models import db
+from sqlalchemy.orm import joinedload
 
 from ... import config
 from ...core.utils import utc_now
-from ...core.utils.validator import BaseValidator
 from ...core.utils.sqlalchemy_types import EnumWithUnknown
+from ...core.utils.validator import BaseValidator
 
 
 class NotificationType(str, Enum):
@@ -405,7 +406,18 @@ class Notification(db.Model):
                 (cls.expires_at.is_(None)) | (cls.expires_at > utc_now())
             )
 
-        return query.order_by(cls.created_at.desc()).all()
+        return (query
+            .order_by(cls.created_at.desc())
+            .options(
+                joinedload(cls.recipient),
+                joinedload(cls.sender),
+                joinedload(cls.ticket),
+                joinedload(cls.team),
+                joinedload(cls.event),
+                joinedload(cls.challenge)
+            )
+            .all()
+        )
 
     @classmethod
     def get_unread_count(cls, recipient_id: int) -> int:

--- a/backend/ng/scoring/models/Attempt.py
+++ b/backend/ng/scoring/models/Attempt.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 from CTFd.models import db
+from sqlalchemy.orm import joinedload
 
 from ... import config
 from ...core.exceptions import (
@@ -296,7 +297,16 @@ class Attempt(db.Model):
         if is_correct is not None:
             query = query.filter_by(is_correct=is_correct)
 
-        return query.order_by(cls.timestamp.desc()).all()  # type: ignore[no-any-return]
+        return (query
+            .order_by(cls.timestamp.desc())
+            .options(
+                joinedload(cls.user),
+                joinedload(cls.team),
+                joinedload(cls.challenge),
+                joinedload(cls.question),
+            )
+            .all()
+        )
 
     def delete_attempt(self, commit: bool = True) -> None:
         """

--- a/backend/ng/scoring/models/HintRedemption.py
+++ b/backend/ng/scoring/models/HintRedemption.py
@@ -3,21 +3,22 @@ Defines the HintRedemption model for tracking hint usage.
 """
 
 from __future__ import annotations
-from typing import (
-    Any,
-    TypedDict,
-    NotRequired,
-)
 
 from datetime import datetime
+from typing import (
+    Any,
+    NotRequired,
+    TypedDict,
+)
 
 from CTFd.models import db
+from sqlalchemy.orm import joinedload
 
-from ...core.utils import utc_now
 from ...core.exceptions import (
-    ValidationError,
     BusinessLogicError,
+    ValidationError,
 )
+from ...core.utils import utc_now
 from ...core.utils.validator import BaseValidator
 
 
@@ -116,8 +117,8 @@ class HintRedemption(db.Model):
         """
         # LAZY-IMPORT: Tagging all necessary lazy imports for easy searchability & visibility.
         from ...challenge.models.Hint import Hint
-        from ...team.models.TeamMember import TeamMember
         from ...event.models.Event import Event
+        from ...team.models.TeamMember import TeamMember
 
         # TODO: Move most logic to permission check system
         member = TeamMember.find_by_user_and_team(user_id, team_id)
@@ -243,6 +244,7 @@ class HintRedemption(db.Model):
         Find hint redemptions based on filters
         """
         # LAZY-IMPORT
+        from ...challenge.models.Challenge import Challenge
         from ...challenge.models.Hint import Hint
 
         query = cls.query
@@ -256,7 +258,19 @@ class HintRedemption(db.Model):
         if challenge_id is not None:
             query = query.join(Hint).filter(Hint.challenge_id == challenge_id)
 
-        return query.order_by(cls.timestamp.desc()).all()  # type: ignore[no-any-return]
+        return (query
+            .order_by(cls.timestamp.desc())
+            .options(
+                joinedload(cls.user),
+                joinedload(cls.team),
+                joinedload(cls.hint
+                    .joinedload(Hint.challenge
+                        .joinedload(Challenge.event)
+                    )
+                ),
+            )
+            .all()
+        )
 
     @classmethod
     def find_by_team_and_event(cls, team_id: int, event_id: int) -> list[HintRedemption]:
@@ -271,8 +285,8 @@ class HintRedemption(db.Model):
             List of hint redemptions for the team in the event
         """
         # LAZY-IMPORT
-        from ...challenge.models.Hint import Hint
         from ...challenge.models.Challenge import Challenge
+        from ...challenge.models.Hint import Hint
 
         return (
             cls.query

--- a/backend/ng/scoring/models/HintRedemption.py
+++ b/backend/ng/scoring/models/HintRedemption.py
@@ -263,11 +263,9 @@ class HintRedemption(db.Model):
             .options(
                 joinedload(cls.user),
                 joinedload(cls.team),
-                joinedload(cls.hint
-                    .joinedload(Hint.challenge
+                joinedload(cls.hint)
+                    .joinedload(Hint.challenge)
                         .joinedload(Challenge.event)
-                    )
-                ),
             )
             .all()
         )

--- a/backend/ng/scoring/models/Score.py
+++ b/backend/ng/scoring/models/Score.py
@@ -227,8 +227,7 @@ class Score(db.Model):
         """
         # LAZY-IMPORT
         from ...team.models.Team import Team
-        query = (
-            cls.query
+        query = (cls.query
             .join(cls.team)
             .filter(cls.event_id == event_id)
             .filter(
@@ -236,9 +235,10 @@ class Score(db.Model):
                 Team.start_timestamp.isnot(None),
             )
             .options(
-                joinedload(Score.team)
-                .joinedload(Team.members)
-                .joinedload(TeamMember.sponsor)
+                joinedload(cls.event),
+                joinedload(cls.team)
+                    .joinedload(Team.members)
+                    .joinedload(TeamMember.sponsor)
             )
             .order_by(cls.points.desc(), cls.last_correct_offset.asc())
         )
@@ -329,7 +329,7 @@ class Score(db.Model):
 
         if limit is not None:
             query = query.limit(limit)
-        return query.all()  # type: ignore[no-any-return]
+        return query.options(joinedload(cls.event)).all()
 
     @classmethod
     def clear_leaderboard_cache(cls, event_id: int | None = None) -> None:

--- a/backend/ng/support/models/Ticket.py
+++ b/backend/ng/support/models/Ticket.py
@@ -3,16 +3,17 @@ Defines the Ticket database model for support ticket metadata.
 """
 
 from __future__ import annotations
-from typing import Any, TYPE_CHECKING, TypedDict, NotRequired
-from sqlalchemy.ext.hybrid import hybrid_property
 
-from CTFd.models import db, Users
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
+
+from CTFd.models import Users, db
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import joinedload
 
 from ... import config
+from ...core.exceptions import BusinessLogicError, NotFoundError
 from ...core.utils import utc_now
 from ...core.utils.validator import BaseValidator
-from ...core.exceptions import NotFoundError, BusinessLogicError
-
 
 if TYPE_CHECKING:
     from .TicketMessage import TicketMessage
@@ -420,7 +421,18 @@ class Ticket(db.Model):
             if team_id is not None:
                 query = query.filter_by(team_id=team_id)
 
-        return query.order_by(cls.last_updated.desc()).all()
+        return (
+            query
+                .order_by(cls.last_updated.desc())
+                .options(
+                    joinedload(cls.author),
+                    joinedload(cls.assigned_user),
+                    joinedload(cls.event),
+                    joinedload(cls.team),
+                    joinedload(cls.challenge)
+                )
+                .all()
+        )
 
     def add_message(self, text: str, author_id: int, is_admin: bool = False, commit: bool = True) -> None:
         """

--- a/backend/ng/team/models/Team.py
+++ b/backend/ng/team/models/Team.py
@@ -18,7 +18,7 @@ from CTFd.models import db
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import Mapped, joinedload, selectinload
 
 from ... import config
 from ...core.exceptions import (
@@ -355,7 +355,14 @@ class Team(db.Model):
         Returns:
             list[Team]: List of all team objects
         """
-        return cls.query.order_by(cls.id).all()
+        return (cls.query
+            .order_by(cls.id)
+            .options(
+                joinedload(cls.event),
+                selectinload(cls.members)
+            )
+            .all()
+        )
 
     @classmethod
     def find_by_id(cls, team_id: int) -> Team | None:
@@ -411,7 +418,7 @@ class Team(db.Model):
         Returns:
             list[Team]: List of teams in the event
         """
-        return cls.query.filter_by(event_id=event_id).all()
+        return cls.query.filter_by(event_id=event_id).options(joinedload(cls.event)).all()
 
     @classmethod
     def count_by_event(cls, event_id: int) -> int:

--- a/backend/ng/user/models/User.py
+++ b/backend/ng/user/models/User.py
@@ -8,6 +8,7 @@ from typing import Any, TypedDict
 
 from CTFd.models import db
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.orm import joinedload, selectinload
 
 from ...core.utils.validator import BaseValidator
 from ...permissions.models.UserRole import UserRole
@@ -122,7 +123,15 @@ class User(db.Model):
         from ...team.models.TeamMember import TeamMember
 
         # Get all teams the user is a member of
-        team_members = TeamMember.query.filter_by(user_id=self.id).all()
+        team_members = (TeamMember.query
+            .filter_by(user_id=self.id)
+            .options(
+                joinedload(TeamMember.user),
+                joinedload(TeamMember.team),
+                joinedload(TeamMember.event)
+            )
+            .all()
+        )
         event_ids = [tm.event_id for tm in team_members]
 
         # Get all events for those teams
@@ -149,7 +158,13 @@ class User(db.Model):
         Returns:
             User or None: The user instance if found, None otherwise
         """
-        return cls.query.get(user_id)
+        return (cls.query
+            .options(
+                joinedload(cls.ctfd_user),
+                selectinload(cls.user_roles)
+            )
+            .get(user_id)
+        )
 
     @classmethod
     def find_or_create_by_ctfd_id(cls, ctfd_user_id: int, commit: bool = True) -> User:
@@ -162,7 +177,15 @@ class User(db.Model):
         Returns:
             User: The found or created user instance
         """
-        user = cls.query.get(ctfd_user_id)
+        user = (cls.query
+            .options(
+                joinedload(cls.affiliation),
+                joinedload(cls.ctfd_user),
+                selectinload(cls.user_roles)
+            )
+            .get(ctfd_user_id)
+        )
+
         if not user:
             user = cls.create_user(ctfd_user_id, commit=commit)
         return user
@@ -171,7 +194,14 @@ class User(db.Model):
     def get_all_users(cls):
         """Gets all users with their basic details."""
 
-        return cls.query.all()
+        return (cls.query
+            .options(
+                joinedload(cls.affiliation),
+                joinedload(cls.ctfd_user),
+                selectinload(cls.user_roles)
+            )
+            .all()
+        )
 
     @classmethod
     def check_can_join_team_in_event(cls, user_id: int, event_id: int) -> bool:


### PR DESCRIPTION
I specifically looked at improving queries that either:

1. Call `.all()` to yield multiple results
2. Got flagged by sentry for N+1 performance issues 