### PR TITLE
Updating Challenge Parser

### DIFF
--- a/examples/complex_chall.yml
+++ b/examples/complex_chall.yml
@@ -161,7 +161,7 @@ services:
     # Resource constraints
     mem_limit: "512m"
     memswap_limit: "1g"
-    cpus: "1.0"
+    cpus: "0.25"
   
   # Vulnerable application service  
   app:

--- a/lib/parser/pyproject.toml
+++ b/lib/parser/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyber-skyline-chall-parser"
-version = "0.5.0"
+version = "0.5.1"
 description = "Parser library for handling the specialized challenge docker compose format"
 readme = "README.md"
 authors = [

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/__init__.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/__init__.py
@@ -17,7 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
 # IN THE SOFTWARE.
-from cyber_skyline.chall_parser.compose.compose import ComposeFile, Network, ComposeResourceName, ServicesDict, NetworksDict
+from cyber_skyline.chall_parser.compose.compose import ComposeFile, Network, ServicesDict, NetworksDict
 from cyber_skyline.chall_parser.compose.service import Service
 from cyber_skyline.chall_parser.compose.challenge_info import ChallengeInfo, TextBody, Hint, Question, Variable
 
@@ -30,7 +30,6 @@ __all__ = [
     'Question',
     'Variable',
     'Network',
-    'ComposeResourceName',
     'ServicesDict',
     'NetworksDict'
 ]

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/compose.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/compose.py
@@ -115,7 +115,7 @@ class ComposeFile:
             if (w := _network_warnings(net_name, net)) is not None
         ]
         if network_warnings:
-            yield Warnings("network warnings", None, network_warnings)
+            yield Warnings("networks", None, network_warnings)
 
 
         def _service_warnings(name: str, serv: Service | None) -> Warnings | None:
@@ -136,10 +136,10 @@ class ComposeFile:
             if (w := _service_warnings(serv_name, serv)) is not None
         ]
         if service_warnings:
-            yield Warnings("service warnings", None, service_warnings)
+            yield Warnings("services", None, service_warnings)
 
-    def warnings(self) -> Warnings:
-        warning =  Warnings("ComposeFile", self._warnings(), self._field_warnings())
+    def warnings(self) -> Warnings | None:
+        warning =  Warnings("root", self._warnings(), self._field_warnings())
         if warning.self_warnings or warning.field_warnings:
             return warning
         return None

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/compose.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/compose.py
@@ -25,6 +25,7 @@ for CTF challenge deployment. It enforces security constraints and validation wh
 supporting the x-challenge extension for CTF-specific metadata.
 """
 
+from functools import reduce
 from typing import Iterator, NewType, Dict
 import attrs.validators as v
 from attrs import define, field
@@ -57,7 +58,7 @@ class ComposeFile:
     # Core Docker Compose sections with security constraints
     services: ServicesDict = field(
         default=None, 
-        validator=v.optional(validate_compose_name_pattern)
+        validator=v.deep_mapping(validate_compose_name_pattern, v.instance_of(Service), v.instance_of(dict))
     )
     # Container services that make up the challenge infrastructure
     # - Names must follow Docker naming conventions
@@ -66,12 +67,28 @@ class ComposeFile:
 
     networks: NetworksDict | None = field(
         default=None,
-        validator=v.optional(v.and_(validate_compose_name_pattern, contains("competitor_net")))
+        validator=v.optional(
+            v.and_(
+                v.deep_mapping(validate_compose_name_pattern, v.optional(v.instance_of(Network)), v.instance_of(dict)), 
+                contains("competitor_net")
+            )
+        )
     )
     # Network definitions for service communication
     # - All networks are internal-only for security
     # - Names must follow Docker naming conventions
     # - Optional since simple challenges might not need custom networking
+
+    def __attrs_post_init__(self) -> None:
+        # Ensure That All Networks Are Used by Services
+        if self.networks is not None and self.services is not None:
+            used_networks: set[ComposeResourceName] = set()
+            used_networks = reduce(lambda a, b: a.union(b),
+                                   (serv.network_names() for serv in self.services.values()), used_networks)
+            network_names = set(self.networks.keys())
+            unused_networks = network_names - used_networks
+            if unused_networks:
+                raise ValueError(f"Unused networks defined: {', '.join(unused_networks)}")
     
     def _warnings(self) -> Iterator[str]:
         if self.services is None or len(self.services) == 0:

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/compose.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/compose.py
@@ -26,19 +26,19 @@ supporting the x-challenge extension for CTF-specific metadata.
 """
 
 from functools import reduce
-from typing import Iterator, NewType, Dict
+from typing import Iterator, Dict
 import attrs.validators as v
 from attrs import define, field
 
 from cyber_skyline.chall_parser.compose.service import Service
 from cyber_skyline.chall_parser.compose.network import Network
 from cyber_skyline.chall_parser.compose.challenge_info import ChallengeInfo
+from cyber_skyline.chall_parser.compose.types import ComposeResourceName
 from cyber_skyline.chall_parser.compose.validators import validate_compose_name_pattern, contains
 from cyber_skyline.chall_parser.warnings import Warnings    
 
 # Custom types for pattern-validated dictionaries
 # These provide type safety while enforcing naming constraints
-ComposeResourceName = NewType('ComposeResourceName', str)
 ServicesDict = Dict[ComposeResourceName, Service]
 NetworksDict = Dict[ComposeResourceName, Network | None]
 
@@ -56,8 +56,7 @@ class ComposeFile:
     # specifically for CTF challenge deployment, not general Docker orchestration
     
     # Core Docker Compose sections with security constraints
-    services: ServicesDict = field(
-        default=None, 
+    services: ServicesDict = field( 
         validator=v.deep_mapping(validate_compose_name_pattern, v.instance_of(Service), v.instance_of(dict))
     )
     # Container services that make up the challenge infrastructure

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/service.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/service.py
@@ -28,9 +28,9 @@ needed for challenge infrastructure while ignoring complex orchestration feature
 from typing import Iterator, Literal, Any
 from attrs import define, field
 import attrs.validators as v
-from cyber_skyline.chall_parser.compose import ComposeResourceName
 from cyber_skyline.chall_parser.template import Template
-from cyber_skyline.chall_parser.compose.validators import is_ipv4
+from cyber_skyline.chall_parser.compose.validators import is_ipv4, or_
+from cyber_skyline.chall_parser.compose.types import ComposeResourceName
 
 type CapAdd = Literal['NET_ADMIN', 'SYS_PTRACE']
 
@@ -76,8 +76,22 @@ class Service:
     entrypoint: str | list[str] | None = field(default=None)  # Override the default entrypoint
 
     # Environment and configuration
-    environment: dict[str, Template | str] | list[str | dict[str, Template | str]] | None = field(
-        default=None)
+    environment: dict[str, Template | str] | list[str] | None = field(
+        default=None,
+        validator=v.optional(
+            or_(
+                v.deep_mapping(
+                    v.instance_of(str), 
+                    or_(v.instance_of(str), v.instance_of(Template)),
+                    v.instance_of(dict)
+                ),
+                v.deep_iterable(
+                    v.instance_of(str), 
+                    v.instance_of(list)
+                )
+            )
+        )
+    )
     # Environment variables for the container
     # - dict form: {"VAR": "value"} or {"VAR": Template("fake.name()")}
     # - list form: ["VAR=value", "OTHER_VAR=other_value"]

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/service.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/service.py
@@ -122,7 +122,10 @@ class Service:
     # Resource constraints - important for preventing resource abuse
     mem_limit: int | str | None = field(default=None)  # Memory limit (e.g., "512m", "1g")
     memswap_limit: int | str | None = field(default=None)  # Memory + swap limit
-    cpus: float | str | None = field(default=None)  # CPU limit (e.g., 0.5, "1.5")
+    cpus: float | str | None = field(default=None, 
+                                     converter=lambda x: float(x) if x is not None else None
+                                     )  # CPU limit (e.g., 0.5 for half a CPU)
+        
 
     # User and permissions
     user: str | None = field(default=None)  # User to run the container as (e.g., "1000:1000", "nobody")

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/service.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/service.py
@@ -28,6 +28,7 @@ needed for challenge infrastructure while ignoring complex orchestration feature
 from typing import Iterator, Literal, Any
 from attrs import define, field
 import attrs.validators as v
+from cyber_skyline.chall_parser.compose import ComposeResourceName
 from cyber_skyline.chall_parser.template import Template
 from cyber_skyline.chall_parser.compose.validators import is_ipv4
 
@@ -75,7 +76,7 @@ class Service:
     entrypoint: str | list[str] | None = field(default=None)  # Override the default entrypoint
 
     # Environment and configuration
-    environment: dict[str, Template | str] | list[str] | None = field(
+    environment: dict[str, Template | str] | list[str | dict[str, Template | str]] | None = field(
         default=None)
     # Environment variables for the container
     # - dict form: {"VAR": "value"} or {"VAR": Template("fake.name()")}
@@ -83,10 +84,18 @@ class Service:
     # Template support allows dynamic variable generation for each challenge instance
     
     # Networking configuration
-    networks: list[str] | dict[str, ServiceNetwork | None] | None = field(default=None)
+    networks: list[ComposeResourceName] | dict[ComposeResourceName, ServiceNetwork | None] | None = field(default=None)
     # Network connections for the service
     # - list form: ["network1", "network2"] - simple network attachment
     # - dict form: {"network1": None} - allows for future network-specific configuration
+
+    def network_names(self) -> set[ComposeResourceName]:
+        """Helper to get the list of network names the service is attached to."""
+        if self.networks is None:
+            return set()
+        if isinstance(self.networks, list):
+            return set(self.networks)
+        return set(self.networks.keys())
 
     
     # Security and capabilities

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/types.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/types.py
@@ -1,0 +1,3 @@
+from typing import NewType
+
+ComposeResourceName = NewType('ComposeResourceName', str)

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/validators.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/validators.py
@@ -29,6 +29,7 @@ import re
 import ipaddress
 from typing import Any
 from cyber_skyline.chall_parser.compose.answer import Answer, AnswerTestCase
+from cyber_skyline.chall_parser.compose import ComposeResourceName
 from cyber_skyline.chall_parser.template import Template
 from collections.abc import Callable, Container
 
@@ -130,7 +131,7 @@ def validate_tabler_icon(instance, attribute, value):
     if not value.startswith("Tb"):
         raise ValueError(f"Icon name '{value}' must start with 'Tb' prefix")
 
-def validate_compose_name_pattern(instance, attribute, value):
+def validate_compose_name_pattern(instance, attribute, value: ComposeResourceName):
     """Validator for compose resource names that must match ^[a-zA-Z0-9._-]+$.
     
     This enforces the Docker Compose specification for valid resource names,
@@ -138,9 +139,8 @@ def validate_compose_name_pattern(instance, attribute, value):
     """
     if value is not None:
         pattern = re.compile(r'^[a-zA-Z0-9._-]+$')
-        for key in value.keys():
-            if not pattern.match(key):
-                raise ValueError(f"Invalid {attribute.name} key '{key}': must match pattern ^[a-zA-Z0-9._-]+$")
+        if not pattern.match(value):
+            raise ValueError(f"Invalid {attribute.name} compose resource name '{value}': must match pattern ^[a-zA-Z0-9._-]+$")
 
 # TODO: Add more validators as needed:
 # - validate_challenge_difficulty (easy, medium, hard)

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/validators.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/validators.py
@@ -29,9 +29,9 @@ import re
 import ipaddress
 from typing import Any
 from cyber_skyline.chall_parser.compose.answer import Answer, AnswerTestCase
-from cyber_skyline.chall_parser.compose import ComposeResourceName
 from cyber_skyline.chall_parser.template import Template
 from collections.abc import Callable, Container
+from cyber_skyline.chall_parser.compose.types import ComposeResourceName
 
 
 logger = logging.getLogger(__name__)

--- a/lib/parser/src/cyber_skyline/chall_parser/compose/validators.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/compose/validators.py
@@ -223,3 +223,28 @@ def validate_regex(instance,attribute,value: str):
         re.compile(value)
     except re.error as e:
         raise ValueError(f"Invalid regex pattern for {attribute.name}: {value}") from e
+
+def validate_cpus(instance, attribute, value: Any):
+    """Validator for CPU limit values.
+    
+    Ensures that the provided CPU limit is a positive float or string
+    that can be converted to a positive float.
+    
+    Args:
+        instance: The instance being validated
+        attribute: The attribute being validated
+        value: The CPU limit to validate
+    Raises:
+        ValueError: If the CPU limit is larger than allowed
+    """
+    if value is None:
+        return  # Allow None values
+    
+    try:
+        cpu_value = float(value)
+        if cpu_value <= 0:
+            raise ValueError(f"CPU limit for {attribute.name} must be a positive number, got {value}")
+        if cpu_value > 0.5:
+            raise ValueError(f"CPU limit for {attribute.name} is too high ({value}), maximum allowed is 0.5")
+    except TypeError as e:
+        raise ValueError(f"CPU limit for {attribute.name} must be convertible to float, got {value}") from e

--- a/lib/parser/src/cyber_skyline/chall_parser/rewriter.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/rewriter.py
@@ -185,7 +185,7 @@ class Rewriter:
             else:
                 return
 
-    def persist_anchored_scalar(self, event: Event) -> Event:
+    def _persist_anchored_scalar(self, event: Event) -> Event:
         """Store a scalar event in the anchors dictionary if it has an anchor."""
         if isinstance(event, ScalarEvent) and event.anchor is not None:
             logger.debug(f"Persisting anchored event: {event.anchor}")
@@ -194,7 +194,7 @@ class Rewriter:
 
     def _persist_anchored_scalars(self, events: Generator[Event, None, None]) -> Generator[Event, None, None]:
         """Store an scalars events in the anchors dictionary if it has an anchor."""
-        yield from (self.persist_anchored_scalar(event) for event in events)
+        yield from (self._persist_anchored_scalar(event) for event in events)
 
     # TODO: Refactor this to utilize a pipeline type architecture instead
     def rewrite(self) -> Generator[Event, None, None]:

--- a/lib/parser/src/cyber_skyline/chall_parser/rewriter.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/rewriter.py
@@ -46,17 +46,25 @@ class Rewriter:
 
     def _rewrite_variable(self, variable_name: str, events: Generator[Event, None, None]) -> Generator[Event, None, None]:
         logger.debug("Entering rewrite_variable")
-        events_mapping: dict[str, tuple[ScalarEvent, ScalarEvent | AliasEvent]] = {}
+        events_mapping: dict[str, tuple[ScalarEvent, list[Event]]] = {}
         final_event: Event | None = None
         try:
             while (key_event := next(events)) and isinstance(key_event, ScalarEvent):
                 logger.debug(f"Key event value: {key_event.value}")
                 value_event = next(events)
-                if not isinstance(value_event, ScalarEvent | AliasEvent):
-                    raise ValueError("Variable values can only be resolved from scalar or alias events")
-                logger.debug(f"Value event type: {type(value_event)}, value: {getattr(value_event, 'value', None)}")
-                events_mapping[key_event.value] = (key_event, value_event)
+                value_events = [value_event]
+                unmatched_starts = 1 if isinstance(value_event, MappingStartEvent) else 0
+                while unmatched_starts > 0:
+                    next_event = next(events)
+                    if isinstance(next_event, MappingStartEvent):
+                        unmatched_starts += 1
+                    elif isinstance(next_event, MappingEndEvent):
+                        unmatched_starts -= 1
+
+                    value_events.append(next_event)
+                events_mapping[key_event.value] = (key_event, value_events)
             else:
+                logger.debug(f"No more key events, storing final event: {key_event}")
                 final_event = key_event
         except StopIteration:
             pass
@@ -66,6 +74,9 @@ class Rewriter:
             raise ValueError(f"Variable '{variable_name}' must have a 'template' key")
         
         template_key, template_value = events_mapping.pop('template')
+        if len(template_value) > 1 or not isinstance(template_value[0], ScalarEvent | AliasEvent):
+            raise ValueError(f"Variable '{variable_name}' template value must be a single scalar or alias event")
+        template_value = template_value[0]
         logger.debug(f"Template key: {template_key}, value: {template_value}")
 
         if 'default' not in events_mapping:
@@ -73,6 +84,9 @@ class Rewriter:
             raise ValueError(f"Variable '{variable_name}' must have a 'default' key")
         
         default_key, default_value = events_mapping.pop('default')
+        if len(default_value) > 1 or not isinstance(default_value[0], ScalarEvent | AliasEvent):
+            raise ValueError(f"Variable '{variable_name}' default value must be a single scalar or alias event")
+        default_value = default_value[0]
         logger.debug(f"Default key: {default_key}, value: {default_value}")
 
         if default_value.anchor is None:
@@ -93,19 +107,25 @@ class Rewriter:
         yield ScalarEvent(value="eval", anchor=None, tag=None, implicit=(True, False))
         yield ScalarEvent(value=template_value.value, anchor=None, tag=None, implicit=(True, False))
         yield MappingEndEvent()
+        logger.debug("Finished template mapping")
 
+        logger.debug("Yielding default key and value with cleared anchor")
         default_value.anchor = None
         yield from (default_key, default_value)
+
 
         for (key_event, value_event) in events_mapping.values():
             yield key_event
             if isinstance(value_event, AliasEvent):
                 yield self._resolve_alias(value_event)
             else:
-                yield value_event
+                yield from value_event
 
         if final_event is not None:
+            logger.debug("Yielding final event after variable mapping")
             yield final_event
+        else:
+            logger.debug("No final event to yield after variable mapping")
 
     def _rewrite_variables(self, events: Generator[Event, None, None]) -> Generator[Event, None, None]:
         logger.debug("Entering rewrite_variables")
@@ -117,11 +137,15 @@ class Rewriter:
                 break
             
             yield event
+        else:
+            logger.debug("No 'variables' section found in events")
+            return
         
         event = next(events)
         yield event
         if not isinstance(event, MappingStartEvent):
-            logger.debug("`variables` following events do not start with MappingStartEvent")
+            logger.debug("yaml events following `variables` do not start with MappingStartEvent")
+            yield from events
             return
         
         try:
@@ -129,13 +153,16 @@ class Rewriter:
                 if isinstance(event, ScalarEvent):
                     logger.debug(f"Processing variable key: {event.value}")
                     yield event
-                    if not isinstance(next(events), MappingStartEvent):
+                    mapping_event = next(events)
+                    if not isinstance(mapping_event, MappingStartEvent):
                         logger.debug("No MappingStartEvent after variable key")
                         raise ValueError("variable must be followed by a mapping")
+                    yield mapping_event
                     yield from self._rewrite_variable(event.value, events)
                 elif isinstance(event, MappingEndEvent):
                     logger.debug("Reached end of variables mapping")
                     yield event
+                    yield from events
                     return
                 else:
                     raise ValueError("Unexpected event type in variables mapping")
@@ -143,14 +170,20 @@ class Rewriter:
         except StopIteration:
             return
 
+    def _log_events(self, events: Generator[Event, None, None], context: str) -> Generator[Event, None, None]:
+        """Generator to log events from the loader for debugging purposes."""
+        for event in events:
+            logger.debug(f"{context} event: {event}")
+            yield event
+
     def _loader_events(self) -> Generator[Event, None, None]:
         logger.debug("Entering loader_events")
         while True:
             if self._loader.check_event():
-                yield self._loader.get_event()
+                event = self._loader.get_event()
+                yield event
             else:
-                logger.debug("No more events in loader_events")
-                break
+                return
 
     def persist_anchored_scalar(self, event: Event) -> Event:
         """Store a scalar event in the anchors dictionary if it has an anchor."""
@@ -176,8 +209,10 @@ class Rewriter:
     def rewrite(self) -> Generator[Event, None, None]:
         logger.debug("Entering rewrite_aliases")
         pipeline = self._loader_events()
+        pipeline = self._log_events(pipeline, "loader")
         pipeline = self._persist_anchored_scalars(pipeline)
         pipeline = self._rewrite_variables(pipeline)
-        pipeline = self._resolve_alias_events(pipeline)
+        # pipeline = self._resolve_alias_events(pipeline)
+        pipeline = self._log_events(pipeline, "final")
         yield from pipeline
 

--- a/lib/parser/src/cyber_skyline/chall_parser/rewriter.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/rewriter.py
@@ -195,15 +195,6 @@ class Rewriter:
     def _persist_anchored_scalars(self, events: Generator[Event, None, None]) -> Generator[Event, None, None]:
         """Store an scalars events in the anchors dictionary if it has an anchor."""
         yield from (self.persist_anchored_scalar(event) for event in events)
-    
-    def _resolve_alias_events(self, events: Generator[Event, None, None]) -> Generator[Event, None, None]:
-        """Helper function to process alias events in a generator."""
-        for event in events:
-            if isinstance(event, AliasEvent):
-                logger.debug(f"Processing AliasEvent: {event.anchor}")
-                yield self._resolve_alias(event)
-            else:
-                yield event
 
     # TODO: Refactor this to utilize a pipeline type architecture instead
     def rewrite(self) -> Generator[Event, None, None]:
@@ -212,7 +203,6 @@ class Rewriter:
         pipeline = self._log_events(pipeline, "loader")
         pipeline = self._persist_anchored_scalars(pipeline)
         pipeline = self._rewrite_variables(pipeline)
-        # pipeline = self._resolve_alias_events(pipeline)
         pipeline = self._log_events(pipeline, "final")
         yield from pipeline
 

--- a/lib/parser/src/cyber_skyline/chall_parser/rewriter.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/rewriter.py
@@ -19,60 +19,67 @@
 # IN THE SOFTWARE.
 import logging
 from typing import Generator
-from yaml import AliasEvent, BaseLoader, Event, MappingEndEvent, MappingStartEvent, ScalarEvent
+from yaml import AliasEvent, Event, MappingEndEvent, MappingStartEvent, SafeLoader, ScalarEvent
 logger = logging.getLogger(__name__)
 
 class Rewriter:
     """Rewriter class for processing YAML events, resolving aliases, and rewriting variables."""
     
-    def __init__(self, loader: BaseLoader):
-        self.loader = loader
-        self.anchors: dict[str, ScalarEvent] = {}
+    def __init__(self, loader: SafeLoader):
+        self._loader = loader
+        self._anchors: dict[str, ScalarEvent] = {}
         logger.debug(f"Rewriter initialized with loader: {loader}")
     
-    def resolve_alias(self, alias: AliasEvent) -> AliasEvent | ScalarEvent:
+    def _resolve_alias(self, alias: AliasEvent) -> AliasEvent | ScalarEvent:
         """Resolve an alias event to its corresponding event scalar event if possible."""
 
         logger.debug(f"Resolving alias: {alias.anchor}")
-        if alias.anchor not in self.anchors:
+        if alias.anchor not in self._anchors:
            return alias
 
-        resolved_event = self.anchors[alias.anchor]
+        resolved_event = self._anchors.get(alias.anchor)
         if not isinstance(resolved_event, ScalarEvent):
             raise ValueError(f"Alias '{alias.anchor}' does not point to a valid scalar event")
         
         return resolved_event
 
 
-    def rewrite_variable(self, variable_name: str) -> Generator[Event, None, None]:
+    def _rewrite_variable(self, variable_name: str, events: Generator[Event, None, None]) -> Generator[Event, None, None]:
         logger.debug("Entering rewrite_variable")
-        yield self.loader.get_event()
-        events: dict[str, tuple[ScalarEvent, ScalarEvent | AliasEvent]] = {}
-        while self.loader.check_event(ScalarEvent):
-            key_event = self.loader.get_event()
-            logger.debug(f"Key event value: {key_event.value}")
-            events[key_event.value] = (key_event, self.loader.get_event())
-            logger.debug(f"Events dict updated: {events}")
+        events_mapping: dict[str, tuple[ScalarEvent, ScalarEvent | AliasEvent]] = {}
+        final_event: Event | None = None
+        try:
+            while (key_event := next(events)) and isinstance(key_event, ScalarEvent):
+                logger.debug(f"Key event value: {key_event.value}")
+                value_event = next(events)
+                if not isinstance(value_event, ScalarEvent | AliasEvent):
+                    raise ValueError("Variable values can only be resolved from scalar or alias events")
+                logger.debug(f"Value event type: {type(value_event)}, value: {getattr(value_event, 'value', None)}")
+                events_mapping[key_event.value] = (key_event, value_event)
+            else:
+                final_event = key_event
+        except StopIteration:
+            pass
         
-        if 'template' not in events:
+        if 'template' not in events_mapping:
             logger.debug("No 'template' key found in variable")
             raise ValueError(f"Variable '{variable_name}' must have a 'template' key")
         
-        template_key, template_value = events.pop('template')
+        template_key, template_value = events_mapping.pop('template')
         logger.debug(f"Template key: {template_key}, value: {template_value}")
 
-        if 'default' not in events:
+        if 'default' not in events_mapping:
             logger.debug("No 'default' key found in variable")
             raise ValueError(f"Variable '{variable_name}' must have a 'default' key")
         
-        default_key, default_value = events.pop('default')
+        default_key, default_value = events_mapping.pop('default')
         logger.debug(f"Default key: {default_key}, value: {default_value}")
 
         if default_value.anchor is None:
             raise ValueError("Default value must have an anchor for variable rewriting")
 
         yield template_key
-        if isinstance(template_value, AliasEvent) and isinstance((resolved := self.resolve_alias(template_value)), ScalarEvent):
+        if isinstance(template_value, AliasEvent) and isinstance((resolved := self._resolve_alias(template_value)), ScalarEvent):
             template_value = resolved
 
         if not isinstance(template_value, ScalarEvent):
@@ -90,55 +97,87 @@ class Rewriter:
         default_value.anchor = None
         yield from (default_key, default_value)
 
-        for _, (key_event, value_event) in events.items():
+        for (key_event, value_event) in events_mapping.values():
             yield key_event
             if isinstance(value_event, AliasEvent):
-                yield self.resolve_alias(value_event)
+                yield self._resolve_alias(value_event)
             else:
                 yield value_event
 
-        yield self.loader.get_event()
+        if final_event is not None:
+            yield final_event
 
-    def rewrite_variables(self) -> Generator[Event, None, None]:
+    def _rewrite_variables(self, events: Generator[Event, None, None]) -> Generator[Event, None, None]:
         logger.debug("Entering rewrite_variables")
-        if not self.loader.check_event(MappingStartEvent):
-            logger.debug("No MappingStartEvent after 'variables'")
+        
+        for event in events:
+            if isinstance(event, ScalarEvent) and event.value == "variables":
+                logger.debug("Found 'variables' key, extracting variable events")
+                yield event
+                break
+            
+            yield event
+        
+        event = next(events)
+        yield event
+        if not isinstance(event, MappingStartEvent):
+            logger.debug("`variables` following events do not start with MappingStartEvent")
             return
         
-        yield self.loader.get_event()
-        logger.debug("Processing variables")
-        while self.loader.check_event(ScalarEvent):
-            variable_key: ScalarEvent = self.loader.get_event()
-            yield variable_key
-            if not self.loader.check_event(MappingStartEvent):
-                logger.debug("No MappingStartEvent after variable key")
-                return
-            yield from self.rewrite_variable(variable_key.value)
+        try:
+            while (event := next(events)):
+                if isinstance(event, ScalarEvent):
+                    logger.debug(f"Processing variable key: {event.value}")
+                    yield event
+                    if not isinstance(next(events), MappingStartEvent):
+                        logger.debug("No MappingStartEvent after variable key")
+                        raise ValueError("variable must be followed by a mapping")
+                    yield from self._rewrite_variable(event.value, events)
+                elif isinstance(event, MappingEndEvent):
+                    logger.debug("Reached end of variables mapping")
+                    yield event
+                    return
+                else:
+                    raise ValueError("Unexpected event type in variables mapping")
+
+        except StopIteration:
+            return
+
+    def _loader_events(self) -> Generator[Event, None, None]:
+        logger.debug("Entering loader_events")
+        while True:
+            if self._loader.check_event():
+                yield self._loader.get_event()
+            else:
+                logger.debug("No more events in loader_events")
+                break
+
+    def persist_anchored_scalar(self, event: Event) -> Event:
+        """Store a scalar event in the anchors dictionary if it has an anchor."""
+        if isinstance(event, ScalarEvent) and event.anchor is not None:
+            logger.debug(f"Persisting anchored event: {event.anchor}")
+            self._anchors[event.anchor] = event
+        return event
+
+    def _persist_anchored_scalars(self, events: Generator[Event, None, None]) -> Generator[Event, None, None]:
+        """Store an scalars events in the anchors dictionary if it has an anchor."""
+        yield from (self.persist_anchored_scalar(event) for event in events)
+    
+    def _resolve_alias_events(self, events: Generator[Event, None, None]) -> Generator[Event, None, None]:
+        """Helper function to process alias events in a generator."""
+        for event in events:
+            if isinstance(event, AliasEvent):
+                logger.debug(f"Processing AliasEvent: {event.anchor}")
+                yield self._resolve_alias(event)
+            else:
+                yield event
 
     # TODO: Refactor this to utilize a pipeline type architecture instead
     def rewrite(self) -> Generator[Event, None, None]:
         logger.debug("Entering rewrite_aliases")
-        while True:
-            if self.loader.check_event(ScalarEvent):
-                logger.debug("Found ScalarEvent in rewrite_aliases")
-                event: ScalarEvent = self.loader.get_event()
-                logger.debug(f"Got event: {event}")
-                if event.anchor is not None:
-                    # Store the event in anchors if it has an anchor
-                    logger.debug(f"Storing event in anchors with anchor: {event.anchor}")
-                    self.anchors[event.anchor] = event
-                yield event
-                if event.value != "variables":
-                    logger.debug(f"Event value is not 'variables': {event.value}")
-                    continue
-                logger.debug("Found 'variables' key, rewriting variables")
-                yield from self.rewrite_variables()
-            elif self.loader.check_event(AliasEvent):
-                logger.debug("Attempting to resolve AliasEvent during rewrite_aliases")
-                yield self.resolve_alias(self.loader.get_event())
-            elif self.loader.check_event():
-                logger.debug("Not a ScalarEvent or AliasEvent, yielding next event")
-                yield self.loader.get_event()
-            else:
-                logger.debug("No more events in rewrite_aliases")
-                break
+        pipeline = self._loader_events()
+        pipeline = self._persist_anchored_scalars(pipeline)
+        pipeline = self._rewrite_variables(pipeline)
+        pipeline = self._resolve_alias_events(pipeline)
+        yield from pipeline
+

--- a/lib/parser/src/cyber_skyline/chall_parser/template.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/template.py
@@ -70,7 +70,7 @@ class Template:
 
 
     @classmethod
-    def from_yaml(cls, loader: yaml.Loader | yaml.FullLoader | yaml.UnsafeLoader | None, node: yaml.nodes.Node) -> 'Template':
+    def from_yaml(cls, loader: yaml.SafeLoader | None, node: yaml.nodes.Node) -> 'Template':
         logger.debug(f"Creating Template from YAML node: {node}")
         if not isinstance(node, yaml.nodes.MappingNode):
             raise yaml.YAMLError("Template must be a mapping")

--- a/lib/parser/src/cyber_skyline/chall_parser/yaml_parser.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/yaml_parser.py
@@ -93,6 +93,16 @@ class ComposeYamlParser:
         converter.register_structure_hook(Template, template_struct_hook)
         converter.register_unstructure_hook(Template, template_unstruct_hook)
 
+        # Register structure hooks to disable coercion
+        def no_coercion(value, tp):
+            if isinstance(value, tp):
+                return value
+            raise ValueError(f"Expected {tp}, got {value!r}")
+        converter.register_structure_hook(int, no_coercion)
+        converter.register_structure_hook(str, no_coercion)
+        converter.register_structure_hook(bool, no_coercion)
+        converter.register_structure_hook(float, no_coercion)
+
         converter.register_structure_hook_func(is_dict_list_union, dict_list_union_hook_gen(converter))
         
         return converter
@@ -125,6 +135,7 @@ class ComposeYamlParser:
             logger.debug("Rewriting aliases and templates")
             # Use the Rewriter to process the YAML content
             events = list(Rewriter(loader).rewrite())
+            logger.debug(f"Rewritten events: {events}")
             
             # Step 3: Reconstruct YAML from events
             logger.debug("Reconstructing YAML from rewritten events")
@@ -132,10 +143,12 @@ class ComposeYamlParser:
             logger.debug(f"Rewritten YAML:\n{rewritten_yaml}")
             # Step 4: Parse the rewritten YAML into a dictionary
             parsed_data = yaml.load(rewritten_yaml, Loader=yaml.SafeLoader)
+            logger.debug(f"Parsed YAML data: {parsed_data}")
             
             # Step 5: Structure into ComposeFile using cattrs
             logger.debug("Structuring data into ComposeFile")
             compose_file = self.converter.structure(parsed_data, ComposeFile)
+            logger.debug(f"Structured ComposeFile: {compose_file}")
             
             logger.info("Successfully parsed compose file")
             return compose_file
@@ -149,6 +162,7 @@ class ComposeYamlParser:
         """Convert a ComposeFile back to YAML string."""
         # Unstructure the compose file to a dictionary
         data = self.converter.unstructure(compose_file)
+        logger.debug(f"Unstructured compose file data: {data}")
         
         # Convert to YAML
         return yaml.dump(data, default_flow_style=False, sort_keys=False)

--- a/lib/parser/src/cyber_skyline/chall_parser/yaml_parser.py
+++ b/lib/parser/src/cyber_skyline/chall_parser/yaml_parser.py
@@ -32,7 +32,7 @@ from cyber_skyline.chall_parser.template import Template
 
 logger = logging.getLogger(__name__)
             
-yaml.add_constructor('!template', Template.from_yaml)
+yaml.add_constructor('!template', Template.from_yaml, Loader=yaml.SafeLoader)
 yaml.add_representer(Template, Template.to_yaml)
 
 def is_dict_list_union(tp):
@@ -118,7 +118,7 @@ class ComposeYamlParser:
         logger.debug("Starting YAML parsing with template rewriting")
         
         # Step 1: Create a YAML loader for rewriting the stream
-        loader = yaml.BaseLoader(yaml_content)
+        loader = yaml.SafeLoader(yaml_content)
         
         try:
             # Step 2: Rewrite aliases/templates
@@ -131,7 +131,7 @@ class ComposeYamlParser:
             rewritten_yaml = yaml.emit(events)
             logger.debug(f"Rewritten YAML:\n{rewritten_yaml}")
             # Step 4: Parse the rewritten YAML into a dictionary
-            parsed_data = yaml.load(rewritten_yaml, Loader=yaml.Loader)
+            parsed_data = yaml.load(rewritten_yaml, Loader=yaml.SafeLoader)
             
             # Step 5: Structure into ComposeFile using cattrs
             logger.debug("Structuring data into ComposeFile")

--- a/lib/parser/test/test_compose.py
+++ b/lib/parser/test/test_compose.py
@@ -18,9 +18,10 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
 # IN THE SOFTWARE.
 from typing import cast
+from cyber_skyline.chall_parser.compose.types import ComposeResourceName
 import pytest
 from cyber_skyline.chall_parser.compose import (
-    ComposeFile, Network, ComposeResourceName, ServicesDict, NetworksDict, Service, ChallengeInfo
+    ComposeFile, Network, ServicesDict, NetworksDict, Service, ChallengeInfo
     
 )
 from cyber_skyline.chall_parser.compose.validators import validate_compose_name_pattern
@@ -37,11 +38,12 @@ class TestComposeFile:
         challenge = ChallengeInfo(
             name="Test Challenge",
             description="A test challenge",
-            questions=[]
+            questions=[],
         )
-        compose = ComposeFile(challenge=challenge)
+        services = {}
+        compose = ComposeFile(challenge=challenge, services=services, networks=None)
         assert compose.challenge.name == "Test Challenge"
-        assert compose.services is None
+        assert compose.services == {}
         assert compose.networks is None
 
     def test_compose_file_with_all_sections(self):
@@ -53,8 +55,8 @@ class TestComposeFile:
         )
         
         services = {
-            ComposeResourceName("web"): Service(image="nginx", hostname="web"),
-            ComposeResourceName("db"): Service(image="postgres", hostname="db")
+            ComposeResourceName("web"): Service(image="nginx", hostname="web", networks=[ComposeResourceName("frontend"), ComposeResourceName("competitor_net")]),
+            ComposeResourceName("db"): Service(image="postgres", hostname="db", networks=[ComposeResourceName("backend"), ComposeResourceName("competitor_net")])
         }
         
         networks = {
@@ -77,25 +79,24 @@ class TestComposeFile:
 class TestComposeNameValidation:
     def test_compose_name_pattern_validator_edge_cases(self):
         """Test edge cases for compose name pattern validation."""
-        # Test with empty dict
-        validate_compose_name_pattern(None, type('obj', (), {'name': 'test'})(), {})
         
         # Test with valid patterns
         valid_names = {
-            "a": "value",
-            "1": "value", 
-            "a-b": "value",
-            "a_b": "value",
-            "a.b": "value",
-            "a1b2c3": "value"
+            ComposeResourceName("a"): "value",
+            ComposeResourceName("1"): "value", 
+            ComposeResourceName("a-b"): "value",
+            ComposeResourceName("a_b"): "value",
+            ComposeResourceName("a.b"): "value",
+            ComposeResourceName("a1b2c3"): "value"
         }
-        validate_compose_name_pattern(None, type('obj', (), {'name': 'test'})(), valid_names)
+        for name in valid_names.keys():
+            validate_compose_name_pattern(None, type('obj', (), {'name': 'test'})(), name)
 
     def test_invalid_compose_names(self):
         """Test that invalid compose names are rejected."""
         invalid_dict = {
-            "service with spaces": "value",
-            "service@special": "value"
+            ComposeResourceName("service with spaces"): "value",
+            ComposeResourceName("service@special"): "value"
         }
         
         class MockInstance:
@@ -104,5 +105,6 @@ class TestComposeNameValidation:
         class MockAttribute:
             name = "services"
         
-        with pytest.raises(ValueError, match="must match pattern"):
-            validate_compose_name_pattern(MockInstance(), MockAttribute(), invalid_dict)
+        for key in invalid_dict.keys():
+            with pytest.raises(ValueError, match="must match pattern"):
+                validate_compose_name_pattern(MockInstance(), MockAttribute(), key)

--- a/lib/parser/test/test_rewriter.py
+++ b/lib/parser/test/test_rewriter.py
@@ -20,7 +20,7 @@
 import pytest
 import yaml
 import io
-from yaml import BaseLoader
+from yaml import SafeLoader
 from cyber_skyline.chall_parser.rewriter import Rewriter
 from cyber_skyline.chall_parser.template import Template
 
@@ -28,10 +28,10 @@ class TestRewriter:
     def test_rewriter_initialization(self):
         """Test that Rewriter initializes correctly."""
         yaml_content = "test: value"
-        loader = BaseLoader(yaml_content)
+        loader = SafeLoader(yaml_content)
         rewriter = Rewriter(loader)
-        assert rewriter.loader == loader
-        assert rewriter.anchors == {}
+        assert rewriter._loader == loader
+        assert rewriter._anchors == {}
 
     def test_rewrite_variable_no_anchor_in_default(self):
         """Test that rewriter fails when default has no anchor."""
@@ -41,7 +41,7 @@ variables:
     template: "fake.word()"
     default: "no_anchor_value"  # missing anchor
 """
-        loader = BaseLoader(yaml_content)
+        loader = SafeLoader(yaml_content)
         rewriter = Rewriter(loader)
         
         # This should raise an error because anchor is required for rewriting
@@ -55,7 +55,7 @@ services:
   web:
     image: nginx
 """
-        loader = BaseLoader(yaml_content)
+        loader = SafeLoader(yaml_content)
         rewriter = Rewriter(loader)
         events = list(rewriter.rewrite())
         # Should pass through all events unchanged
@@ -69,7 +69,7 @@ services:
   web:
     image: nginx
 """
-        loader = BaseLoader(yaml_content)
+        loader = SafeLoader(yaml_content)
         rewriter = Rewriter(loader)
         events = list(rewriter.rewrite())
         # Should handle empty variables section
@@ -78,29 +78,29 @@ services:
     def test_resolve_alias_not_found(self):
         """Test alias resolution when anchor is not found."""
         yaml_content = "test: value"
-        loader = BaseLoader(yaml_content)
+        loader = SafeLoader(yaml_content)
         rewriter = Rewriter(loader)
         
         # Create a mock alias event
         from yaml import AliasEvent
         alias = AliasEvent(anchor="unknown")
-        result = rewriter.resolve_alias(alias)
+        result = rewriter._resolve_alias(alias)
         assert result == alias
 
     def test_resolve_alias_invalid_type(self):
         """Test alias resolution when anchor points to non-scalar."""
         yaml_content = "test: value"
-        loader = BaseLoader(yaml_content)
+        loader = SafeLoader(yaml_content)
         rewriter = Rewriter(loader)
         
         # Mock an anchor that points to something other than ScalarEvent
         from yaml import MappingStartEvent, AliasEvent
         non_scalar_event = MappingStartEvent(anchor=None, tag=None, implicit=True)
-        rewriter.anchors["bad_anchor"] = non_scalar_event # type: ignore
+        rewriter._anchors["bad_anchor"] = non_scalar_event # type: ignore
         
         alias = AliasEvent(anchor="bad_anchor")
         with pytest.raises(ValueError, match="does not point to a valid scalar event"):
-            rewriter.resolve_alias(alias)
+            rewriter._resolve_alias(alias)
 
 class TestTemplate:
     def test_template_initialization(self):
@@ -218,7 +218,7 @@ services:
     environment:
       FLAG: *flag_var
 """
-        loader = BaseLoader(yaml_content)
+        loader = SafeLoader(yaml_content)
         rewriter = Rewriter(loader)
         
         events = list(rewriter.rewrite())

--- a/lib/parser/test/test_service.py
+++ b/lib/parser/test/test_service.py
@@ -18,6 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
 # IN THE SOFTWARE.
 from cyber_skyline.chall_parser.compose.service import Service
+from cyber_skyline.chall_parser.compose.types import ComposeResourceName
 from cyber_skyline.chall_parser.template import Template
 
 class TestService:
@@ -37,11 +38,11 @@ class TestService:
             hostname="test-server",
             mem_limit="1g",
             memswap_limit="2g", 
-            cpus="1.5"
+            cpus="0.5"
         )
         assert service.mem_limit == "1g"
         assert service.memswap_limit == "2g"
-        assert service.cpus == "1.5"
+        assert service.cpus == 0.5
 
     def test_service_with_capabilities(self):
         """Test service with Linux capabilities."""
@@ -121,19 +122,19 @@ class TestService:
         service1 = Service(
             image="app:latest",
             hostname="test-server",
-            networks=["frontend", "backend"]
+            networks=[ComposeResourceName("frontend"), ComposeResourceName("backend")]
         )
-        assert service1.networks == ["frontend", "backend"]
+        assert service1.networks == [ComposeResourceName("frontend"), ComposeResourceName("backend")]
 
         # Test dict form
         service2 = Service(
             image="app:latest",
             hostname="test-server",
-            networks={"frontend": None, "backend": None}
+            networks={ComposeResourceName("frontend"): None, ComposeResourceName("backend"): None}
         )
         assert isinstance(service2.networks, dict)
-        assert "frontend" in service2.networks
-        assert "backend" in service2.networks
+        assert ComposeResourceName("frontend") in service2.networks
+        assert ComposeResourceName("backend") in service2.networks
 
     def test_service_command_and_entrypoint(self):
         """Test command and entrypoint configuration."""

--- a/lib/parser/test/test_validators.py
+++ b/lib/parser/test/test_validators.py
@@ -21,6 +21,7 @@ import pytest
 from attrs import define, field
 from cyber_skyline.chall_parser.compose.validators import validate_tabler_icon, validate_compose_name_pattern, validate_template_evals
 from cyber_skyline.chall_parser.template import Template
+from cyber_skyline.chall_parser.compose.types import ComposeResourceName
 
 @define
 class MockChallengeWithIcon:
@@ -90,12 +91,12 @@ class TestTablerIconValidator:
 class TestComposeNameValidator:
     def test_valid_compose_names(self):
         """Test that valid compose resource names pass validation."""
-        valid_dict = {
-            "web-service": "value",
-            "db_service": "value", 
-            "service123": "value",
-            "my.service": "value",
-            "a": "value",
+        valid_dict: dict[ComposeResourceName, str] = {
+            ComposeResourceName("web-service"): "value",
+            ComposeResourceName("db_service"): "value", 
+            ComposeResourceName("service123"): "value",
+            ComposeResourceName("my.service"): "value",
+            ComposeResourceName("a"): "value",
         }
         
         class MockInstance:
@@ -104,15 +105,16 @@ class TestComposeNameValidator:
         class MockAttribute:
             name = "test_field"
         
-        validate_compose_name_pattern(MockInstance(), MockAttribute(), valid_dict)
+        for key in valid_dict.keys():
+            validate_compose_name_pattern(MockInstance(), MockAttribute(), key)
 
     def test_invalid_compose_names(self):
         """Test that invalid compose resource names are rejected."""
         invalid_cases = [
-            {"service with spaces": "value"},
-            {"service@special": "value"},
-            {"service/slash": "value"},
-            {"": "value"},
+            {ComposeResourceName("service with spaces"): "value"},
+            {ComposeResourceName("service@special"): "value"},
+            {ComposeResourceName("service/slash"): "value"},
+            {ComposeResourceName(""): "value"},
         ]
         
         class MockInstance:
@@ -122,18 +124,9 @@ class TestComposeNameValidator:
             name = "test_field"
         
         for invalid_dict in invalid_cases:
-            with pytest.raises(ValueError, match="must match pattern"):
-                validate_compose_name_pattern(MockInstance(), MockAttribute(), invalid_dict)
-
-    def test_none_value_allowed(self):
-        """Test that None values are allowed."""
-        class MockInstance:
-            pass
-        
-        class MockAttribute:
-            name = "test_field"
-        
-        validate_compose_name_pattern(MockInstance(), MockAttribute(), None)
+            for key in invalid_dict.keys():
+                with pytest.raises(ValueError, match="must match pattern"):
+                    validate_compose_name_pattern(MockInstance(), MockAttribute(), key)
 
 class TestTemplateValidator:
     def test_valid_template(self):
@@ -146,11 +139,6 @@ class TestTemplateValidator:
         """Test that non-Template objects are rejected."""
         with pytest.raises(ValueError, match="Expected Template object"):
             MockVariableWithTemplate(template="not a template") # type: ignore
-
-    def test_none_template(self):
-        """Test that None templates are allowed."""
-        # This test would need a different mock class that allows None
-        pass
 
     def test_template_eval_error(self):
         """Test that templates with evaluation errors are caught."""

--- a/lib/parser/test/test_yaml_parser.py
+++ b/lib/parser/test/test_yaml_parser.py
@@ -120,7 +120,7 @@ networks:
         assert web_service.hostname == "web-server"
         assert web_service.networks is not None and isinstance(web_service.networks, dict)
         assert "competitor_net" in web_service.networks
-        competitor_net = web_service.networks["competitor_net"]
+        competitor_net = web_service.networks[ComposeResourceName("competitor_net")]
         assert competitor_net is not None
         assert competitor_net.ipv4_address == "172.16.238.10"
         assert compose.networks is not None and isinstance(compose.networks, dict)
@@ -915,6 +915,7 @@ networks:
         # returned for external networks.
         compose = parse_compose_string(yaml_content)
         w = compose.warnings()
+        assert w is not None
         # Field warnings yield Warnings objects per resource; find the network warning
         rendered = w.render()
         # There should be a warning for the external network 'competitor_net'
@@ -1040,3 +1041,49 @@ networks:
         chall = parse_compose_string(yaml_content)
         assert chall.challenge is not None
         assert chall.challenge.questions is not None
+
+
+    def test_error_on_array_of_mappings_in_environment(self):
+        """
+        Test that we get an error when we pass a array of mappings for the environment variables in a service.
+        """
+
+        yaml_content = """
+x-challenge:
+  name: Basic Challenge
+  description: A simple challenge to test parsing
+  summary: A simple challenge to test parsing
+  icon: TbPuzzle
+  templates:
+    flag-template: &flag_tmpl "fake.bothify('CTF{????-####}', letters='ABCDEF')"
+  variables:
+    db_password:
+      template: "fake.password(length=12)"
+      default: &db_pass "SecureP4ss!"
+    session_id:
+      template: "fake.uuid4()"
+      default: &session_id "123e4567-e89b-12d3-a456-426614174000"
+  questions:
+    - name: Q1
+      body: What is the flag?
+      points: 100
+      answer: CTF{test_flag}
+      max_attempts: 3
+  hints:
+    - name: check-logs
+      body: Check the logs
+      preview: Log hint
+      deduction: 10
+  tags:
+    - test
+    - beginner
+services:
+  app:
+    image: test:latest
+    hostname: test-host
+    environment:
+      - VAR1: value1
+      - VAR2: value2
+"""
+        with pytest.raises(Exception):
+            parse_compose_string(yaml_content)

--- a/lib/parser/test/test_yaml_parser.py
+++ b/lib/parser/test/test_yaml_parser.py
@@ -22,13 +22,14 @@ import pathlib
 import re
 from cattrs import ClassValidationError
 from cyber_skyline.chall_parser.compose.answer import Answer
+from cyber_skyline.chall_parser.compose.types import ComposeResourceName
 import pytest
 import tempfile
 from pathlib import Path
 from cyber_skyline.chall_parser.compose.challenge_info import ChallengeInfo, TextBody
 from cyber_skyline.chall_parser.template import Template
 from cyber_skyline.chall_parser.yaml_parser import ComposeYamlParser, parse_compose_string, parse_compose_file
-from cyber_skyline.chall_parser.compose import ComposeFile, ComposeResourceName
+from cyber_skyline.chall_parser.compose import ComposeFile
 from cyber_skyline.chall_parser.compose.service import Service
 
 class TestComposeYamlParser:
@@ -299,10 +300,12 @@ services:
         with pytest.raises(Exception):  # Could be various YAML parsing exceptions
             parse_compose_string(invalid_yaml)
 
-    def test_complex_challenge(self):
+    def test_complex_challenge(self, caplog):
         """Test parsing a complex challenge with multiple services and networks."""
+        caplog.set_level("DEBUG")
         chall_file = pathlib.Path(__file__).parent.resolve() / "../../../examples/complex_chall.yml"
         compose = parse_compose_file(chall_file)
+
         
         # Validate challenge metadata
         assert compose.challenge is not None
@@ -669,8 +672,9 @@ services:
         compose = parser.parse_stream(stream)
         assert compose.challenge.name == "Stream Test"
 
-    def test_to_yaml_roundtrip(self):
+    def test_to_yaml_roundtrip(self, caplog):
         """Test that YAML output can be parsed back."""
+        caplog.set_level("DEBUG")
         original_yaml = """
 x-challenge:
   name: Roundtrip Test
@@ -687,6 +691,9 @@ services:
         # Convert to YAML
         parser = ComposeYamlParser()
         yaml_output = parser.to_yaml(compose)
+        logger = logging.getLogger(__name__)
+        logger.debug("YAML Output:\n%s", yaml_output)
+
         
         # Parse the output
         compose2 = parse_compose_string(yaml_output)
@@ -1043,11 +1050,11 @@ networks:
         assert chall.challenge.questions is not None
 
 
-    def test_error_on_array_of_mappings_in_environment(self):
+    def test_error_on_array_of_mappings_in_environment(self, caplog):
         """
         Test that we get an error when we pass a array of mappings for the environment variables in a service.
         """
-
+        caplog.set_level("DEBUG")
         yaml_content = """
 x-challenge:
   name: Basic Challenge
@@ -1082,8 +1089,8 @@ services:
     image: test:latest
     hostname: test-host
     environment:
-      - VAR1: value1
-      - VAR2: value2
+      - VAR1: *db_pass
+      - VAR2: *db_pass
 """
         with pytest.raises(Exception):
             parse_compose_string(yaml_content)

--- a/lib/parser/test/test_yaml_parser.py
+++ b/lib/parser/test/test_yaml_parser.py
@@ -464,7 +464,7 @@ services:
         assert web_service.hostname == "web-server"
         assert web_service.networks == ["competitor_net"]
         assert web_service.mem_limit == "256m"
-        assert web_service.cpus == "0.5"
+        assert web_service.cpus == 0.5
         assert web_service.cap_add == ["NET_ADMIN"]
         
         # Web service environment
@@ -509,7 +509,7 @@ services:
         assert db_service.networks == ["competitor_net"]
         assert db_service.mem_limit == "512m"
         assert db_service.memswap_limit == "1g"
-        assert db_service.cpus == "1.0"
+        assert db_service.cpus == 0.25
         
         # Database service environment
         assert db_service.environment is not None

--- a/lib/parser/uv.lock
+++ b/lib/parser/uv.lock
@@ -35,7 +35,7 @@ wheels = [
 
 [[package]]
 name = "cyber-skyline-chall-parser"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/tools/chall-check/pyproject.toml
+++ b/tools/chall-check/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyber-skyline-chall-check"
-version = "0.5.0"
+version = "0.5.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Fixes
- resolves #605 
- resolves #596 
- resolves #595 

## Changes
- Switch to using safe loader instead of base loader
- Check if there are any unused networks and error if there are
- Limit the CPU resource constraint to minimum 0, maximum 0.5, or None
- Disable coercion in cattrs
- Officially require services be defined
- Make warnings return direct paths so that in the future we can support code squiggles
- Make all private functionalities of the rewriter "private"
- Make the rewriter use a pipeline style architecture
- Allow for more complex values to be defined side by side with the variable templates to allow future expansion
- Add further logging to the parsing process
- Correct tests and add new test for #605