### PR TITLE
Show correct submission values for solved questions

### DIFF
--- a/frontend/src/routes/events/challenge/ChallengeQuestion.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeQuestion.tsx
@@ -58,7 +58,8 @@ export default function ChallengeQuestion({
   let status: 'unanswered' | 'correct' | 'incorrect' = 'unanswered';
   let color: AccentColor | undefined;
 
-  if (attempts.find((attempt) => attempt.is_correct)) {
+  const correctAttempt = attempts.find((attempt) => attempt.is_correct);
+  if (correctAttempt) {
     status = 'correct';
     color = COLOR_POSITIVE;
   } else if (attempts.length > 0) {
@@ -105,7 +106,9 @@ export default function ChallengeQuestion({
                 placeholder={placeholder}
                 required
                 autoComplete="off"
-                disabled={status === 'correct' || attemptsRemaining <= 0 || denied}
+                disabled={status !== 'correct' && (attemptsRemaining <= 0 || denied)}
+                readOnly={status === 'correct'}
+                defaultValue={correctAttempt?.submission}
               >
                 <TextField.Slot>
                   <TbFlag2 className={twMerge(status !== 'unanswered' && 'text-(--accent-10)')} />


### PR DESCRIPTION
Resolves #626. If the team has made a correct submission for a question, the submitted value will be kept in the input field. In this state, the field is read-only (though still selectable) and the submit button is removed.

<img width="547" height="140" alt="image" src="https://github.com/user-attachments/assets/7f5f85ee-ebf3-428d-ae72-c0e4c5c9efaa" />
