### PR TITLE
Add sysctl ansible ops playbook

### DIFF
--- a/ansible/sysctl-apply.yml
+++ b/ansible/sysctl-apply.yml
@@ -1,0 +1,21 @@
+- name: Sysctl config
+  # Replace with inventory conf
+  # for docker hosts
+  hosts: dockerhosts
+  become: true
+  # Replace with your remote user
+  remote_user: user
+  tasks:
+    - ansible.posix.sysctl:
+        name: kernel.pty.max
+        value: '8192'
+        state: present
+    - ansible.posix.sysctl:
+        name: fs.aio-max-nr
+        value: '1048576'
+        state: present
+    - ansible.posix.sysctl:
+        name: fs.inotify.max_user_instances
+        value: '256'
+        state: present
+


### PR DESCRIPTION
Adds a playbook that sets sysctl tuneables to docker challenge hosts