### PR TITLE
Event practice mode flag

### DIFF
--- a/backend/ng/event/controllers/user/join_event_controller.py
+++ b/backend/ng/event/controllers/user/join_event_controller.py
@@ -1,5 +1,7 @@
+from uuid import uuid4
 from CTFd.models import db
 
+from ....core.utils import utc_now
 from ....core import NotFoundError, ValidationError
 from ....team.models.Team import Team
 from ....event.models.Demographic import Demographic
@@ -9,10 +11,15 @@ from ....user.models.User import User
 def join_event_controller(event: Event, user : User, invite_code : str = "", team_name : str = "") -> Team:
     """Main controller for the event joining process.
     """
-    if (not invite_code) and (not team_name):
+    if (not invite_code) and (not team_name) and (not event.practice):
         raise ValidationError("Either invite_code or team_name must be provided")
+    if event.practice and (invite_code or team_name):
+        raise ValidationError("Cannot provide invite_code or team_name for practice events")
     if (not user.affiliation):
         raise ValidationError("User sponsor not set")
+
+    if event.practice:
+      team_name = f"practice-{uuid4().hex}"
 
     try:
         Demographic.create_demographic(user_id=user.id, event_id=event.id, commit=False)
@@ -30,6 +37,9 @@ def join_event_controller(event: Event, user : User, invite_code : str = "", tea
                 ranked=True,
                 commit=False,
             )
+            if event.practice:
+              # immediately grant access to challenges for practice teams
+              team.set_start_timestamp(utc_now())
         db.session.commit()
         return team
     except Exception as e:

--- a/backend/ng/event/models/Event.py
+++ b/backend/ng/event/models/Event.py
@@ -37,6 +37,7 @@ class Event(db.Model):
     allowed_domains: Mapped[list[str]] = db.Column(JSON, nullable=False, default=[])
     blocked_domains: Mapped[list[str]] = db.Column(JSON, nullable=False, default=[])
     show_leaderboard = db.Column(db.Boolean, default=False, nullable=False)
+    practice = db.Column(db.Boolean, default=False, nullable=False)
 
     __table_args__ = (
         CheckConstraint(
@@ -97,6 +98,7 @@ class Event(db.Model):
             "allowed_domains": self.allowed_domains,
             "blocked_domains": self.blocked_domains,
             "show_leaderboard": self.show_leaderboard,
+            "practice": self.practice,
         }
 
         return data
@@ -191,6 +193,12 @@ class Event(db.Model):
             required=False,
             friendly_name="Show leaderboard",
         )
+        validator.validate_boolean(
+            data,
+            "practice",
+            required=False,
+            friendly_name="Practice mode",
+        )
 
         return validator.validate()
 
@@ -213,6 +221,7 @@ class Event(db.Model):
         allowed_domains: list[str] | None = None,
         blocked_domains: list[str] | None = None,
         show_leaderboard: bool = False,
+        practice: bool = False,
         commit: bool = True,
     ):
         """Create and persist a new event to the database.
@@ -250,6 +259,7 @@ class Event(db.Model):
             allowed_domains=allowed_domains,
             blocked_domains=blocked_domains,
             show_leaderboard=show_leaderboard,
+            practice=practice,
         )
 
         db.session.add(event)

--- a/backend/ng/event/models/Event.py
+++ b/backend/ng/event/models/Event.py
@@ -322,16 +322,20 @@ class Event(db.Model):
         return cls.query.filter_by(name=name).first()
 
     @classmethod
-    def get_all_events(cls, public_only=True) -> list[Event]:
+    def get_all_events(cls, public_only=True, practice=None) -> list[Event]:
         """Gets all events
 
         Returns:
             list: List of all <Event> objects in the database.
         """
-
+        query = cls.query
         if public_only:
-            return cls.query.filter_by(public=True).all()
-        return cls.query.all()
+            query = query.filter_by(public=True)
+
+        if practice is not None:
+            query = query.filter_by(practice=practice)
+
+        return query.all()
 
     def get_event_details_with_teams(self) -> dict[str, Any]:
         """

--- a/backend/ng/event/routes/user_routes.py
+++ b/backend/ng/event/routes/user_routes.py
@@ -3,6 +3,7 @@ User Routes for Event Operations
 """
 
 from CTFd.models import db
+from flask import request
 from flask_restx import Namespace, Resource
 
 from ...challenge.models.Challenge import Challenge
@@ -64,7 +65,17 @@ class EventList(Resource):
         """
         Get all public events
         """
-        results = Event.get_all_events(public_only = True)
+        practice_param = request.args.get("practice")
+        if practice_param is None:
+            practice = None
+        elif practice_param.lower() == "true":
+            practice = True
+        elif practice_param.lower() == "false":
+            practice = False
+        else:
+            raise ValidationError("Invalid value for practice parameter. If present, it must be 'true' or 'false'.")
+
+        results = Event.get_all_events(public_only = True, practice = practice)
         return success_response(results)
 
 
@@ -145,9 +156,13 @@ class EventRegistration(Resource):
         has_invite = "invite_code" in json_data
         has_name = "team_name" in json_data
 
-        if (not has_invite) and (not has_name):
+        if (not has_invite) and (not has_name) and (not event.practice):
             raise ValidationError(
                 "Either invite_code or team_name must be provided."
+            )
+        if event.practice and (has_invite or has_name):
+            raise ValidationError(
+                "Cannot provide invite_code or team_name for practice events."
             )
         if has_invite and has_name:
             raise ValidationError(

--- a/frontend/src/components/AdminSidebarHeader.tsx
+++ b/frontend/src/components/AdminSidebarHeader.tsx
@@ -15,7 +15,7 @@ export default function AdminSidebarHeader({
     <Flex direction="row" align="center" justify="between" gap="2">
       <Flex direction="row" align="center" gap="2">
         {icon && <Heading aria-hidden>{icon}</Heading>}
-        <Heading id={id}>{title}</Heading>
+        <Heading id={id} className="wrap-anywhere">{title}</Heading>
       </Flex>
       <Flex direction="row" align="center" gap="2" wrap="wrap" justify="end">
         {children}

--- a/frontend/src/components/EventBadge.tsx
+++ b/frontend/src/components/EventBadge.tsx
@@ -32,6 +32,11 @@ const EVENT_STATES: {
     label : 'Registration Open',
     icon : TbArrowRight,
   },
+  available : {
+    color : COLOR_INFO,
+    label : 'Available',
+    icon : TbArrowRight,
+  },
   registered : {
     color : COLOR_POSITIVE,
     label : 'Registered',
@@ -94,7 +99,7 @@ export default function EventBadge({ eventId, size, className }: { eventId: numb
   }
 
   if (isRegistrationOpen) {
-    state = 'registration_open';
+    state = event?.practice ? 'available' : 'registration_open';
   }
 
   if (isRegistered) {

--- a/frontend/src/components/EventBadge.tsx
+++ b/frontend/src/components/EventBadge.tsx
@@ -32,11 +32,6 @@ const EVENT_STATES: {
     label : 'Registration Open',
     icon : TbArrowRight,
   },
-  available : {
-    color : COLOR_INFO,
-    label : 'Available',
-    icon : TbArrowRight,
-  },
   registered : {
     color : COLOR_POSITIVE,
     label : 'Registered',
@@ -94,12 +89,17 @@ export default function EventBadge({ eventId, size, className }: { eventId: numb
     return <Skeleton><Badge size={size} className={className}>Loading...</Badge></Skeleton>;
   }
 
+  if (event?.practice) {
+    // don't display status badges for practice events
+    return null;
+  }
+
   if (isOngoing) {
     state = 'live';
   }
 
   if (isRegistrationOpen) {
-    state = event?.practice ? 'available' : 'registration_open';
+    state = 'registration_open';
   }
 
   if (isRegistered) {

--- a/frontend/src/hooks/events.ts
+++ b/frontend/src/hooks/events.ts
@@ -83,6 +83,22 @@ export function registerMyEventTeamJoin(eventId: number, inviteCode: string) {
   });
 }
 
+/**
+ * Registers user for practice event
+ * @param event_id The event id
+ */
+export function registerMyPracticeEvent(eventId: number) {
+  return apiMutation(`/events/${eventId}/me/register`, {}, {
+    method : 'POST',
+  }).then(() => mutate(`/permissions/${eventId}/me`).then(() => Promise.all([
+    mutate('/users/me/events'),
+    mutate('/users/me/teams'),
+    mutate(`/events/${eventId}/me/team`),
+  ])).then(() => {
+    mutate(`/events/${eventId}/me/eligibility`);
+  }));
+}
+
 export function useTeamNameFromCode(eventId: number, inviteCode?: string) {
   return useSWR(
     inviteCode ? `/events/${eventId}/team/${inviteCode}` : null,

--- a/frontend/src/hooks/events.ts
+++ b/frontend/src/hooks/events.ts
@@ -9,10 +9,17 @@ import type {
 import useSWR, { mutate } from 'swr';
 
 /**
- * Retrieves a list of all public and registerable events.
+ * Retrieves a list of all public and registerable competition events
  */
-export function useEvents() {
-  return useSWR<Event[], Error>('/events');
+export function useCompetitionEvents() {
+  return useSWR<Event[], Error>('/events?practice=false');
+}
+
+/**
+ * Retrieves a list of all public and registerable practice events
+ */
+export function usePracticeEvents() {
+  return useSWR<Event[], Error>('/events?practice=true');
 }
 
 /**

--- a/frontend/src/routes/admin/events/SidebarTabs/EventRegistrationTab.tsx
+++ b/frontend/src/routes/admin/events/SidebarTabs/EventRegistrationTab.tsx
@@ -178,6 +178,31 @@ export default function EventRegistrationTab({ event }: { event: Event }) {
             )}
           </FormField>
 
+          <FormField label="Practice" error={errors.practice}>
+            {(injected) => (
+              <Controller
+                control={control}
+                name="practice"
+                defaultValue
+                rules={{}}
+                render={({ field }) => (
+                  <Box>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={(checked) => {
+                        field.onChange(checked);
+                      }}
+                      name={field.name}
+                      ref={field.ref}
+                      size="3"
+                      {...injected}
+                    />
+                  </Box>
+                )}
+              />
+            )}
+          </FormField>
+
           {error && <ErrorCallout>{error}</ErrorCallout>}
           {buttonControls()}
         </form>
@@ -188,6 +213,7 @@ export default function EventRegistrationTab({ event }: { event: Event }) {
           <Statistic label="Registration Open" value={event.registration_open ? 'Yes' : 'No'} />
           <Statistic label="Registration Starts" value={event.registration_start_date?.toLocaleString() || 'N/A'} />
           <Statistic label="Registration Ends" value={event.registration_end_date?.toLocaleString() || 'N/A'} />
+          <Statistic label="Practice" value={event.practice ? 'Yes' : 'No'} />
         </>
       )}
     </Flex>

--- a/frontend/src/routes/admin/events/SidebarTabs/EventRegistrationTab.tsx
+++ b/frontend/src/routes/admin/events/SidebarTabs/EventRegistrationTab.tsx
@@ -213,7 +213,15 @@ export default function EventRegistrationTab({ event }: { event: Event }) {
           <Statistic label="Registration Open" value={event.registration_open ? 'Yes' : 'No'} />
           <Statistic label="Registration Starts" value={event.registration_start_date?.toLocaleString() || 'N/A'} />
           <Statistic label="Registration Ends" value={event.registration_end_date?.toLocaleString() || 'N/A'} />
-          <Statistic label="Practice" value={event.practice ? 'Yes' : 'No'} />
+          <Statistic
+            label="Practice"
+            value={event.practice ? 'Yes' : 'No'}
+            description={`
+              Mark this event as practice.
+              It will be available from the Practice page instead of the Events page.
+              Registration will occur automatically for users accessing the event for the first time.
+            `}
+          />
         </>
       )}
     </Flex>

--- a/frontend/src/routes/events/AvailableEvents.tsx
+++ b/frontend/src/routes/events/AvailableEvents.tsx
@@ -1,11 +1,11 @@
-import { useEvents } from '@/hooks/events';
+import { useCompetitionEvents } from '@/hooks/events';
 import { Container, Heading } from '@radix-ui/themes';
 import { ErrorCallout } from 'components/Callouts';
 import EventGrid from 'components/EventGrid';
 import HeaderContainer from 'components/HeaderContainer';
 
 export default function AvailableEvents() {
-  const { data : events, error, isLoading } = useEvents();
+  const { data : events, error, isLoading } = useCompetitionEvents();
 
   return (
     <>

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -20,6 +20,7 @@ import FeedbackTab from './OverviewTabs/FeedbackTab';
 import LeaderboardTab from './OverviewTabs/LeaderboardTab';
 import TeamTab from './OverviewTabs/TeamTab';
 import RegistrationCard from './RegistrationCard';
+import PracticeRegistration from './PracticeRegistration';
 
 export default function Overview() {
   const [ searchParams, setSearchParams ] = useSearchParams();
@@ -65,7 +66,9 @@ export default function Overview() {
             event={data}
           >
             {isAuthenticated && data && (
-              <RegistrationCard event={data} />
+              data.practice
+                ? <PracticeRegistration event={data} />
+                : <RegistrationCard event={data} />
             )}
             {isFinished && feedback === null && (
               <InfoCallout className="max-w-128">

--- a/frontend/src/routes/events/Overview.tsx
+++ b/frontend/src/routes/events/Overview.tsx
@@ -33,8 +33,9 @@ export default function Overview() {
   } = useRegistration(eventId);
 
   const challengesTabAvailable = isRegistered;
+  const leaderboardAvailable = !data?.practice;
   const teamTabAvailable = isRegistered && data && data.max_team_size > 1;
-  const feedbackAvailable = isRegistered && (isFinished || (isStarted && !team!.end_time));
+  const feedbackAvailable = isRegistered && (isFinished || (isStarted && !team!.end_time)) && !data?.practice;
 
   const { data : feedback } = useMyEventFeedback(feedbackAvailable ? eventId : null);
 
@@ -113,10 +114,12 @@ export default function Overview() {
                 Challenges
               </Tabs.Trigger>
             )}
-            <Tabs.Trigger value="leaderboard">
-              <TbStar className="mr-1" />
-              Leaderboard
-            </Tabs.Trigger>
+            {leaderboardAvailable && (
+              <Tabs.Trigger value="leaderboard">
+                <TbStar className="mr-1" />
+                Leaderboard
+              </Tabs.Trigger>
+            )}
             {teamTabAvailable && (
               <Tabs.Trigger value="team">
                 <TeamIcon className="mr-1" />
@@ -138,9 +141,11 @@ export default function Overview() {
           </Tabs.Content>
         )}
 
-        <Tabs.Content value="leaderboard">
-          <LeaderboardTab />
-        </Tabs.Content>
+        {leaderboardAvailable && (
+          <Tabs.Content value="leaderboard">
+            <LeaderboardTab />
+          </Tabs.Content>
+        )}
 
         {teamTabAvailable && (
           <Tabs.Content value="team">

--- a/frontend/src/routes/events/PracticeRegistration.tsx
+++ b/frontend/src/routes/events/PracticeRegistration.tsx
@@ -1,0 +1,58 @@
+import { registerMyPracticeEvent, useMyEligibility } from '@/hooks/events';
+import { useCurrentUser, useRegistration } from '@/hooks/users';
+import type { Event } from '@/types';
+import { ErrorCallout, WarningCallout } from 'components/Callouts';
+import { useEffect, useRef, useState } from 'react';
+import { Link as RadixLink } from '@radix-ui/themes';
+import { Link } from 'react-router';
+
+export default function PracticeRegistration({ event }: {event: Event}) {
+  const { data : user } = useCurrentUser();
+  const { isUnregistered } = useRegistration(event.id);
+  const { data : eligible, error : eligibilityError } = useMyEligibility(isUnregistered ? event.id : null); // only check eligibility if unregistered
+
+  const mySponsor = user?.affiliation;
+
+  // Handling for implicit registration to practice events
+  const hasAttemptedRegistration = useRef(false); // ensures that registration is only attempted once in strict mode
+  const [ implicitRegistrationFailed, setImplicitRegistrationFailed ] = useState(false);
+  useEffect(() => {
+    if (mySponsor && eligible && event.practice && !hasAttemptedRegistration.current) {
+      hasAttemptedRegistration.current = true;
+      registerMyPracticeEvent(event.id).catch(() => {
+        setImplicitRegistrationFailed(true);
+      });
+    }
+  }, [ event, mySponsor, eligible ]);
+
+  return (
+    <>
+      {user && !mySponsor && (
+        <WarningCallout>
+          You must select a sponsor on the
+          {' '}
+          <RadixLink asChild>
+            <Link to="/profile">profile page</Link>
+          </RadixLink>
+          {' '}
+          prior to participating.
+        </WarningCallout>
+      )}
+      {eligibilityError && (
+        <ErrorCallout>
+          {eligibilityError.message}
+        </ErrorCallout>
+      )}
+      {implicitRegistrationFailed && (
+        <ErrorCallout>
+          Failed to add your user to this practice event. Please
+          {' '}
+          <RadixLink asChild>
+            <Link to="/support">contact support</Link>
+          </RadixLink>
+          .
+        </ErrorCallout>
+      )}
+    </>
+  );
+}

--- a/frontend/src/routes/practice/index.tsx
+++ b/frontend/src/routes/practice/index.tsx
@@ -1,3 +1,4 @@
+import { usePracticeEvents } from '@/hooks/events';
 import {
   Button,
   Card,
@@ -10,6 +11,10 @@ import { TbExternalLink } from 'react-icons/tb';
 import { Link } from 'react-router';
 
 export default function Practice() {
+  const { data } = usePracticeEvents();
+  const practiceEvent = data?.[0];
+  const practiceBtnText = 'Go to PC7 Practice Area';
+
   return (
     <Container size="2" align="center" className="mt-12">
       <title>Practice</title>
@@ -44,10 +49,10 @@ For additional resources, visit the [prescup-challenges GitHub](https://github.c
             </RadixMarkdown>
           </Flex>
           <Flex justify="between" className="border-t border-[var(--gray-7)]" pt="4">
-            <Button>
-              <Link to="/events/7">
-                Go to PC7 Practice Area
-              </Link>
+            <Button disabled={!practiceEvent}>
+              {practiceEvent
+                ? <Link to={`/events/${practiceEvent.id}`}>{practiceBtnText}</Link>
+                : practiceBtnText}
             </Button>
             <Button>
               <a href="https://pccc.cisa.gov/gb">Go to External Practice Area</a>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,6 +14,7 @@ export interface Event {
   hints_enabled: boolean;
   time_limit_minutes: number | null;
   show_leaderboard: boolean;
+  practice: boolean;
 }
 
 export interface Sponsor {


### PR DESCRIPTION
Adds a `practice` boolean for events, which:
- Automatically registers & starts users when they visit a practice event page, with team names as `practice-{uuid}`
- Hides registration/name/leave controls from the event.
- Hides event status badge.
- Hides the leaderboard and feedback tabs from the event overview.
- Hides the event from the Events page listing.

The Practice page's "PC7 Practice Area" link also now points to the first event with the practice flag set. In the future, this page could be updated to handle multiple practice areas as well.

Also includes a fix for admin panel layout to ensure the long auto-generated team names don't overflow action buttons off the screen.

When deploying to staging/production, the events db table will need the practice boolean column added, and existing practice areas will need the practice flag set to true.