### PR TITLE
Improve challenge search, add tag filtering

### DIFF
--- a/backend/ng/challenge/models/Challenge.py
+++ b/backend/ng/challenge/models/Challenge.py
@@ -26,6 +26,7 @@ class SerializedChallenge(TypedDict):
     summary: str = ""
     num_questions: int = 0
     total_points: int = 0
+    tags: list[str] = []
 
 
 class Challenge(db.Model):
@@ -63,6 +64,7 @@ class Challenge(db.Model):
             "summary": self.summary or "",
             "num_questions": len(self.questions),
             "total_points": sum(q.points for q in self.questions),
+            "tags": [tag.name for tag in self.tags],
         }
 
         if self.event:
@@ -164,6 +166,7 @@ class Challenge(db.Model):
             .options(
                 joinedload(cls.event),
                 selectinload(cls.questions),
+                selectinload(cls.tags),
             )
             .all()
         )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "ag-grid-community": "^33.3.2",
     "ag-grid-react": "^33.3.2",
     "lodash": "^4.17.21",
+    "minisearch": "^7.2.0",
     "radix-ui": "^1.4.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -79,3 +79,5 @@ export const NOTIF_TYPE = {
     'ticket_assigned',
   ],
 };
+
+export const OTHER_TAXONOMY = 'Tags';

--- a/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeDetailsTab.tsx
+++ b/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeDetailsTab.tsx
@@ -1,5 +1,6 @@
 import { useAdminChallengeHints, useAdminChallengeQuestions, useAdminChallengeVariables } from '@/hooks/challenge';
 import type { Challenge } from '@/types';
+import { tagComparator } from '@/util';
 import {
   Badge,
   Code,
@@ -16,18 +17,7 @@ export default function ChallengeDetailsTab({ challenge }: {challenge: Challenge
   const { data : hints, error : hintsError } = useAdminChallengeHints(challenge.id);
   const { data : variables, error : varsError } = useAdminChallengeVariables(challenge.id);
 
-  const sortedTags = [ ...challenge.tags ].sort((a, b) => {
-    // sort tags alphabetically. tags without a taxonomy (:) should go last
-    const aHasTaxonomy = a.includes(':');
-    const bHasTaxonomy = b.includes(':');
-    if (aHasTaxonomy && !bHasTaxonomy) {
-      return -1;
-    }
-    if (!aHasTaxonomy && bHasTaxonomy) {
-      return 1;
-    }
-    return a.localeCompare(b);
-  });
+  const sortedTags = [ ...challenge.tags ].sort(tagComparator);
 
   return (
     <>

--- a/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeDetailsTab.tsx
+++ b/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeDetailsTab.tsx
@@ -1,6 +1,11 @@
 import { useAdminChallengeHints, useAdminChallengeQuestions, useAdminChallengeVariables } from '@/hooks/challenge';
 import type { Challenge } from '@/types';
-import { Code, Table } from '@radix-ui/themes';
+import {
+  Badge,
+  Code,
+  Flex,
+  Table,
+} from '@radix-ui/themes';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout, InfoCallout } from 'components/Callouts';
 import RadixMarkdown from 'components/RadixMarkdown';
@@ -11,12 +16,38 @@ export default function ChallengeDetailsTab({ challenge }: {challenge: Challenge
   const { data : hints, error : hintsError } = useAdminChallengeHints(challenge.id);
   const { data : variables, error : varsError } = useAdminChallengeVariables(challenge.id);
 
+  const sortedTags = [ ...challenge.tags ].sort((a, b) => {
+    // sort tags alphabetically. tags without a taxonomy (:) should go last
+    const aHasTaxonomy = a.includes(':');
+    const bHasTaxonomy = b.includes(':');
+    if (aHasTaxonomy && !bHasTaxonomy) {
+      return -1;
+    }
+    if (!aHasTaxonomy && bHasTaxonomy) {
+      return 1;
+    }
+    return a.localeCompare(b);
+  });
+
   return (
     <>
       <AdminSidebarHeader title="Description" />
       <RadixMarkdown>
         {challenge.description}
       </RadixMarkdown>
+
+      <AdminSidebarHeader title="Tags" />
+      {sortedTags.length === 0
+        ? <InfoCallout>This challenge does not have any tags.</InfoCallout>
+        : (
+          <Flex direction="row" gap="1" wrap="wrap">
+            {sortedTags.map((tag) => (
+              <Badge key={tag} color="gray" radius="full">
+                {tag}
+              </Badge>
+            ))}
+          </Flex>
+        )}
 
       <AdminSidebarHeader title="Questions" />
       {questionsError && <ErrorCallout>{questionsError.message}</ErrorCallout> }

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/ChallengeCard.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/ChallengeCard.tsx
@@ -1,6 +1,6 @@
 import { COLOR_POSITIVE, COLOR_WARNING, type AccentColor } from '@/constants';
 import type { Challenge, MeChallenge } from '@/types';
-import { prettyPrintTag } from '@/util';
+import { prettyPrintTag, tagComparator } from '@/util';
 import {
   Badge,
   Box,
@@ -50,18 +50,7 @@ function ChallengeCard({
   const inProgress = progress && progress.num_attempts_made > 0 && !complete;
 
   const sortedTags = useMemo(
-    () => [ ...challenge.tags ].sort((a, b) => {
-      // sort tags alphabetically. tags without a taxonomy (:) should go last
-      const aHasTaxonomy = a.includes(':');
-      const bHasTaxonomy = b.includes(':');
-      if (aHasTaxonomy && !bHasTaxonomy) {
-        return -1;
-      }
-      if (!aHasTaxonomy && bHasTaxonomy) {
-        return 1;
-      }
-      return a.localeCompare(b);
-    }),
+    () => [ ...challenge.tags ].sort(tagComparator),
     [ challenge.tags ],
   );
 

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/ChallengeCard.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/ChallengeCard.tsx
@@ -13,6 +13,7 @@ import {
 import ChallengeIcon from 'components/ChallengeIcon';
 import { memo, useMemo } from 'react';
 import * as tb from 'react-icons/tb';
+import { TbCircleCheckFilled, TbPercentage0 } from 'react-icons/tb';
 import { Link } from 'react-router';
 
 function getPercentageIcon(progress: number) {
@@ -35,7 +36,7 @@ function getPercentageIcon(progress: number) {
   }
 
   const iconName = `TbPercentage${percentage}`;
-  const Icon = tb[iconName as keyof typeof tb] || tb.TbPercentage0;
+  const Icon = tb[iconName as keyof typeof tb] || TbPercentage0;
   return <Icon />;
 }
 
@@ -75,7 +76,7 @@ function ChallengeCard({
               <Box flexGrow="1" />
               {complete && (
                 <Text size="2" color={color}>
-                  <tb.TbCircleCheckFilled />
+                  <TbCircleCheckFilled />
                 </Text>
               )}
               {inProgress && (

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/ChallengeCard.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/ChallengeCard.tsx
@@ -1,6 +1,8 @@
 import { COLOR_POSITIVE, COLOR_WARNING, type AccentColor } from '@/constants';
 import type { Challenge, MeChallenge } from '@/types';
+import { prettyPrintTag } from '@/util';
 import {
+  Badge,
   Box,
   Card,
   Flex,
@@ -9,6 +11,7 @@ import {
   Text,
 } from '@radix-ui/themes';
 import ChallengeIcon from 'components/ChallengeIcon';
+import { memo, useMemo } from 'react';
 import * as tb from 'react-icons/tb';
 import { Link } from 'react-router';
 
@@ -36,7 +39,7 @@ function getPercentageIcon(progress: number) {
   return <Icon />;
 }
 
-export default function ChallengeCard({
+function ChallengeCard({
   challenge,
   progress,
 }: {
@@ -45,6 +48,22 @@ export default function ChallengeCard({
 }) {
   const complete = progress && progress.num_questions_solved === progress.num_questions_available;
   const inProgress = progress && progress.num_attempts_made > 0 && !complete;
+
+  const sortedTags = useMemo(
+    () => [ ...challenge.tags ].sort((a, b) => {
+      // sort tags alphabetically. tags without a taxonomy (:) should go last
+      const aHasTaxonomy = a.includes(':');
+      const bHasTaxonomy = b.includes(':');
+      if (aHasTaxonomy && !bHasTaxonomy) {
+        return -1;
+      }
+      if (!aHasTaxonomy && bHasTaxonomy) {
+        return 1;
+      }
+      return a.localeCompare(b);
+    }),
+    [ challenge.tags ],
+  );
 
   let color: AccentColor | undefined;
 
@@ -57,32 +76,53 @@ export default function ChallengeCard({
   return (
     <Card asChild>
       <Link to={`./challenge/${challenge.id}`}>
-        <Flex direction="row" align="center" gap="1">
-          <Heading size="4" color={color}>
-            <ChallengeIcon icon={challenge?.icon} />
-          </Heading>
-          <Heading size="4" color={color}>{challenge.name}</Heading>
-          <Box flexGrow="1" />
-          {complete && (
-            <Text size="2" color={color}>
-              <tb.TbCircleCheckFilled />
-            </Text>
+        <Flex direction="column" gap="3" justify="between" className="h-full">
+          <Box>
+            <Flex direction="row" align="center" gap="1">
+              <Heading size="4" color={color}>
+                <ChallengeIcon icon={challenge?.icon} />
+              </Heading>
+              <Heading size="4" color={color}>{challenge.name}</Heading>
+              <Box flexGrow="1" />
+              {complete && (
+                <Text size="2" color={color}>
+                  <tb.TbCircleCheckFilled />
+                </Text>
+              )}
+              {inProgress && (
+                <Text size="2" color={color}>
+                  {getPercentageIcon(progress.num_questions_solved / progress.num_questions_available)}
+                </Text>
+              )}
+              <Skeleton loading={!progress}>
+                <Text size="2" color={color}>
+                  {progress?.total_points_scored ?? '000'}
+                  /
+                  {progress?.total_points_available ?? '000'}
+                </Text>
+              </Skeleton>
+            </Flex>
+            <Text color="gray">{challenge.summary}</Text>
+          </Box>
+          {sortedTags.length > 0 && (
+            <Flex direction="row" gap="1" wrap="wrap">
+              {sortedTags.map((tag) => (
+                <Badge
+                  key={tag}
+                  size="1"
+                  radius="full"
+                  color="gray"
+                >
+                  {prettyPrintTag(tag)}
+                </Badge>
+              ))}
+            </Flex>
           )}
-          {inProgress && (
-            <Text size="2" color={color}>
-              {getPercentageIcon(progress.num_questions_solved / progress.num_questions_available)}
-            </Text>
-          )}
-          <Skeleton loading={!progress}>
-            <Text size="2" color={color}>
-              {progress?.total_points_scored ?? '000'}
-              /
-              {progress?.total_points_available ?? '000'}
-            </Text>
-          </Skeleton>
         </Flex>
-        <Text color="gray">{challenge.summary}</Text>
       </Link>
     </Card>
   );
 }
+
+// use memo here to skip re-rendering cards if data is unchanged, keeps the challenge list snappy when searching/filtering
+export default memo(ChallengeCard);

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/EventChallenges.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/EventChallenges.tsx
@@ -1,30 +1,104 @@
 import { useEventChallenges, useMyChallenges } from '@/hooks/challenge';
 import {
+  Button,
   Card,
   Container,
+  Flex,
   Grid,
   Skeleton,
+  Text,
   TextField,
+  Tooltip,
 } from '@radix-ui/themes';
-import { ErrorCallout } from 'components/Callouts';
-import { keyBy } from 'lodash';
-import { useMemo, useState } from 'react';
-import { TbSearch } from 'react-icons/tb';
+import { ErrorCallout, InfoCallout } from 'components/Callouts';
+import { groupBy, keyBy } from 'lodash';
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  TbFilter,
+  TbFilterFilled,
+  TbFilterOff,
+  TbSearch,
+} from 'react-icons/tb';
+import MiniSearch from 'minisearch';
+import { getTaxonomy, prettyPrintTag } from '@/util';
+import { COLOR_NEGATIVE } from '@/constants';
 import ChallengeCard from './ChallengeCard';
+import FilterPanel from './FilterPanel';
 
 export default function EventChallenges({ eventId }: {eventId: number}) {
-  const { data, error, isLoading } = useEventChallenges(eventId);
+  const { data = [], error, isLoading } = useEventChallenges(eventId);
   const { data : myChallenges, error : myError } = useMyChallenges(eventId);
 
+  const challengeMap = useMemo(() => keyBy(data, (challenge) => challenge.id), [ data ]);
   const challengeProgressMap = useMemo(() => keyBy(myChallenges, (progress) => progress.challenge_id), [ myChallenges ]);
 
+  // current search query from the input field
   const [ searchQuery, setSearchQuery ] = useState('');
 
-  const filteredChallenges = useMemo(() => {
-    if (!data) return [];
-    return data.filter((challenge) => challenge.name.toLowerCase().includes(searchQuery.toLowerCase())
-      || challenge.summary.toLowerCase().includes(searchQuery.toLowerCase()));
-  }, [ data, searchQuery ]);
+  // debounced query to reduce CPU usage and potential jank while typing
+  const [ debouncedQuery, setDebouncedQuery ] = useState('');
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 200);
+    return () => clearTimeout(timer);
+  }, [ searchQuery ]);
+
+  // set of tags that are currently selected for filtering
+  const [ selectedTags, setSelectedTags ] = useState(new Set<string>());
+  // group selected tags by taxonomy for filtering
+  const selectedTagsByTaxonomy = useMemo(() => groupBy(Array.from(selectedTags), getTaxonomy), [ selectedTags ]);
+
+  // whether filter UI should be shown
+  const [ showFilters, setShowFilters ] = useState(false);
+  const filterPanelId = useId();
+
+  // Build the search index based on data
+  // important to memoize, this is expensive
+  const miniSearch = useMemo(() => {
+    if (!data) return null;
+    const search = new MiniSearch({
+      fields : [ 'name', 'summary', 'description', 'tags' ],
+      extractField(document, fieldName) {
+        if (fieldName === 'tags') {
+          // join tags into a single pretty-printed string for indexing
+          return document.tags.map(prettyPrintTag).join(' ');
+        }
+        return document[fieldName] || '';
+      },
+    });
+    search.addAll(data);
+    return search;
+  }, [ data ]);
+
+  // Actual search/filter process begins here:
+  // This is done in multiple memo steps so changes to tag selection won't require re-running the search
+
+  // produce search results from the debounced query
+  // since the search index is built once to cover all data, run the search first
+  const searchResults = useMemo(() => {
+    // skip the actual search if query is empty or we don't have an index (no data yet)
+    if (debouncedQuery.trim() === '' || !miniSearch) return data;
+
+    return miniSearch.search(debouncedQuery, {
+      prefix : true,
+      fuzzy : 0.2,
+      boost : { name : 2 },
+    }).map((result) => challengeMap[result.id])
+      .filter(Boolean); // guard against undefined results if index somehow gets out of sync
+  }, [ miniSearch, debouncedQuery, data, challengeMap ]);
+
+  // apply tag filters to the search results. OR within taxonomy, AND across taxonomies
+  const filteredResults = useMemo(() => searchResults.filter(
+    (challenge) => Object.values(selectedTagsByTaxonomy).every(
+      (tagsInTaxonomy) => tagsInTaxonomy.some(
+        (tag) => challenge.tags.includes(tag),
+      ),
+    ),
+  ), [ searchResults, selectedTagsByTaxonomy ]);
 
   if (error) {
     return (
@@ -37,11 +111,96 @@ export default function EventChallenges({ eventId }: {eventId: number}) {
   return (
     <>
       <Container size="2" mb="3">
-        <TextField.Root placeholder="Search challenges..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)}>
-          <TextField.Slot>
-            <TbSearch height="16" width="16" />
-          </TextField.Slot>
-        </TextField.Root>
+        <Flex direction="row" gap="1">
+          <TextField.Root
+            placeholder="Search challenges..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="grow"
+          >
+            <TextField.Slot>
+              <TbSearch height="16" width="16" />
+            </TextField.Slot>
+          </TextField.Root>
+          <Button
+            variant={selectedTags.size > 0 ? 'solid' : 'surface'}
+            color={showFilters || selectedTags.size > 0 ? undefined : 'gray'}
+            onClick={() => setShowFilters((prev) => !prev)}
+            className="tabular-nums!"
+            aria-label={selectedTags.size > 0 ? `Filters (${selectedTags.size} active)` : 'Filters'}
+            aria-expanded={showFilters}
+            aria-controls={filterPanelId}
+          >
+            {selectedTags.size > 0 ? <TbFilterFilled /> : <TbFilter />}
+            Filter
+          </Button>
+        </Flex>
+        {showFilters && (
+          <FilterPanel
+            challenges={data}
+            selectedTags={selectedTags}
+            onTagToggle={(tag) => {
+              setSelectedTags((prev) => {
+                const newSet = new Set(prev);
+                if (newSet.has(tag)) {
+                  newSet.delete(tag);
+                } else {
+                  newSet.add(tag);
+                }
+                return newSet;
+              });
+            }}
+            id={filterPanelId}
+          />
+        )}
+        <Flex direction="row" gap="2" justify="between" mt="1">
+          <Text
+            color="gray"
+            size="2"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            Showing
+            {' '}
+            {filteredResults.length}
+            {' '}
+            of
+            {' '}
+            {data.length}
+            {' '}
+            challenge
+            {data.length !== 1 && 's'}
+          </Text>
+          {selectedTags.size > 0 && (
+            <Flex direction="row" gap="1" align="center">
+              <Text size="2" color="gray">
+                {selectedTags.size}
+                {' '}
+                filter
+                {selectedTags.size !== 1 && 's'}
+                {' '}
+                active
+              </Text>
+              <Tooltip content="Clear filters">
+                <Button
+                  variant="ghost"
+                  color={COLOR_NEGATIVE}
+                  size="1"
+                  className="m-0! p-1!"
+                  onClick={() => setSelectedTags(new Set())}
+                >
+                  <TbFilterOff />
+                </Button>
+              </Tooltip>
+            </Flex>
+          )}
+        </Flex>
+        {filteredResults.length === 0 && !isLoading && (
+          <InfoCallout className="mt-3">
+            No challenges found.
+          </InfoCallout>
+        )}
       </Container>
       <Container size="4">
         {myError && (<ErrorCallout className="mb-3">Failed to load your progress.</ErrorCallout>)}
@@ -53,7 +212,7 @@ export default function EventChallenges({ eventId }: {eventId: number}) {
               <Skeleton><Card className="!h-18" /></Skeleton>
             </>
           )}
-          {filteredChallenges.map((challenge) => (
+          {filteredResults.map((challenge) => (
             <ChallengeCard
               challenge={challenge}
               progress={challengeProgressMap[challenge.id]}

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/FilterPanel.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/FilterPanel.tsx
@@ -1,0 +1,96 @@
+import { OTHER_TAXONOMY } from '@/constants';
+import type { Challenge } from '@/types';
+import { getTaxonomy, prettyPrintTag } from '@/util';
+import {
+  Button,
+  Card,
+  DataList,
+  Flex,
+  Inset,
+  Text,
+} from '@radix-ui/themes';
+import { groupBy } from 'lodash';
+import { useMemo } from 'react';
+
+export default function FilterPanel({
+  challenges,
+  selectedTags,
+  onTagToggle,
+  id,
+}: {
+  challenges: Challenge[];
+  selectedTags: Set<string>;
+  onTagToggle: (tag: string) => void;
+  id: string;
+}) {
+  // group all tags by taxonomy, sort tags within each taxonomy by frequency for display
+  const taxonomizedTags = useMemo(() => {
+    // compute tag frequencies across all challenges
+    const tagFrequencies = new Map<string, number>();
+    challenges.forEach((challenge) => {
+      challenge.tags.forEach((tag) => {
+        tagFrequencies.set(tag, (tagFrequencies.get(tag) ?? 0) + 1);
+      });
+    });
+
+    // group tags by taxonomy (the part before the last colon, or OTHER_TAXONOMY if no colon)
+    const grouped = groupBy(Array.from(tagFrequencies.keys()), getTaxonomy);
+
+    // sort tags within each taxonomy by frequency
+    Object.keys(grouped).forEach((taxonomy) => {
+      grouped[taxonomy].sort((a, b) => (tagFrequencies.get(b) || 0) - (tagFrequencies.get(a) || 0));
+    });
+
+    return grouped;
+  }, [ challenges ]);
+
+  return (
+    <Card mt="1" id={id} role="region" aria-label="Filters">
+      <Inset side="all" className="max-h-64 overflow-y-auto! p-3">
+        <DataList.Root>
+          {Object.entries(taxonomizedTags)
+            .sort(([ a ], [ b ]) => {
+              // sort alphabetically, but with OTHER_TAXONOMY last
+              if (a === OTHER_TAXONOMY) return 1;
+              if (b === OTHER_TAXONOMY) return -1;
+              return a.localeCompare(b);
+            })
+            .map(([ taxonomy, tags ]) => (
+              <DataList.Item key={taxonomy}>
+                <DataList.Label className="translate-y-0.5" id={`${id}-${taxonomy}`}>{taxonomy}</DataList.Label>
+                <DataList.Value>
+                  <Flex
+                    direction="row"
+                    gap="1"
+                    wrap="wrap"
+                    role="group"
+                    aria-labelledby={`${id}-${taxonomy}`}
+                  >
+                    {tags.map((tag) => {
+                      const selected = selectedTags.has(tag);
+                      return (
+                        <Button
+                          key={tag}
+                          radius="full"
+                          size="1"
+                          variant={selected ? 'solid' : 'outline'}
+                          color={selected ? undefined : 'gray'}
+                          aria-pressed={selected}
+                          onClick={() => onTagToggle(tag)}
+                        >
+                          {prettyPrintTag(tag)}
+                        </Button>
+                      );
+                    })}
+                  </Flex>
+                </DataList.Value>
+              </DataList.Item>
+            ))}
+        </DataList.Root>
+        {Object.entries(taxonomizedTags).length === 0 && (
+          <Text color="gray">No filters available.</Text>
+        )}
+      </Inset>
+    </Card>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -76,6 +76,7 @@ export interface Challenge {
   num_questions: number;
   total_points: number;
   event_name?: string;
+  tags: string[];
 }
 
 export interface MeChallenge {

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -123,3 +123,16 @@ export function getTaxonomy(tag: string) {
   const parts = tag.split(':');
   return parts.length > 1 ? parts.slice(0, -1).join(':') : OTHER_TAXONOMY;
 }
+
+export function tagComparator(a: string, b: string) {
+  // sort tags alphabetically. tags without a taxonomy (:) should go last
+  const aHasTaxonomy = a.includes(':');
+  const bHasTaxonomy = b.includes(':');
+  if (aHasTaxonomy && !bHasTaxonomy) {
+    return -1;
+  }
+  if (!aHasTaxonomy && bHasTaxonomy) {
+    return 1;
+  }
+  return a.localeCompare(b);
+}

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -1,3 +1,4 @@
+import { OTHER_TAXONOMY } from '@/constants';
 import { useEffect, useState } from 'react';
 
 /**
@@ -110,12 +111,15 @@ export function useBreakpoint(minWidth: string) {
 }
 
 export function prettyPrintTag(tag: string) {
+  // Extract the tag itself, dropping any taxonomy prefix.
+  // We don't do any additional formatting here to prevent different tags being normalized
+  // to the same thing visually while still showing separately, which could cause confusion.
+  // Capitalization, spacing, etc. are all governed by what the challenge creator inputs.
   const parts = tag.split(':');
-  return parts[parts.length - 1]
-    .replace(/[-_]+/g, ' ') // kebab/snake → spaces
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2') // split acronym before capitalized word
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // split camelCase (lower/num → upper)
-    .trim()
-    .replace(/\s+/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase()); // capitalize each word
+  return parts[parts.length - 1].trim();
+}
+
+export function getTaxonomy(tag: string) {
+  const parts = tag.split(':');
+  return parts.length > 1 ? parts.slice(0, -1).join(':') : OTHER_TAXONOMY;
 }

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -108,3 +108,14 @@ export function useBreakpoint(minWidth: string) {
 
   return matches;
 }
+
+export function prettyPrintTag(tag: string) {
+  const parts = tag.split(':');
+  return parts[parts.length - 1]
+    .replace(/[-_]+/g, ' ') // kebab/snake → spaces
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2') // split acronym before capitalized word
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // split camelCase (lower/num → upper)
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase()); // capitalize each word
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      minisearch:
+        specifier: ^7.2.0
+        version: 7.2.0
       radix-ui:
         specifier: ^1.4.2
         version: 1.4.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -129,10 +132,10 @@ importers:
         version: 8.57.1
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@5.2.0(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1)
+        version: 19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@5.2.0(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-airbnb-typescript:
         specifier: ^18.0.0
-        version: 18.0.0(@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+        version: 18.0.0(@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1)
@@ -3899,6 +3902,9 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   minizlib@3.0.2:
     resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
@@ -8627,6 +8633,15 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+    dependencies:
+      confusing-browser-globals: 1.0.11
+      eslint: 8.57.1
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      object.assign: 4.1.7
+      object.entries: 1.1.9
+      semver: 6.3.1
+
   eslint-config-airbnb-typescript@18.0.0(@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.42.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
@@ -8636,10 +8651,30 @@ snapshots:
     transitivePeerDependencies:
       - eslint-plugin-import
 
+  eslint-config-airbnb-typescript@18.0.0(@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.42.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.42.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint: 8.57.1
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - eslint-plugin-import
+
   eslint-config-airbnb@19.0.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@5.2.0(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
+      eslint-plugin-react: 7.37.5(eslint@8.57.1)
+      eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
+      object.assign: 4.1.7
+      object.entries: 1.1.9
+
+  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@5.2.0(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -9888,6 +9923,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minisearch@7.2.0: {}
 
   minizlib@3.0.2:
     dependencies:


### PR DESCRIPTION
Update sorting/filtering on the event page:
- Search bar now uses `minisearch` to index across name, summary, description, and tags for fast searching. I've verified with a few hundred challenges with large metadata and observed no slowdown after applying some optimizations.
- Tags as defined in YAML are used to construct the filter UI. Tags can be clicked to toggle them on and off.
  - Only tags that are present within the current event are listed.
  - The filter panel is collapsed by default on page load to put focus on the challenges - users that want to narrow things down can click the "Filter" button to access it.
  - Tag groups are determined by taxonomy, in YAML this looks like `Taxonomy:Tag`. YAML is the source of truth for capitalization and spacing, the platform itself doesn't normalize or apply semantic meaning to tags to give as much flexibility as possible.
  - Tags/taxonomies are sorted deterministically. This is alphabetical in most cases (including the taxonomy as part of the string), though tags are sorted by frequency in the filter panel for easy access to the most common ones. No special cases exist for custom ordering (again, YAML is the source of truth.)
- Tags are also now listed on the challenge admin panel adjacent to the description. These are listed in full without truncation.

<img width="1172" height="412" alt="image" src="https://github.com/user-attachments/assets/7b303aa8-5175-4c8e-bd3b-734fa9a3bbfa" />
<img width="720" height="257" alt="image" src="https://github.com/user-attachments/assets/b707a0fd-58c1-438d-8e9b-f9412db67b83" />
