### PR TITLE
Populate last team name by default during registration

### DIFF
--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -1,5 +1,6 @@
 import { ROUTEPREFIX } from '@/constants';
 import { apiMutation } from '@/fetchers';
+import { useMyEvents } from '@/hooks/events';
 import type {
   AdminUser,
   Event,
@@ -7,6 +8,7 @@ import type {
   User,
   Workspace,
 } from '@/types';
+import { keyBy } from 'lodash';
 import useSWR, { mutate } from 'swr';
 
 /**
@@ -80,6 +82,29 @@ export function useMyTeams() {
   return useSWR<Team[], Error>(
     '/users/me/teams',
   );
+}
+
+/**
+ * Gets the most recent team/leaderboard name the user has been associated with.
+ * @param isTeamGame Whether to look for the last team event name (true) or individual event leaderboard name (false).
+ */
+export function usePreviousName(isTeamGame: boolean) {
+  // get both teams and events here to allow filtering by event properties
+  const { data : myTeams = [], isLoading : teamsLoading } = useMyTeams();
+  const { data : myEvents = [], isLoading : eventsLoading } = useMyEvents();
+
+  const eventsById = keyBy(myEvents, 'id');
+  const filteredTeams = myTeams
+    .filter((team) => {
+      const event = eventsById[team.event_id];
+
+      // we don't want to populate auto-generated names into the registration form, only past user-provided ones.
+      // also don't fill past team names for individual events and vice versa.
+      return !!event && !event.practice && (isTeamGame ? event.max_team_size > 1 : event.max_team_size === 1);
+    });
+
+  // last item in the list is the most recent team join, get the name associated with that or null if not present.
+  return { data : filteredTeams.at(-1)?.name || null, isLoading : teamsLoading || eventsLoading };
 }
 
 /* Get the user's sponsor/affiliation */

--- a/frontend/src/routes/events/RegistrationModal.tsx
+++ b/frontend/src/routes/events/RegistrationModal.tsx
@@ -6,6 +6,7 @@ import Modal from 'components/Modal';
 import { isUndefined } from 'lodash';
 import { TbDoorEnter } from 'react-icons/tb';
 import { useNavigate, useParams } from 'react-router';
+import { usePreviousName } from '@/hooks/users';
 import RegistrationDataForm from './RegistrationDataForm';
 
 export default function RegistrationModal({ eventId, eventName, isTeamGame }: {eventId : Event['id'], eventName: string, isTeamGame: boolean}) {
@@ -13,6 +14,9 @@ export default function RegistrationModal({ eventId, eventName, isTeamGame }: {e
   const joinWithCode = !!(eventId === Number(idEvent) && !isUndefined(inviteCode));
 
   const navigate = useNavigate();
+
+  // capture loading state here to ensure modal can't be opened until defaults are set
+  const { data : prevName, isLoading : prevNameLoading } = usePreviousName(isTeamGame);
 
   const handleRegister = async (data: { leaderboardName: string; joinCode: string; termsConditions: boolean, selectedOption: string }) => {
     const { leaderboardName, selectedOption } = data;
@@ -36,7 +40,7 @@ export default function RegistrationModal({ eventId, eventName, isTeamGame }: {e
     <Modal
       title={`Register for ${eventName}`}
       trigger={(
-        <Button color={COLOR_POSITIVE}>
+        <Button color={COLOR_POSITIVE} loading={prevNameLoading}>
           <TbDoorEnter />
           Register
         </Button>
@@ -45,7 +49,7 @@ export default function RegistrationModal({ eventId, eventName, isTeamGame }: {e
       submitVerb="Register"
       defaultOpen={joinWithCode}
       defaultValues={{
-        leaderboardName : '',
+        leaderboardName : prevName || '',
         termsConditions : false,
         selectedOption : joinWithCode ? 'join-team' : 'create-team',
       }}


### PR DESCRIPTION
Adds a `usePreviousName` hook to retrieve the previous name, which is used to autofill event registration forms.

Team event registration will be autofilled with the user's previous team name and individual event registration will be autofilled with the previous individual leaderboard name - they will not mix to avoid potential collisions.

Events with the practice flag are skipped, since the names used for those are automatically generated and not user-provided.