### PR TITLE
Add date time stamps for container instances

### DIFF
--- a/backend/ng/containers/models/ContainerInstance.py
+++ b/backend/ng/containers/models/ContainerInstance.py
@@ -15,6 +15,7 @@ from .. constants import DOCKER_RUNNING, DOCKER_BRIDGE, DOCKER_MEM_REGEX, DOCKER
 from ...challenge.models.ContainerBlueprint import ContainerBlueprint
 from ...team.models.Team import Team
 from ...core import BusinessLogicError
+from ...core.utils import utc_now
 from ..utils.redis import get_redis_client
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ class SerializedContainerInstance(TypedDict):
     team_id: int
     hostip: str
     dockerid: str
+    created_at: str | None
 
 class ContainerInstance(db.Model):
     __tablename__ = "ng_container_instances"
@@ -43,7 +45,8 @@ class ContainerInstance(db.Model):
     team_id = db.Column(db.Integer, db.ForeignKey("ng_teams.id"), nullable=False)
     hostip = db.Column(db.String(255), nullable=False)
     dockerid: Mapped[str] = db.Column(db.String(255), nullable=False)
-
+    # Allow nullabe for old containers that don't have a start time
+    created_at = db.Column(db.DateTime, nullable=True, default=utc_now)
     team = db.relationship("Team")
 
     def __repr__(self):
@@ -470,6 +473,7 @@ class ContainerInstance(db.Model):
             team_id=self.team_id,
             hostip=self.hostip,
             dockerid=self.dockerid,
+            created_at=self.created_at,
        )
 
 

--- a/frontend/src/routes/admin/deployments/ServiceCard.tsx
+++ b/frontend/src/routes/admin/deployments/ServiceCard.tsx
@@ -48,12 +48,12 @@ export default function ServiceCard({ service }: { service: ContainerInstance })
             </Tooltip>
             <br />
             <Text color="gray">{hostip}</Text>
-            {createdAt ? (
+            {createdAt && (
               <>
                 <br />
                 <Text color="gray">{createdAt?.toLocaleString()}</Text>
               </>
-            ) : null}
+            )}
           </Box>
         </Flex>
         <Skeleton loading={!statusData}>

--- a/frontend/src/routes/admin/deployments/ServiceCard.tsx
+++ b/frontend/src/routes/admin/deployments/ServiceCard.tsx
@@ -22,7 +22,7 @@ import RestartContainerModal from './RestartContainerModal';
 export default function ServiceCard({ service }: { service: ContainerInstance }) {
   const { data : statusData, error } = useContainerStatus(service.id);
 
-  const { dockerid, hostip } = service;
+  const { dockerid, hostip, created_at : createdAt } = service;
   const {
     name, image, status, env,
   } = statusData || {};
@@ -48,6 +48,12 @@ export default function ServiceCard({ service }: { service: ContainerInstance })
             </Tooltip>
             <br />
             <Text color="gray">{hostip}</Text>
+            {createdAt ? (
+              <>
+                <br />
+                <Text color="gray">{createdAt?.toLocaleString()}</Text>
+              </>
+            ) : null}
           </Box>
         </Flex>
         <Skeleton loading={!statusData}>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -214,6 +214,7 @@ export interface ContainerInstance {
   team_id: number;
   hostip: string;
   dockerid: string;
+  created_at?: Date;
 }
 
 export interface ContainerStatus {


### PR DESCRIPTION
Chris had asked for us to add timestamps for when challenge containers get created. Including a screenshot of the admin panel image as well.
<img width="729" height="570" alt="Screenshot 2026-07-07 at 10 21 47 AM" src="https://github.com/user-attachments/assets/3da50927-1f1b-4595-81c6-c7f2cb6ac2e0" />
