### PR TITLE
Make date parsing explicit at the component level

### DIFF
--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -1,5 +1,6 @@
 import { TeamIcon, UserIcon } from '@/constants';
 import type { Event } from '@/types';
+import { formatDate } from '@/util';
 import {
   Box,
   Card,
@@ -48,7 +49,7 @@ export default function EventCard({ event }: { event: Event }) {
                 <Text size="2" color="gray">
                   <TbCalendarEvent className="inline" aria-label="Event start time" />
                   {' '}
-                  {event.start_time?.toLocaleString([], {
+                  {formatDate(event.start_time, {
                     year : 'numeric', month : 'numeric', day : 'numeric', hour : '2-digit', minute : '2-digit',
                   })}
                 </Text>

--- a/frontend/src/components/EventGrid.tsx
+++ b/frontend/src/components/EventGrid.tsx
@@ -12,14 +12,14 @@ import EventSection from './EventSection';
 
 export default function EventGrid({ events, loading = false, group = false } : { events: Event[], loading?: boolean, group?: boolean }) {
   const sortedEvents = useMemo(() => events.slice().sort((a, b) => {
-    const dateA = a.start_time?.getTime() || 0;
-    const dateB = b.start_time?.getTime() || 0;
+    const dateA = a.start_time ? new Date(a.start_time).getTime() : 0;
+    const dateB = b.start_time ? new Date(b.start_time).getTime() : 0;
     return dateA - dateB;
   }), [ events ]);
 
   const groupedEvents = useMemo(() => {
     if (!group) return { Unknown : sortedEvents };
-    return groupBy(sortedEvents, (event) => event.start_time?.getFullYear()?.toString() || 'Unknown');
+    return groupBy(sortedEvents, (event) => (event.start_time ? new Date(event.start_time).getFullYear().toString() : 'Unknown'));
   }, [ sortedEvents, group ]);
 
   return (

--- a/frontend/src/components/EventHeader.tsx
+++ b/frontend/src/components/EventHeader.tsx
@@ -1,4 +1,5 @@
 import type { Event } from '@/types';
+import { formatDate } from '@/util';
 import {
   Box,
   Flex,
@@ -28,7 +29,7 @@ export default function EventHeader({
     max_team_size : maxTeamSize,
   } = event;
 
-  const dateRange = (!isNull(startTime) && !isNull(endTime)) && `${startTime?.toLocaleString()} - ${endTime?.toLocaleString()}`;
+  const dateRange = (!isNull(startTime) && !isNull(endTime)) && `${formatDate(startTime)} - ${formatDate(endTime)}`;
 
   return (
     <Flex direction="row" gap="6" align="start">

--- a/frontend/src/components/NotificationsPopover.tsx
+++ b/frontend/src/components/NotificationsPopover.tsx
@@ -7,6 +7,7 @@ import {
   useNotificationSoundEnabled,
 } from '@/hooks/notifications';
 import type { Notification } from '@/types';
+import { formatDate } from '@/util';
 import {
   Button,
   Card,
@@ -94,7 +95,7 @@ export default function NotificationsPopover({ triggerClassName, contentClassNam
       >
         <Flex direction="column">
           <Text weight={notif.read_at ? 'regular' : 'bold'}>{notif.title}</Text>
-          <Text size="1">{notif.created_at.toLocaleDateString('en-US', dateFormat)}</Text>
+          <Text size="1">{formatDate(notif.created_at, dateFormat)}</Text>
           <Text size="2" wrap="pretty" className="pt-2">{notif.message}</Text>
         </Flex>
       </Card>

--- a/frontend/src/components/TicketMessagesCard/index.tsx
+++ b/frontend/src/components/TicketMessagesCard/index.tsx
@@ -1,4 +1,5 @@
 import type { TicketMessage } from '@/types';
+import { formatDate } from '@/util';
 import {
   Card,
   Flex,
@@ -33,7 +34,7 @@ export default function TicketMessagesCard({
         >
           <Flex justify="between">
             <Text weight="bold" size="2">{message.author_name}</Text>
-            <Text weight="bold" size="2">{message.created_at.toLocaleString()}</Text>
+            <Text weight="bold" size="2">{formatDate(message.created_at)}</Text>
           </Flex>
           <Separator size="4" className="mb-1" />
           <RadixMarkdown>

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -12,19 +12,8 @@ async function parseResponseData(res: Response) {
   let parsedData: unknown;
 
   try {
-    // Attempt to parse the response as JSON
-    parsedData = JSON.parse(data, (_key, value) => {
-      // if the value is an ISO date, parse it into a Date object
-      if (
-        typeof value === 'string'
-        && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value)
-      ) {
-        return new Date(value);
-      }
-
-      // otherwise, return the value as is
-      return value;
-    });
+    // Date fields are kept as raw ISO strings; convert to Date at the point of use.
+    parsedData = JSON.parse(data);
   } catch {
     throw new Error(`Failed to parse API response. (${res.status})`);
   }

--- a/frontend/src/grid.ts
+++ b/frontend/src/grid.ts
@@ -1,7 +1,33 @@
-import { AllCommunityModule, ModuleRegistry, themeQuartz } from 'ag-grid-community';
+import {
+  AllCommunityModule,
+  ModuleRegistry,
+  provideGlobalGridOptions,
+  themeQuartz,
+} from 'ag-grid-community';
+import { formatDate } from '@/util';
 
 // Register AG grid community modules.
 ModuleRegistry.registerModules([ AllCommunityModule ]);
+
+// Set global date handling behavior.
+provideGlobalGridOptions({
+  dataTypeDefinitions : {
+    dateString : {
+      baseDataType : 'dateString',
+      extendsDataType : 'dateString',
+      // flatten to date only when parsing dates for filters
+      dateParser : (value) => {
+        const parsed = value ? new Date(value) : undefined;
+        return parsed && !Number.isNaN(parsed.getTime())
+          ? new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate())
+          : undefined;
+      },
+      dateFormatter : (date) => date?.toISOString(),
+      // use our date formatter for display
+      valueFormatter : ({ value }) => formatDate(value),
+    },
+  },
+});
 
 // Theme to adapt radix colors to ag-grid.
 // eslint-disable-next-line import/prefer-default-export

--- a/frontend/src/hooks/events.ts
+++ b/frontend/src/hooks/events.ts
@@ -35,13 +35,13 @@ export function useEventStatus(eventId: number | null) {
 
   return {
     isRegistrationOpen : !!(data && data.registration_open
-      && (!data.registration_start_date || data.registration_start_date <= new Date())
-      && (!data.registration_end_date || data.registration_end_date >= new Date())
+      && (!data.registration_start_date || new Date(data.registration_start_date) <= new Date())
+      && (!data.registration_end_date || new Date(data.registration_end_date) >= new Date())
     ),
     isOngoing : !!(data
-       && (!data.start_time || data.start_time <= new Date())
-       && (!data.end_time || data.end_time >= new Date())),
-    isConcluded : !!(data && data.end_time && data.end_time < new Date()),
+       && (!data.start_time || new Date(data.start_time) <= new Date())
+       && (!data.end_time || new Date(data.end_time) >= new Date())),
+    isConcluded : !!(data && data.end_time && new Date(data.end_time) < new Date()),
     isLoading,
     error,
     event : data,

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -68,7 +68,7 @@ export function useRegistration(eventId: number | null) {
     isRegistered : !!myTeam,
     isUnregistered : !myTeam && !isLoading && !error,
     isStarted : !!myTeam?.start_timestamp,
-    isFinished : !!(myTeam?.end_time && myTeam.end_time < new Date()),
+    isFinished : !!(myTeam?.end_time && new Date(myTeam.end_time) < new Date()),
     team : myTeam,
     error,
     isLoading,

--- a/frontend/src/routes/admin/announcements/index.tsx
+++ b/frontend/src/routes/admin/announcements/index.tsx
@@ -10,6 +10,7 @@ import Entity from 'components/Entity';
 import { UserIcon, COLOR_NEGATIVE } from '@/constants';
 import type { ColDef, ICellRendererParams } from 'ag-grid-community';
 import type { Announcement } from '@/types';
+import { formatDate } from '@/util';
 import { AgGridReact, type CustomCellRendererProps } from 'ag-grid-react';
 import { radixTheme } from '@/grid';
 import { useCallback, useMemo, useState } from 'react';
@@ -61,11 +62,13 @@ export default function AdminAnnouncements() {
     }, {
       field : 'created_at',
       headerName : 'Created Date',
-      valueFormatter : (params) => params.value?.toLocaleString(),
+      cellDataType : 'dateString',
+      valueFormatter : (params) => formatDate(params.value),
     }, {
       field : 'expires_at',
       headerName : 'Expiration Date',
-      valueFormatter : (params) => params.value?.toLocaleString(),
+      cellDataType : 'dateString',
+      valueFormatter : (params) => formatDate(params.value),
     }, {
       field : 'type',
       headerName : 'type',

--- a/frontend/src/routes/admin/announcements/index.tsx
+++ b/frontend/src/routes/admin/announcements/index.tsx
@@ -10,7 +10,6 @@ import Entity from 'components/Entity';
 import { UserIcon, COLOR_NEGATIVE } from '@/constants';
 import type { ColDef, ICellRendererParams } from 'ag-grid-community';
 import type { Announcement } from '@/types';
-import { formatDate } from '@/util';
 import { AgGridReact, type CustomCellRendererProps } from 'ag-grid-react';
 import { radixTheme } from '@/grid';
 import { useCallback, useMemo, useState } from 'react';
@@ -63,12 +62,10 @@ export default function AdminAnnouncements() {
       field : 'created_at',
       headerName : 'Created Date',
       cellDataType : 'dateString',
-      valueFormatter : (params) => formatDate(params.value),
     }, {
       field : 'expires_at',
       headerName : 'Expiration Date',
       cellDataType : 'dateString',
-      valueFormatter : (params) => formatDate(params.value),
     }, {
       field : 'type',
       headerName : 'type',

--- a/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeAttemptsTab.tsx
+++ b/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeAttemptsTab.tsx
@@ -2,6 +2,7 @@ import { TeamIcon, UserIcon } from '@/constants';
 import { radixTheme } from '@/grid';
 import { useAdminChallengeAttempts } from '@/hooks/challenge';
 import type { Attempt } from '@/types';
+import { formatDate } from '@/util';
 import { Spinner } from '@radix-ui/themes';
 import { AgGridReact, type CustomCellRendererProps } from 'ag-grid-react';
 import { ErrorCallout } from 'components/Callouts';
@@ -22,11 +23,12 @@ export default function ChallengeAttemptsTab({ challengeId }: {challengeId: numb
           field : 'timestamp',
           headerName : 'Timestamp',
           minWidth : 180,
+          cellDataType : 'dateString',
           sortable : true,
           filter : true,
           pinned : 'left',
           sort : 'desc',
-          valueFormatter : (params) => params.value.toLocaleString(),
+          valueFormatter : (params) => formatDate(params.value),
         },
         {
           field : 'team_name',

--- a/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeAttemptsTab.tsx
+++ b/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeAttemptsTab.tsx
@@ -2,7 +2,6 @@ import { TeamIcon, UserIcon } from '@/constants';
 import { radixTheme } from '@/grid';
 import { useAdminChallengeAttempts } from '@/hooks/challenge';
 import type { Attempt } from '@/types';
-import { formatDate } from '@/util';
 import { Spinner } from '@radix-ui/themes';
 import { AgGridReact, type CustomCellRendererProps } from 'ag-grid-react';
 import { ErrorCallout } from 'components/Callouts';
@@ -28,7 +27,6 @@ export default function ChallengeAttemptsTab({ challengeId }: {challengeId: numb
           filter : true,
           pinned : 'left',
           sort : 'desc',
-          valueFormatter : (params) => formatDate(params.value),
         },
         {
           field : 'team_name',

--- a/frontend/src/routes/admin/deployments/ServiceCard.tsx
+++ b/frontend/src/routes/admin/deployments/ServiceCard.tsx
@@ -1,6 +1,7 @@
 import { COLOR_NEGATIVE, COLOR_POSITIVE } from '@/constants';
 import { useContainerStatus } from '@/hooks/container';
 import type { ContainerInstance } from '@/types';
+import { formatDate } from '@/util';
 import {
   Badge,
   Box,
@@ -51,7 +52,7 @@ export default function ServiceCard({ service }: { service: ContainerInstance })
             {createdAt && (
               <>
                 <br />
-                <Text color="gray">{createdAt?.toLocaleString()}</Text>
+                <Text color="gray">{formatDate(createdAt)}</Text>
               </>
             )}
           </Box>

--- a/frontend/src/routes/admin/events/SidebarTabs/EventGameplayTab.tsx
+++ b/frontend/src/routes/admin/events/SidebarTabs/EventGameplayTab.tsx
@@ -1,5 +1,5 @@
 import type { Event } from '@/types';
-import { adjustDateForInput } from '@/util';
+import { adjustDateForInput, formatDate } from '@/util';
 import { omit } from 'lodash';
 import {
   Box,
@@ -29,16 +29,16 @@ export default function EventGameplayTab({ event }: { event: Event }) {
   } = useForm<Event>({
     defaultValues : {
       ...omit(event, 'id'),
-      start_time : adjustDateForInput(event?.start_time || null) as unknown as Date,
-      end_time : adjustDateForInput(event?.end_time || null) as unknown as Date,
+      start_time : adjustDateForInput(event?.start_time || null),
+      end_time : adjustDateForInput(event?.end_time || null),
     },
   });
 
   useEffect(() => {
     reset({
       ...omit(event, 'id'),
-      start_time : adjustDateForInput(event?.start_time || null) as unknown as Date,
-      end_time : adjustDateForInput(event?.end_time || null) as unknown as Date,
+      start_time : adjustDateForInput(event?.start_time || null),
+      end_time : adjustDateForInput(event?.end_time || null),
     });
   }, [ event, reset ]);
 
@@ -193,8 +193,8 @@ export default function EventGameplayTab({ event }: { event: Event }) {
       ) : (
         <>
           <Statistic label="Max Team Size" value={event.max_team_size} />
-          <Statistic label="Event Starts" value={event.start_time?.toLocaleString() || 'N/A'} />
-          <Statistic label="Event Ends" value={event.end_time?.toLocaleString() || 'N/A'} />
+          <Statistic label="Event Starts" value={formatDate(event.start_time) || 'N/A'} />
+          <Statistic label="Event Ends" value={formatDate(event.end_time) || 'N/A'} />
           <Statistic label="Time Limit" value={event.time_limit_minutes ? `${event.time_limit_minutes} minutes` : 'N/A'} />
           <Statistic label="Hints Enabled" value={event.hints_enabled ? 'Yes' : 'No'} />
           <Statistic label="Show Leaderboard" value={event.show_leaderboard ? 'Yes' : 'No'} />

--- a/frontend/src/routes/admin/events/SidebarTabs/EventRegistrationTab.tsx
+++ b/frontend/src/routes/admin/events/SidebarTabs/EventRegistrationTab.tsx
@@ -1,5 +1,5 @@
 import type { Event } from '@/types';
-import { adjustDateForInput } from '@/util';
+import { adjustDateForInput, formatDate } from '@/util';
 import { omit } from 'lodash';
 import {
   Box,
@@ -29,16 +29,16 @@ export default function EventRegistrationTab({ event }: { event: Event }) {
   } = useForm<Event>({
     defaultValues : {
       ...omit(event, 'id'),
-      registration_start_date : adjustDateForInput(event?.registration_start_date || null) as unknown as Date,
-      registration_end_date : adjustDateForInput(event?.registration_end_date || null) as unknown as Date,
+      registration_start_date : adjustDateForInput(event?.registration_start_date || null),
+      registration_end_date : adjustDateForInput(event?.registration_end_date || null),
     },
   });
 
   useEffect(() => {
     reset({
       ...omit(event, 'id'),
-      registration_start_date : adjustDateForInput(event?.registration_start_date || null) as unknown as Date,
-      registration_end_date : adjustDateForInput(event?.registration_end_date || null) as unknown as Date,
+      registration_start_date : adjustDateForInput(event?.registration_start_date || null),
+      registration_end_date : adjustDateForInput(event?.registration_end_date || null),
     });
   }, [ event, reset ]);
 
@@ -211,8 +211,8 @@ export default function EventRegistrationTab({ event }: { event: Event }) {
           <Statistic label="Public" value={event.public ? 'Yes' : 'No'} />
           <Statistic label="Teams Locked" value={event.locked ? 'Yes' : 'No'} />
           <Statistic label="Registration Open" value={event.registration_open ? 'Yes' : 'No'} />
-          <Statistic label="Registration Starts" value={event.registration_start_date?.toLocaleString() || 'N/A'} />
-          <Statistic label="Registration Ends" value={event.registration_end_date?.toLocaleString() || 'N/A'} />
+          <Statistic label="Registration Starts" value={formatDate(event.registration_start_date) || 'N/A'} />
+          <Statistic label="Registration Ends" value={formatDate(event.registration_end_date) || 'N/A'} />
           <Statistic
             label="Practice"
             value={event.practice ? 'Yes' : 'No'}

--- a/frontend/src/routes/admin/events/index.tsx
+++ b/frontend/src/routes/admin/events/index.tsx
@@ -1,5 +1,6 @@
 import { useAllEvents } from '@/hooks/events';
 import type { Event } from '@/types';
+import { formatDate } from '@/util';
 import { Flex } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
@@ -31,28 +32,32 @@ const colDefs: ColDef<Event>[] = [
     field : 'start_time',
     headerName : 'Start Time',
     sort : 'desc',
-    valueFormatter : (params) => params.value && params.value.toLocaleString(),
+    cellDataType : 'dateString',
+    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },
   {
     field : 'end_time',
     headerName : 'End Time',
-    valueFormatter : (params) => params.value && params.value.toLocaleString(),
+    cellDataType : 'dateString',
+    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },
   {
     field : 'registration_start_date',
     headerName : 'Registration Start',
-    valueFormatter : (params) => params.value && params.value.toLocaleString(),
+    cellDataType : 'dateString',
+    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },
   {
     field : 'registration_end_date',
     headerName : 'Registration End',
-    valueFormatter : (params) => params.value && params.value.toLocaleString(),
+    cellDataType : 'dateString',
+    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },

--- a/frontend/src/routes/admin/events/index.tsx
+++ b/frontend/src/routes/admin/events/index.tsx
@@ -1,6 +1,5 @@
 import { useAllEvents } from '@/hooks/events';
 import type { Event } from '@/types';
-import { formatDate } from '@/util';
 import { Flex } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
@@ -33,7 +32,6 @@ const colDefs: ColDef<Event>[] = [
     headerName : 'Start Time',
     sort : 'desc',
     cellDataType : 'dateString',
-    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },
@@ -41,7 +39,6 @@ const colDefs: ColDef<Event>[] = [
     field : 'end_time',
     headerName : 'End Time',
     cellDataType : 'dateString',
-    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },
@@ -49,7 +46,6 @@ const colDefs: ColDef<Event>[] = [
     field : 'registration_start_date',
     headerName : 'Registration Start',
     cellDataType : 'dateString',
-    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },
@@ -57,7 +53,6 @@ const colDefs: ColDef<Event>[] = [
     field : 'registration_end_date',
     headerName : 'Registration End',
     cellDataType : 'dateString',
-    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },

--- a/frontend/src/routes/admin/teams/EditTeamModal.tsx
+++ b/frontend/src/routes/admin/teams/EditTeamModal.tsx
@@ -21,12 +21,12 @@ export default function EditTeamModal({
 }) {
   const handleSubmit = async (data: Pick<Team, 'name' | 'ranked' | 'start_timestamp' | 'end_time'>) => adminUpdateTeam(teamToUpdate.id, data);
 
-  // Default value Dates must be converted to datetime-local string format, even though the value is typed as Date.
-  // This is because valueAsDate only applies to entered values, not default values.
+  // Default values must be converted to datetime-local string format.
+  // valueAsDate (below) only applies to entered values, not default values.
   const defaultValues: DefaultValues<Pick<Team, 'name' | 'ranked' | 'start_timestamp' | 'end_time'>> = {
     ...pick(teamToUpdate, [ 'name', 'ranked' ]),
-    start_timestamp : adjustDateForInput(teamToUpdate.start_timestamp || null) as unknown as Date,
-    end_time : adjustDateForInput(teamToUpdate.end_time || null) as unknown as Date,
+    start_timestamp : adjustDateForInput(teamToUpdate.start_timestamp || null),
+    end_time : adjustDateForInput(teamToUpdate.end_time || null),
   };
 
   return (

--- a/frontend/src/routes/admin/teams/TeamActivity.tsx
+++ b/frontend/src/routes/admin/teams/TeamActivity.tsx
@@ -2,6 +2,7 @@ import { ChallengeIcon, UserIcon } from '@/constants';
 import { radixTheme } from '@/grid';
 import { useTeamAttempts, useTeamHintRedemptions, useTeamManualAwards } from '@/hooks/scoring';
 import type { Attempt, HintRedemption, ManualPointAward } from '@/types';
+import { formatDate } from '@/util';
 import { Spinner } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
@@ -46,7 +47,8 @@ const colDefs: ColDef<Attempt | HintRedemption | ManualPointAward>[] = [
   },
   {
     field : 'timestamp',
-    valueFormatter : ({ value }) => value.toLocaleString(),
+    cellDataType : 'dateString',
+    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
     sort : 'desc',
@@ -143,7 +145,7 @@ export default function TeamActivity({ eventId, teamId }: { eventId: number, tea
   // memoize merging the arrays, sorting by timestamp (descending)
   const merged = useMemo(
     () => [ ...(attempts ?? []), ...(hintRedemptions ?? []), ...(manualAwards ?? []) ]
-      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime()),
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()),
     [ attempts, hintRedemptions, manualAwards ],
   );
 

--- a/frontend/src/routes/admin/teams/TeamActivity.tsx
+++ b/frontend/src/routes/admin/teams/TeamActivity.tsx
@@ -2,7 +2,6 @@ import { ChallengeIcon, UserIcon } from '@/constants';
 import { radixTheme } from '@/grid';
 import { useTeamAttempts, useTeamHintRedemptions, useTeamManualAwards } from '@/hooks/scoring';
 import type { Attempt, HintRedemption, ManualPointAward } from '@/types';
-import { formatDate } from '@/util';
 import { Spinner } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
@@ -48,7 +47,6 @@ const colDefs: ColDef<Attempt | HintRedemption | ManualPointAward>[] = [
   {
     field : 'timestamp',
     cellDataType : 'dateString',
-    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
     sort : 'desc',

--- a/frontend/src/routes/admin/teams/TeamSidebar.tsx
+++ b/frontend/src/routes/admin/teams/TeamSidebar.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/constants';
 import { useTeamMembers } from '@/hooks/team';
 import type { Team } from '@/types';
+import { formatDate } from '@/util';
 import { Flex, Grid, Table } from '@radix-ui/themes';
 import AdminLink from 'components/AdminLink';
 import AdminSidebar from 'components/AdminSidebar';
@@ -72,12 +73,12 @@ export default function TeamSidebar({ entity }: { entity: Team }) {
 
         <Statistic
           label="Start Time"
-          value={entity.start_timestamp?.toLocaleString() || 'None'}
+          value={formatDate(entity.start_timestamp) || 'None'}
           size="5"
         />
         <Statistic
           label="End Time"
-          value={entity.end_time?.toLocaleString() || 'None'}
+          value={formatDate(entity.end_time) || 'None'}
           size="5"
         />
 
@@ -113,7 +114,7 @@ export default function TeamSidebar({ entity }: { entity: Team }) {
                 </Table.Cell>
                 <Table.Cell>{member.sponsor && <SponsorBadge sponsor={member.sponsor} />}</Table.Cell>
                 <Table.Cell><RoleBadge value={member.role} /></Table.Cell>
-                <Table.Cell>{member.joined_at.toLocaleString()}</Table.Cell>
+                <Table.Cell>{formatDate(member.joined_at)}</Table.Cell>
                 <Table.Cell>
                   <Flex direction="row" align="center" gap="4" justify="end">
                     <KickUserModal member={member} solo={members.length === 1} />

--- a/frontend/src/routes/admin/teams/index.tsx
+++ b/frontend/src/routes/admin/teams/index.tsx
@@ -1,7 +1,6 @@
 import { EventIcon } from '@/constants';
 import { useAllTeams } from '@/hooks/team';
 import type { Team } from '@/types';
-import { formatDate } from '@/util';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
@@ -51,7 +50,6 @@ const colDefs: ColDef<Team>[] = [
     cellDataType : 'dateString',
     filter : 'agDateColumnFilter',
     floatingFilter : true,
-    valueFormatter : ({ value }) => formatDate(value),
   },
   {
     field : 'end_time',
@@ -60,7 +58,6 @@ const colDefs: ColDef<Team>[] = [
     cellDataType : 'dateString',
     filter : 'agDateColumnFilter',
     floatingFilter : true,
-    valueFormatter : ({ value }) => formatDate(value),
   },
   {
     field : 'ranked',

--- a/frontend/src/routes/admin/teams/index.tsx
+++ b/frontend/src/routes/admin/teams/index.tsx
@@ -1,6 +1,7 @@
 import { EventIcon } from '@/constants';
 import { useAllTeams } from '@/hooks/team';
 import type { Team } from '@/types';
+import { formatDate } from '@/util';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
@@ -47,17 +48,19 @@ const colDefs: ColDef<Team>[] = [
     field : 'start_timestamp',
     headerName : 'Start Time',
     width : 200,
+    cellDataType : 'dateString',
     filter : 'agDateColumnFilter',
     floatingFilter : true,
-    valueFormatter : (params) => params.value?.toLocaleString(),
+    valueFormatter : ({ value }) => formatDate(value),
   },
   {
     field : 'end_time',
     headerName : 'End Time',
     width : 200,
+    cellDataType : 'dateString',
     filter : 'agDateColumnFilter',
     floatingFilter : true,
-    valueFormatter : (params) => params.value?.toLocaleString(),
+    valueFormatter : ({ value }) => formatDate(value),
   },
   {
     field : 'ranked',

--- a/frontend/src/routes/admin/tickets/MessagesSidebar.tsx
+++ b/frontend/src/routes/admin/tickets/MessagesSidebar.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/hooks/support';
 import { useCurrentUser, useUserEvents } from '@/hooks/users';
 import type { AdminTicket, TicketAttachment } from '@/types';
+import { formatDate } from '@/util';
 import {
   Badge,
   Box,
@@ -364,19 +365,19 @@ export default function MessagesSidebar({ entity : selectedRow }: { entity: Admi
         <DataList.Item>
           <DataList.Label>Opened Date</DataList.Label>
           <DataList.Value className="whitespace-pre-wrap">
-            {openedTimestamp && openedTimestamp.toLocaleString()}
+            {formatDate(openedTimestamp)}
           </DataList.Value>
         </DataList.Item>
         <DataList.Item>
           <DataList.Label>Closed Date</DataList.Label>
           <DataList.Value className="whitespace-pre-wrap">
-            {closedTimestamp && closedTimestamp.toLocaleString()}
+            {formatDate(closedTimestamp)}
           </DataList.Value>
         </DataList.Item>
         <DataList.Item>
           <DataList.Label>Last Updated</DataList.Label>
           <DataList.Value className="whitespace-pre-wrap">
-            {lastUpdated && lastUpdated.toLocaleString()}
+            {formatDate(lastUpdated)}
           </DataList.Value>
         </DataList.Item>
         <DataList.Item>

--- a/frontend/src/routes/admin/tickets/index.tsx
+++ b/frontend/src/routes/admin/tickets/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/constants';
 import { useAdminAllTickets } from '@/hooks/support';
 import type { AdminTicket } from '@/types';
+import { formatDate } from '@/util';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
@@ -71,7 +72,8 @@ const colDefs: ColDef<AdminTicket>[] = [
   {
     field : 'last_updated',
     headerName : 'Updated Date',
-    valueFormatter : (params) => params.value && params.value.toLocaleString(),
+    cellDataType : 'dateString',
+    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },
@@ -117,7 +119,8 @@ const colDefs: ColDef<AdminTicket>[] = [
   {
     field : 'opened_timestamp',
     headerName : 'Created Date',
-    valueFormatter : (params) => params.value && params.value.toLocaleString(),
+    cellDataType : 'dateString',
+    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },

--- a/frontend/src/routes/admin/tickets/index.tsx
+++ b/frontend/src/routes/admin/tickets/index.tsx
@@ -6,7 +6,6 @@ import {
 } from '@/constants';
 import { useAdminAllTickets } from '@/hooks/support';
 import type { AdminTicket } from '@/types';
-import { formatDate } from '@/util';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
@@ -73,7 +72,6 @@ const colDefs: ColDef<AdminTicket>[] = [
     field : 'last_updated',
     headerName : 'Updated Date',
     cellDataType : 'dateString',
-    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },
@@ -120,7 +118,6 @@ const colDefs: ColDef<AdminTicket>[] = [
     field : 'opened_timestamp',
     headerName : 'Created Date',
     cellDataType : 'dateString',
-    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },

--- a/frontend/src/routes/admin/users/UserSidebar.tsx
+++ b/frontend/src/routes/admin/users/UserSidebar.tsx
@@ -8,7 +8,7 @@ import {
 import { useTeamMembers } from '@/hooks/team';
 import { useUserTeams, useUserWorkspace, useWorkspaceStatus } from '@/hooks/users';
 import type { AdminUser, Team } from '@/types';
-import { utf8ToBase64 } from '@/util';
+import { formatDate, utf8ToBase64 } from '@/util';
 import {
   Badge,
   Box,
@@ -67,7 +67,7 @@ function RegistrationRow({ userId, team }: { userId: number, team: Team }) {
         <RoleBadge value={membership.role} />
       </Table.Cell>
       <Table.Cell>
-        {membership?.joined_at.toLocaleString()}
+        {formatDate(membership?.joined_at)}
       </Table.Cell>
     </Table.Row>
   );
@@ -114,7 +114,7 @@ export default function UserSidebar({ entity }: { entity: AdminUser }) {
         />
         <Statistic
           label="Registered At"
-          value={entity.registered_at.toLocaleString()}
+          value={formatDate(entity.registered_at)}
           size="5"
         />
         <Box>

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -1,6 +1,5 @@
 import { useAllUsers } from '@/hooks/users';
 import type { AdminUser } from '@/types';
-import { formatDate } from '@/util';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
@@ -48,7 +47,6 @@ const colDefs: ColDef<AdminUser>[] = [
     headerName : 'Registered At',
     width : 220,
     cellDataType : 'dateString',
-    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -1,5 +1,6 @@
 import { useAllUsers } from '@/hooks/users';
 import type { AdminUser } from '@/types';
+import { formatDate } from '@/util';
 import type { ColDef } from 'ag-grid-community';
 import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
@@ -46,7 +47,8 @@ const colDefs: ColDef<AdminUser>[] = [
     field : 'registered_at',
     headerName : 'Registered At',
     width : 220,
-    valueFormatter : (params) => params.value && params.value.toLocaleString(),
+    cellDataType : 'dateString',
+    valueFormatter : ({ value }) => formatDate(value),
     filter : true,
     floatingFilter : true,
   },

--- a/frontend/src/routes/dashboard/PastEvents.tsx
+++ b/frontend/src/routes/dashboard/PastEvents.tsx
@@ -8,11 +8,11 @@ import EventCard from 'components/EventCard';
 
 export default function PastEvents() {
   const { data, error } = useMyEvents();
-  const pastEvents = data?.filter((event) => event.end_time && new Date() > event.end_time);
+  const pastEvents = data?.filter((event) => event.end_time && new Date() > new Date(event.end_time));
 
   const groupedEvents = useMemo(() => chain(pastEvents)
-    .sortBy((event) => event.start_time?.getTime() || 0)
-    .groupBy((event) => event.start_time?.getFullYear()?.toString() || 'Unknown')
+    .sortBy((event) => (event.start_time ? new Date(event.start_time).getTime() : 0))
+    .groupBy((event) => (event.start_time ? new Date(event.start_time).getFullYear().toString() : 'Unknown'))
     .toPairs()
     .reverse()
     .value(), [ pastEvents ]);

--- a/frontend/src/routes/dashboard/UpcomingEvents.tsx
+++ b/frontend/src/routes/dashboard/UpcomingEvents.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router';
 
 export default function UpcomingEvents() {
   const { data, error, isLoading } = useMyEvents();
-  const upcomingEvents = data?.filter((event) => !event.start_time || new Date() < event.start_time);
+  const upcomingEvents = data?.filter((event) => !event.start_time || new Date() < new Date(event.start_time));
 
   if (error) {
     return (

--- a/frontend/src/routes/dashboard/index.tsx
+++ b/frontend/src/routes/dashboard/index.tsx
@@ -22,12 +22,12 @@ export default function Dashboard() {
 
   const liveEvents = data?.filter(
     (event) => {
-      if (event.start_time && new Date() < event.start_time) {
+      if (event.start_time && new Date() < new Date(event.start_time)) {
         // events that haven't started yet shouldn't be shown
         return false;
       }
 
-      if (event.end_time && new Date() > event.end_time) {
+      if (event.end_time && new Date() > new Date(event.end_time)) {
         // events that have ended shouldn't be shown
         return false;
       }

--- a/frontend/src/routes/events/AvailableEvents.tsx
+++ b/frontend/src/routes/events/AvailableEvents.tsx
@@ -58,7 +58,7 @@ export default function AvailableEvents() {
     const past: Event[] = [];
 
     filteredEvents.forEach((event) => {
-      if (!event.end_time || event.end_time > now) {
+      if (!event.end_time || new Date(event.end_time) > now) {
         upcoming.push(event);
       } else {
         past.push(event);
@@ -68,9 +68,9 @@ export default function AvailableEvents() {
     return {
       upcomingEvents : upcoming,
       groupedPastEvents : chain(past)
-        .sortBy((event) => event.start_time?.getTime() ?? 0)
+        .sortBy((event) => (event.start_time ? new Date(event.start_time).getTime() : 0))
         .groupBy(
-          (event) => event.start_time?.getFullYear().toString() ?? 'Unknown',
+          (event) => (event.start_time ? new Date(event.start_time).getFullYear().toString() : 'Unknown'),
         )
         .toPairs()
         .reverse()

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/NotAvailable.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/NotAvailable.tsx
@@ -27,9 +27,7 @@ export default function NotAvailable() {
             <Text size="3" color="gray">
               The event will start on
               {' '}
-              {formatDate(event.start_time, { year : 'numeric', month : 'numeric', day : 'numeric' })}
-              {' at '}
-              {formatDate(event.start_time, { hour : 'numeric', minute : 'numeric' })}
+              {formatDate(event.start_time, { dateStyle : 'long', timeStyle : 'short' })}
               .
             </Text>
           )}

--- a/frontend/src/routes/events/OverviewTabs/ChallengesTab/NotAvailable.tsx
+++ b/frontend/src/routes/events/OverviewTabs/ChallengesTab/NotAvailable.tsx
@@ -1,4 +1,5 @@
 import { useEvent, useEventStatus } from '@/hooks/events';
+import { formatDate } from '@/util';
 import {
   Box,
   Container,
@@ -26,9 +27,9 @@ export default function NotAvailable() {
             <Text size="3" color="gray">
               The event will start on
               {' '}
-              {event.start_time.toLocaleDateString()}
+              {formatDate(event.start_time, { year : 'numeric', month : 'numeric', day : 'numeric' })}
               {' at '}
-              {event.start_time.toLocaleTimeString()}
+              {formatDate(event.start_time, { hour : 'numeric', minute : 'numeric' })}
               .
             </Text>
           )}

--- a/frontend/src/routes/events/OverviewTabs/LeaderboardTab/TeamPerformance.tsx
+++ b/frontend/src/routes/events/OverviewTabs/LeaderboardTab/TeamPerformance.tsx
@@ -1,5 +1,6 @@
 import { useMyTeamScore } from '@/hooks/scoring';
 import { useRegistration } from '@/hooks/users';
+import { formatDate } from '@/util';
 import { Flex } from '@radix-ui/themes';
 import { ErrorCallout } from 'components/Callouts';
 import Statistic from 'components/Statistic';
@@ -19,7 +20,7 @@ export default function TeamPerformance({ eventId }: {eventId: number}) {
       <>
         {scoreError && <ErrorCallout>{scoreError.message}</ErrorCallout>}
         <Flex direction="row" gap="3">
-          <Statistic value={score?.points ?? ''} label="Your Score" description={`Last updated ${score?.last_update.toLocaleString()}`} />
+          <Statistic value={score?.points ?? ''} label="Your Score" description={`Last updated ${formatDate(score?.last_update)}`} />
         </Flex>
       </>
     );

--- a/frontend/src/routes/events/RegistrationCard.tsx
+++ b/frontend/src/routes/events/RegistrationCard.tsx
@@ -57,7 +57,7 @@ export default function RegistrationCard({ event }: {event: Event}) {
             <Box>
               <Text color="gray" size="2">Time remaining:</Text>
               <Timer
-                target={team.end_time}
+                target={new Date(team.end_time)}
                 onEnd={() => {
                   // Refresh SWR state on timer end
                   mutate(`/permissions/${event.id}/me`);

--- a/frontend/src/routes/events/StartModal.tsx
+++ b/frontend/src/routes/events/StartModal.tsx
@@ -35,7 +35,7 @@ export default function StartModal({ event }: {event: Event}) {
         avail = event.time_limit_minutes;
 
         if (event.end_time) {
-          const minutesUntilEnd = Math.round((event.end_time.getTime() - Date.now()) / 60000);
+          const minutesUntilEnd = Math.round((new Date(event.end_time).getTime() - Date.now()) / 60000);
           if (minutesUntilEnd < avail) {
             // the event will end before the full time limit elapses - truncate the calculated available time to match backend
             // clamp to 0 if negative, just in case

--- a/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
+++ b/frontend/src/routes/events/challenge/ChallengeSidebar.tsx
@@ -67,7 +67,7 @@ export default function ChallengeSidebar() {
 
               {team && team.end_time && (
                 <Timer
-                  target={team.end_time}
+                  target={new Date(team.end_time)}
                   size="3"
                   onEnd={() => {
                     // Refresh SWR state on timer end

--- a/frontend/src/routes/events/challenge/HistoryModal.tsx
+++ b/frontend/src/routes/events/challenge/HistoryModal.tsx
@@ -1,6 +1,7 @@
 import { COLOR_INFO } from '@/constants';
 import { radixTheme } from '@/grid';
 import type { Attempt } from '@/types';
+import { formatDate } from '@/util';
 import { Button } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
@@ -27,7 +28,8 @@ const colDefs: ColDef<Attempt>[] = [
     field : 'timestamp',
     headerName : 'Date',
     width : 200,
-    valueFormatter : (params) => params.value.toLocaleString(),
+    cellDataType : 'dateString',
+    valueFormatter : (params) => formatDate(params.value),
     sort : 'desc',
     filter : true,
     floatingFilter : true,

--- a/frontend/src/routes/events/challenge/HistoryModal.tsx
+++ b/frontend/src/routes/events/challenge/HistoryModal.tsx
@@ -1,7 +1,6 @@
 import { COLOR_INFO } from '@/constants';
 import { radixTheme } from '@/grid';
 import type { Attempt } from '@/types';
-import { formatDate } from '@/util';
 import { Button } from '@radix-ui/themes';
 import type { ColDef } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
@@ -29,7 +28,6 @@ const colDefs: ColDef<Attempt>[] = [
     headerName : 'Date',
     width : 200,
     cellDataType : 'dateString',
-    valueFormatter : (params) => formatDate(params.value),
     sort : 'desc',
     filter : true,
     floatingFilter : true,

--- a/frontend/src/routes/support/index.tsx
+++ b/frontend/src/routes/support/index.tsx
@@ -12,7 +12,6 @@ import { StatusBadgeCell } from 'components/StatusBadge';
 import { radixTheme } from '@/grid';
 import { useMyTickets } from '@/hooks/support';
 import type { Ticket } from '@/types';
-import { formatDate } from '@/util';
 import { isUndefined } from 'lodash';
 import { ErrorCallout } from 'components/Callouts';
 
@@ -29,13 +28,11 @@ export default function Support() {
       field : 'opened_timestamp',
       headerName : 'Created Date',
       cellDataType : 'dateString',
-      valueFormatter : ({ value }) => formatDate(value),
     },
     {
       field : 'last_updated',
       headerName : 'Last Updated Date',
       cellDataType : 'dateString',
-      valueFormatter : ({ value }) => formatDate(value),
     },
   ];
 

--- a/frontend/src/routes/support/index.tsx
+++ b/frontend/src/routes/support/index.tsx
@@ -12,6 +12,7 @@ import { StatusBadgeCell } from 'components/StatusBadge';
 import { radixTheme } from '@/grid';
 import { useMyTickets } from '@/hooks/support';
 import type { Ticket } from '@/types';
+import { formatDate } from '@/util';
 import { isUndefined } from 'lodash';
 import { ErrorCallout } from 'components/Callouts';
 
@@ -24,8 +25,18 @@ export default function Support() {
     { field : 'subject', headerName : 'Subject' },
     { field : 'event_name', headerName : 'Event Name' },
     { field : 'status', headerName : 'Status', cellRenderer : StatusBadgeCell },
-    { field : 'opened_timestamp', headerName : 'Created Date', valueFormatter : (params) => params.value.toLocaleString() },
-    { field : 'last_updated', headerName : 'Last Updated Date', valueFormatter : (params) => params.value.toLocaleString() },
+    {
+      field : 'opened_timestamp',
+      headerName : 'Created Date',
+      cellDataType : 'dateString',
+      valueFormatter : ({ value }) => formatDate(value),
+    },
+    {
+      field : 'last_updated',
+      headerName : 'Last Updated Date',
+      cellDataType : 'dateString',
+      valueFormatter : ({ value }) => formatDate(value),
+    },
   ];
 
   return (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,13 +4,13 @@ export interface Event {
   description?: string | null;
   image?: string | null;
   max_team_size: number;
-  start_time?: Date;
-  end_time?: Date;
+  start_time: string | null;
+  end_time: string | null;
   locked: boolean;
   public: boolean;
   registration_open: boolean;
-  registration_start_date?: Date;
-  registration_end_date?: Date;
+  registration_start_date: string | null;
+  registration_end_date: string | null;
   hints_enabled: boolean;
   time_limit_minutes: number | null;
   show_leaderboard: boolean;
@@ -26,7 +26,7 @@ export interface Sponsor {
 export interface UploadedFile {
   filename: string,
   folder: string,
-  last_modified?: Date,
+  last_modified?: string,
   download_url?: string,
 }
 
@@ -35,7 +35,7 @@ export interface User {
   name: string;
   email: string;
   roles: string[];
-  registered_at: Date;
+  registered_at: string;
   affiliation: Sponsor | null;
 }
 
@@ -52,8 +52,8 @@ export interface Team {
   member_count: number;
   ranked: boolean;
   invite_code?: string;
-  start_timestamp: Date | null;
-  end_time: Date | null;
+  start_timestamp: string | null;
+  end_time: string | null;
 }
 
 export interface TeamMember {
@@ -62,7 +62,7 @@ export interface TeamMember {
   user_name: string;
   team_id: number;
   event_id: number;
-  joined_at: Date;
+  joined_at: string;
   role: 'member' | 'captain';
   sponsor?: Sponsor;
 }
@@ -121,7 +121,7 @@ export interface Attempt {
   challenge_id: number;
   question_id: number;
   score_event_id?: number;
-  timestamp: Date;
+  timestamp: string;
   points: number;
   submission: string;
   is_correct: boolean;
@@ -136,7 +136,7 @@ export interface HintRedemption {
   user_id: number;
   team_id: number;
   score_event_id?: number;
-  timestamp: Date;
+  timestamp: string;
   points: number;
   user_name?: string;
   team_name?: string;
@@ -152,7 +152,7 @@ export interface ManualPointAward {
   admin_id: number;
   team_id: number;
   score_event_id: number;
-  timestamp: Date;
+  timestamp: string;
   points: number;
   reason: string;
   admin_name?: string;
@@ -164,7 +164,7 @@ export interface Score {
    team_id: number;
    event_id: number;
    points: number;
-   last_update: Date;
+   last_update: string;
    team_name: string | null;
    last_correct_offset: number;
 }
@@ -175,7 +175,7 @@ export interface ScoreEvent {
   team_id: number;
   team_name: string;
   points: number;
-  timestamp: Date;
+  timestamp: string;
 }
 
 export interface Deployment {
@@ -215,7 +215,7 @@ export interface ContainerInstance {
   team_id: number;
   hostip: string;
   dockerid: string;
-  created_at?: Date;
+  created_at: string | null;
 }
 
 export interface ContainerStatus {
@@ -233,8 +233,8 @@ export interface Ticket {
   author_id: number;
   author_name: string;
   status: string;
-  opened_timestamp: Date;
-  last_updated: Date;
+  opened_timestamp: string;
+  last_updated: string;
   event_id?: number;
   event_name?: string;
   team_id?: number;
@@ -247,7 +247,7 @@ export interface Ticket {
 export interface TicketAttachment {
   id: number;
   ticket_id: number;
-  uploaded_at: Date;
+  uploaded_at: string;
   uploaded_by: number;
   content_type: string;
   download_url: string;
@@ -268,7 +268,7 @@ export interface AdminTicket extends Ticket {
   assigned_to?: number;
   assigned_to_name?: string;
   muted: boolean;
-  closed_timestamp?: Date;
+  closed_timestamp: string | null;
   tags: TicketTag[];
 }
 
@@ -276,7 +276,7 @@ export interface TicketMessage {
   author_id: number;
   author_name: string;
   author_type: string;
-  created_at: Date;
+  created_at: string;
   id: number;
   text: string;
   ticket_id: number
@@ -288,10 +288,10 @@ export interface Notification {
   title: string;
   message: string;
   recipient_id: number;
-  created_at: Date;
+  created_at: string;
   sender_id?: number;
-  read_at?: Date;
-  expires_at?: Date;
+  read_at: string | null;
+  expires_at: string | null;
   ticket_id?: number;
   team_id?: number;
   event_id?: number;
@@ -307,8 +307,8 @@ export interface Announcement {
   id: number;
   title: string;
   message: string;
-  created_at: Date;
-  expires_at: Date;
+  created_at: string;
+  expires_at: string;
   sender_id: number;
   sender_name: string;
   type: string;
@@ -342,6 +342,6 @@ export interface Feedback {
   event_id: number;
   challenge_id: number;
   feedback_data: Record<string, unknown>;
-  created_at: Date;
-  updated_at: Date;
+  created_at: string;
+  updated_at: string;
 }

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -2,17 +2,28 @@ import { OTHER_TAXONOMY } from '@/constants';
 import { useEffect, useState } from 'react';
 
 /**
- * Formats a Date object for use with a datetime-local input field.
- * @param date Date object to format
+ * Formats a date for use with a datetime-local input field.
+ * @param date Date (or ISO string) to format
  * @returns String compatible with datetime-local input
  */
-export function adjustDateForInput(date: Date | null): string | null {
+export function adjustDateForInput(date: Date | string | null): string | null {
   // Adjust the date to be in the format required by datetime-local input
   if (date === null) return null;
   const dateObj = new Date(date);
   const offset = dateObj.getTimezoneOffset();
   const localDate = new Date(dateObj.getTime() - (offset * 60 * 1000));
   return localDate.toISOString().slice(0, 16);
+}
+
+/**
+ * Formats a date for display, in the user's locale.
+ *
+ * @param date Date or ISO date string to format.
+ * @param options Intl.DateTimeFormat options, e.g. to format only the date or time portion.
+ * @returns Locale-formatted date string, or an empty string if no date was given.
+ */
+export function formatDate(date?: Date | string | null, options?: Intl.DateTimeFormatOptions): string {
+  return date ? new Date(date).toLocaleString(undefined, options) : '';
 }
 
 /**


### PR DESCRIPTION
Fixes #687.

Do date parsing at the component layer which is safer than the implicit parsing done before. Also automatically resolves #203 by letting the grid parse string dates and manage its filters based on those.

Introduces a `formatDate` helper to make date formatting within components cleaner.