### PR TITLE
Progress bars for image pull status

### DIFF
--- a/backend/ng/containers/tasks.py
+++ b/backend/ng/containers/tasks.py
@@ -1,5 +1,6 @@
 import os
 import json
+import time
 import docker
 import redis
 
@@ -35,10 +36,56 @@ def pull_image_celery(host, image, user_id, blueprint_id, auth_conf=None):
     tls_config = docker.tls.TLSConfig(client_cert=("/var/lib/certs/ssl/cert.pem", "/var/lib/certs/ssl/key.pem"))
     client = docker.DockerClient(base_url=f"https://{host}:2376/", tls=tls_config)
     try:
+        pull_kwargs = {"stream": True, "decode": True}
         if auth_conf:
-            client.images.pull(image, auth_config=auth_conf)
-        else:
-            client.images.pull(image)
+            pull_kwargs["auth_config"] = auth_conf
+
+        # keep track of layer sizes and progress for weighted average
+        layers = {}
+
+        # send initial 0 progress notification so the client knows the pull has started
+        # otherwise, there may be a bit of a delay while docker thinks
+        message = {
+            "user_ids": [user_id],
+            "event_name": "pull-progress",
+            "data": { "id": blueprint_id, "image": image, "percent": 0 }
+        }
+
+        redis_client.publish("ctf_notifications", json.dumps(message))
+        last_emit = time.monotonic()
+
+        # pull the image and loop over the generator of per-layer progress events
+        for event in client.api.pull(image, **pull_kwargs):
+            # runs for each layer status update
+            layer_id = event.get("id")
+            detail = event.get("progressDetail")
+            status = event.get("status")
+
+            if layer_id and detail and detail.get("total"):
+                # store layer progress as we receive status updates.
+                # total is doubled to account for both download and extract phases, since both must finish for the layer to be at 100%.
+                if status == "Downloading":
+                    # download phase, (current/total) runs 0 -> 0.5
+                    layers[layer_id] = { "total": detail["total"] * 2, "current": detail["current"] }
+                elif status == "Extracting" and layer_id in layers:
+                    # extract phase, (current/total) runs 0.5 -> 1
+                    layers[layer_id]["progress"] = detail["total"] + detail["current"]
+
+            # throttle socket notifications since the generator is noisy
+            now = time.monotonic()
+            if layers and now - last_emit > 1:
+                current_sum = sum(layer["current"] for layer in layers.values())
+                total_sum = sum(layer["total"] for layer in layers.values())
+                percent = round(current_sum / total_sum * 100, 1)
+
+                message = {
+                    "user_ids": [user_id],
+                    "event_name": "pull-progress",
+                    "data": { "id": blueprint_id, "image": image, "percent": percent }
+                }
+
+                redis_client.publish("ctf_notifications", json.dumps(message))
+                last_emit = now
 
         # Similar to above this is what emit_notification is doing
         # these will send a notifcation when the image is done pulling

--- a/backend/ng/containers/tasks.py
+++ b/backend/ng/containers/tasks.py
@@ -62,21 +62,26 @@ def pull_image_celery(host, image, user_id, blueprint_id, auth_conf=None):
             status = event.get("status")
 
             if layer_id and detail and detail.get("total"):
-                # store layer progress as we receive status updates.
-                # total is doubled to account for both download and extract phases, since both must finish for the layer to be at 100%.
+                # track download/extract percentages separately since they're based on different denominators
+                # use download size as a stable value to weight the average by
                 if status == "Downloading":
-                    # download phase, (current/total) runs 0 -> 0.5
-                    layers[layer_id] = { "total": detail["total"] * 2, "current": detail["current"] }
+                    layers[layer_id] = {
+                        "size": detail["total"],
+                        "download": detail["current"] / detail["total"],
+                        "extract": 0.0,
+                    }
                 elif status == "Extracting" and layer_id in layers:
-                    # extract phase, (current/total) runs 0.5 -> 1
-                    layers[layer_id]["progress"] = detail["total"] + detail["current"]
+                    layers[layer_id]["extract"] = detail["current"] / detail["total"]
 
             # throttle socket notifications since the generator is noisy
             now = time.monotonic()
             if layers and now - last_emit > 1:
-                current_sum = sum(layer["current"] for layer in layers.values())
-                total_sum = sum(layer["total"] for layer in layers.values())
-                percent = round(current_sum / total_sum * 100, 1)
+                total_size = sum(layer["size"] for layer in layers.values())
+                weighted_progress = sum(
+                    layer["size"] * (layer["download"] + layer["extract"]) / 2
+                    for layer in layers.values()
+                )
+                percent = round(weighted_progress / total_size * 100, 1)
 
                 message = {
                     "user_ids": [user_id],

--- a/frontend/src/components/ImagePullStatus.tsx
+++ b/frontend/src/components/ImagePullStatus.tsx
@@ -1,0 +1,59 @@
+import { COLOR_NEGATIVE, COLOR_POSITIVE } from '@/constants';
+import { useImagePullStatus } from '@/hooks/container';
+import {
+  Code,
+  Flex,
+  HoverCard,
+  Progress,
+  Skeleton,
+  Text,
+} from '@radix-ui/themes';
+import { TbCheck, TbInfoCircle } from 'react-icons/tb';
+
+export default function ImagePullStatus({ id } : { id: string | number }) {
+  const { data : pull } = useImagePullStatus(id);
+
+  if (pull?.status === 'pulling') {
+    return (
+      <Flex direction="row" align="center" gap="2">
+        {!!pull.percent && (
+          <Text size="2" color="gray">Pulling</Text>
+        )}
+        <Skeleton loading={!pull.percent}>
+          <Progress value={pull.percent} className="w-24" />
+        </Skeleton>
+      </Flex>
+    );
+  }
+
+  if (pull?.status === 'success') {
+    return (
+      <Text color={COLOR_POSITIVE}>
+        <TbCheck className="inline me-1" />
+        Pulled
+      </Text>
+    );
+  }
+
+  if (pull?.status === 'fail') {
+    return (
+      <Flex direction="row" align="center" gap="1">
+        <Text color={COLOR_NEGATIVE}>Error</Text>
+        <HoverCard.Root>
+          <HoverCard.Trigger>
+            <button type="button">
+              <Text color={COLOR_NEGATIVE}>
+                <TbInfoCircle aria-label="More info" />
+              </Text>
+            </button>
+          </HoverCard.Trigger>
+          <HoverCard.Content>
+            <Code color="gray" className="block whitespace-pre-wrap">{pull.error}</Code>
+          </HoverCard.Content>
+        </HoverCard.Root>
+      </Flex>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/components/ImagePullStatus.tsx
+++ b/frontend/src/components/ImagePullStatus.tsx
@@ -8,7 +8,7 @@ import {
   Skeleton,
   Text,
 } from '@radix-ui/themes';
-import { TbCheck, TbInfoCircle } from 'react-icons/tb';
+import { TbCancel, TbCheck } from 'react-icons/tb';
 
 export default function ImagePullStatus({ id } : { id: string | number }) {
   const { data : pull } = useImagePullStatus(id);
@@ -37,21 +37,19 @@ export default function ImagePullStatus({ id } : { id: string | number }) {
 
   if (pull?.status === 'fail') {
     return (
-      <Flex direction="row" align="center" gap="1">
-        <Text color={COLOR_NEGATIVE}>Error</Text>
-        <HoverCard.Root>
-          <HoverCard.Trigger>
-            <button type="button">
-              <Text color={COLOR_NEGATIVE}>
-                <TbInfoCircle aria-label="More info" />
-              </Text>
-            </button>
-          </HoverCard.Trigger>
-          <HoverCard.Content>
-            <Code color="gray" className="block whitespace-pre-wrap">{pull.error}</Code>
-          </HoverCard.Content>
-        </HoverCard.Root>
-      </Flex>
+      <HoverCard.Root>
+        <HoverCard.Trigger>
+          <button type="button" aria-label="Show error details">
+            <Text color={COLOR_NEGATIVE} className="underline decoration-dashed">
+              <TbCancel className="inline me-1" />
+              Error
+            </Text>
+          </button>
+        </HoverCard.Trigger>
+        <HoverCard.Content>
+          <Code color="gray" className="block whitespace-pre-wrap">{pull.error}</Code>
+        </HoverCard.Content>
+      </HoverCard.Root>
     );
   }
 

--- a/frontend/src/hooks/container.ts
+++ b/frontend/src/hooks/container.ts
@@ -106,3 +106,14 @@ export function pullVNCImage() {
     method : 'POST',
   });
 }
+
+/**
+ * Gets image pull status based on a blueprint ID.
+ * data is undefined if no pull was requested.
+ * @param id blueprint ID, or "VNC" for the VNC image.
+ */
+export function useImagePullStatus(id: string | number) {
+  return useSWR<
+    { status: 'pulling', percent: number } | { status: 'success' } | { status: 'fail', error: string }
+  >([ 'pull-status', id ], null);
+}

--- a/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeBlueprintTab.tsx
+++ b/frontend/src/routes/admin/challenges/SidebarTabs/ChallengeBlueprintTab.tsx
@@ -1,69 +1,25 @@
-import { COLOR_NEGATIVE, COLOR_POSITIVE, COLOR_WARNING } from '@/constants';
+import { COLOR_WARNING } from '@/constants';
 import { apiMutation } from '@/fetchers';
 import { useAdminChallengeBlueprints } from '@/hooks/challenge';
-import socket from '@/socket';
 import {
   Button,
   Card,
   Code,
   DataList,
   Grid,
-  Spinner,
-  Text,
 } from '@radix-ui/themes';
 import AdminSidebarHeader from 'components/AdminSidebarHeader';
 import { ErrorCallout, WarningCallout } from 'components/Callouts';
+import ImagePullStatus from 'components/ImagePullStatus';
 import Modal from 'components/Modal';
-import { useEffect, useState } from 'react';
-import {
-  TbCancel,
-  TbCheck,
-  TbDownload,
-  TbPackage,
-} from 'react-icons/tb';
+import { TbDownload, TbPackage } from 'react-icons/tb';
 
 export default function ChallengeBlueprintTab({ challengeId }: {challengeId: number}) {
   const { data : blueprints, error } = useAdminChallengeBlueprints(challengeId);
 
-  const [ pullStates, setPullStates ] = useState<{[key: number]:'pulling' | 'success' | 'fail'}>({});
-  const [ pullErrors, setPullErrors ] = useState<string[]>([]);
-
-  const handlePull = async () => {
-    setPullStates((prev) => {
-      const current = { ...prev };
-      (blueprints || []).forEach((bp) => {
-        current[bp.id] = 'pulling';
-      });
-      return current;
-    });
-    setPullErrors([]);
-
-    return apiMutation(`/admin/challenges/${challengeId}/pull`, {}, {
-      method : 'POST',
-    });
-  };
-
-  useEffect(() => {
-    socket.on('pull-success', ({ id }: {id: number}) => {
-      setPullStates((prev) => ({
-        ...prev,
-        [id] : 'success',
-      }));
-    });
-
-    socket.on('pull-fail', ({ error : pullError, id }: {error: string, id: number}) => {
-      setPullErrors((prev) => ([ ...prev, pullError ]));
-      setPullStates((prev) => ({
-        ...prev,
-        [id] : 'fail',
-      }));
-    });
-
-    return () => {
-      socket.off('pull-success');
-      socket.off('pull-fail');
-    };
-  }, []);
+  const handlePull = () => apiMutation(`/admin/challenges/${challengeId}/pull`, {}, {
+    method : 'POST',
+  });
 
   if (error) {
     return <ErrorCallout>{error.message}</ErrorCallout>;
@@ -92,27 +48,11 @@ export default function ChallengeBlueprintTab({ challengeId }: {challengeId: num
         </Modal>
       </AdminSidebarHeader>
 
-      {pullErrors.map((err) => (
-        <ErrorCallout key={err} className="mt-2">{err}</ErrorCallout>
-      ))}
-
       <Grid columns="2" gap="2" mt="2">
         {blueprints?.map((blueprint) => (
           <Card key={blueprint.id} className="mb-3">
             <AdminSidebarHeader title={blueprint.name} icon={<TbPackage />}>
-              {pullStates[blueprint.id] === 'pulling' && (<Spinner />)}
-              {pullStates[blueprint.id] === 'success' && (
-                <Text color={COLOR_POSITIVE}>
-                  <TbCheck className="inline me-1" />
-                  Pulled
-                </Text>
-              )}
-              {pullStates[blueprint.id] === 'fail' && (
-                <Text color={COLOR_NEGATIVE}>
-                  <TbCancel className="inline me-1" />
-                  Error
-                </Text>
-              )}
+              <ImagePullStatus id={blueprint.id} />
             </AdminSidebarHeader>
             <DataList.Root className="!gap-1 !mt-3">
               <DataList.Item>

--- a/frontend/src/routes/admin/dashboard/AdminProvisionerCard.tsx
+++ b/frontend/src/routes/admin/dashboard/AdminProvisionerCard.tsx
@@ -19,12 +19,12 @@ export default function AdminProvisionerCard() {
 
   return (
     <Card>
-      <Heading>
-        <Flex direction="row" align="center" justify="between">
+      <Flex direction="row" align="center" justify="between">
+        <Heading>
           Provisioner
-          <AdminPullVncModal />
-        </Flex>
-      </Heading>
+        </Heading>
+        <AdminPullVncModal />
+      </Flex>
       <Flex gap="4" mt="3">
         <Statistic
           label="Containers Running"

--- a/frontend/src/routes/admin/dashboard/AdminPullVncModal.tsx
+++ b/frontend/src/routes/admin/dashboard/AdminPullVncModal.tsx
@@ -1,67 +1,35 @@
 import { COLOR_POSITIVE } from '@/constants';
-import { pullVNCImage } from '@/hooks/container';
-import { Button, Text } from '@radix-ui/themes';
-import { ErrorCallout } from 'components/Callouts';
+import { pullVNCImage, useImagePullStatus } from '@/hooks/container';
+import { Button, Flex, Text } from '@radix-ui/themes';
+import ImagePullStatus from 'components/ImagePullStatus';
 import Modal from 'components/Modal';
-import socket from '@/socket';
 import { TbDownload } from 'react-icons/tb';
-import { useEffect, useState } from 'react';
-
-type Status = 'pulling' | 'success' | 'fail' | null;
 
 export default function AdminPullVncModal() {
-  const [ pullState, setPullState ] = useState<Status>(null);
-  const [ pullError, setPullError ] = useState<string | undefined>(undefined);
+  const { data : pull } = useImagePullStatus('VNC');
 
-  const handlePull = async () => {
-    setPullState('pulling');
-    pullVNCImage();
-  };
-
-  useEffect(() => {
-    socket.on('pull-success', () => {
-      setPullState('success');
-    });
-
-    socket.on('pull-fail', ({ error } : { error: string }) => {
-      setPullState('fail');
-      setPullError(error);
-    });
-
-    return () => {
-      socket.off('pull-success');
-      socket.off('pull-fail');
-    };
-  }, []);
-
-  if (pullError) {
-    return (
-      <ErrorCallout className="ml-4">
-        {pullError}
-      </ErrorCallout>
-    );
-  }
+  const handlePull = () => pullVNCImage();
 
   return (
-    <Modal
-      title="Pull VNC Container image"
-      description="This will pull the VNC container image."
-      submitVerb="Pull"
-      submitColor={COLOR_POSITIVE}
-      onSubmit={handlePull}
-      trigger={(
-        <Button
-          color={COLOR_POSITIVE}
-          loading={pullState === 'pulling'}
-        >
-          <TbDownload />
-          {pullState ? 'Image Pull Succes' : 'Pull Vnc Image'}
-        </Button>
-      )}
-    >
-      <Text color="gray">
-        The workspace VNC will be pulled. All existing workspaces will need to be recycled to get the new image.
-      </Text>
-    </Modal>
+    <Flex direction="row-reverse" gap="2" align="center">
+      <Modal
+        title="Pull VNC Container image"
+        description="This will pull the VNC container image."
+        submitVerb="Pull"
+        submitColor={COLOR_POSITIVE}
+        onSubmit={handlePull}
+        trigger={(
+          <Button color={COLOR_POSITIVE} loading={pull?.status === 'pulling'}>
+            <TbDownload />
+            Pull VNC Image
+          </Button>
+          )}
+      >
+        <Text color="gray">
+          The workspace VNC will be pulled. All existing workspaces will need to be recycled to get the new image.
+        </Text>
+      </Modal>
+      <ImagePullStatus id="VNC" />
+    </Flex>
   );
 }

--- a/frontend/src/routes/admin/dashboard/AdminPullVncModal.tsx
+++ b/frontend/src/routes/admin/dashboard/AdminPullVncModal.tsx
@@ -8,8 +8,6 @@ import { TbDownload } from 'react-icons/tb';
 export default function AdminPullVncModal() {
   const { data : pull } = useImagePullStatus('VNC');
 
-  const handlePull = () => pullVNCImage();
-
   return (
     <Flex direction="row-reverse" gap="2" align="center">
       <Modal
@@ -17,7 +15,7 @@ export default function AdminPullVncModal() {
         description="This will pull the VNC container image."
         submitVerb="Pull"
         submitColor={COLOR_POSITIVE}
-        onSubmit={handlePull}
+        onSubmit={pullVNCImage}
         trigger={(
           <Button color={COLOR_POSITIVE} loading={pull?.status === 'pulling'}>
             <TbDownload />

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -22,4 +22,18 @@ socket.on('system_announcement', () => {
   mutate('/notifications/announcements');
 });
 
+// Watch for image pull events and write them to the SWR cache as they occur.
+// Global listeners make sure that events aren't missed if users navigate away and come back during a pull.
+socket.on('pull-progress', ({ id, percent } : { id: string | number, percent: number }) => {
+  mutate([ 'pull-status', id ], { status : 'pulling', percent }, false);
+});
+
+socket.on('pull-success', ({ id } : { id: string | number }) => {
+  mutate([ 'pull-status', id ], { status : 'success' }, false);
+});
+
+socket.on('pull-fail', ({ id, error } : { id: string | number, error: string }) => {
+  mutate([ 'pull-status', id ], { status : 'fail', error }, false);
+});
+
 export default socket;


### PR DESCRIPTION
- Adds `pull-progress` messages to the image pull task, which periodically send an aggregate progress value to the client.
- `ImagePullStatus` component & hook, with global socket listeners writing to SWR to keep pull events flowing when on other pages.
- `ChallengeBlueprintTab` and `AdminProvisionerCard` updated to use the new pull status component, including progress bars to display the progress value.

<img width="424" height="255" alt="Screenshot From 2026-07-16 15-38-42" src="https://github.com/user-attachments/assets/0a8bab72-9a7b-4de5-8e52-f787d983be9d" />
