### PR TITLE
Allow expo user creation and password changes via admin panel

### DIFF
--- a/backend/ng/user/controllers/create_user.py
+++ b/backend/ng/user/controllers/create_user.py
@@ -1,0 +1,23 @@
+"""
+Controller for creating new users
+"""
+
+from CTFd.models import Users, db
+
+from ..models.User import User
+
+
+def create_user(name: str, email: str, password: str) -> User:
+    """
+    Create a password-authenticated (expo) user and its NG extension
+    """
+    ctfd_user = Users(name=name, email=email, password=password, type="user")
+    ctfd_user.verified = True
+
+    db.session.add(ctfd_user)
+    db.session.flush()
+
+    ng_user = User.create_user(user_id=ctfd_user.id, commit=False)
+    db.session.commit()
+
+    return ng_user

--- a/backend/ng/user/models/User.py
+++ b/backend/ng/user/models/User.py
@@ -97,6 +97,16 @@ class User(db.Model):
         return validator.validate()
 
     @classmethod
+    def validate_creation(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Validate the data required to create a new user."""
+        validator = BaseValidator()
+        validator.validate_string(data, "name", 128, required=True, friendly_name="Username")
+        validator.validate_string(data, "email", 128, required=True, friendly_name="Email")
+        validator.validate_string(data, "password", 128, required=True, friendly_name="Password", trim_whitespace=False)
+
+        return validator.validate()
+
+    @classmethod
     def create_user(cls, user_id, commit=True):
         """Create and persist a new user extension to the database.
 

--- a/backend/ng/user/models/User.py
+++ b/backend/ng/user/models/User.py
@@ -10,6 +10,7 @@ from CTFd.models import db
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import joinedload, selectinload
 
+from ...core.exceptions import BusinessLogicError
 from ...core.utils.validator import BaseValidator
 from ...permissions.models.UserRole import UserRole
 
@@ -75,6 +76,7 @@ class User(db.Model):
                 "registered_at": self.ctfd_user.created.isoformat() + "Z",
                 "affiliation": self.affiliation.serialize(include_admin_fields=True) if self.affiliation else None,
                 "banned": self.ctfd_user.banned,
+                "is_sso": self.oauth_id is not None,
             }
         return {
             "id": self.id,
@@ -92,7 +94,8 @@ class User(db.Model):
             validator.validate_string(data, "name", 128, required=True, friendly_name="Username")
         if "email" in data:
             validator.validate_string(data, "email", 128, required=True, friendly_name="Email")
-
+        if "password" in data:
+            validator.validate_string(data, "password", 128, required=True, friendly_name="Password", trim_whitespace=False)
 
         return validator.validate()
 
@@ -291,6 +294,10 @@ class User(db.Model):
         Args:
             **kwargs: Fields to update
         """
+        # make sure we can't create expo account backdoors on an SSO user
+        if "password" in kwargs and self.oauth_id is not None:
+            raise BusinessLogicError("Cannot set a password for an SSO user", "password")
+
         for key, value in kwargs.items():
             if hasattr(self.ctfd_user, key):
                 setattr(self.ctfd_user, key, value)

--- a/backend/ng/user/routes/admin_routes.py
+++ b/backend/ng/user/routes/admin_routes.py
@@ -18,6 +18,7 @@ from ..controllers.ban_user import (
     ban_user,
     unban_user,
 )
+from ..controllers.create_user import create_user
 
 
 users_admin_namespace = Namespace("/admin/users", description="user endpoints for admins")
@@ -36,6 +37,34 @@ class UsersAdminResource(Resource):
     def get(self, **kwargs):
         """Get all users on the system"""
         return success_response(User.get_all_users())
+
+    @admin_endpoint(json_required=True, validation_func=User.validate_creation)
+    @users_admin_namespace.doc(
+        description="Create a new user",
+        params={
+            "json_data": {
+                "description": "User data in JSON format",
+                "in": "body",
+                "required": True,
+                "example": {
+                    "name": "new_username",
+                    "email": "new_email@example.com",
+                    "password": "hunter2",
+                }
+            }
+        },
+        responses={
+            200: "User created successfully",
+            400: "Invalid input",
+            403: "Forbidden - Admin access required",
+            409: "A user with this name or email already exists",
+            500: "Internal server error",
+        },
+    )
+    def post(self, validated_data, **kwargs):
+        """Create a new user"""
+        user = create_user(**validated_data)
+        return success_response(user)
 
 @users_admin_namespace.route("/<int:user_id>")
 class UserAdminResource(Resource):

--- a/backend/ng/user/tests/test_user_api.py
+++ b/backend/ng/user/tests/test_user_api.py
@@ -474,3 +474,57 @@ def test_non_admin_create_user(logged_in_client):
     )
 
     assert response.status_code == 403
+
+
+def test_user_put_password(admin_client, user, db_session):
+    """
+    Test that an admin can change an expo user's password
+    """
+    from CTFd.utils.crypto import verify_password
+
+    response = admin_client.put(f"/ng/admin/users/{user.id}", json={"password": "newpassword123"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+
+    db_session.refresh(user)
+    assert verify_password("newpassword123", user.password)
+
+
+def test_user_put_password_sso_rejected(admin_client, user_factory, db_session):
+    """
+    Test that an admin cannot set a password for an SSO user
+    """
+    from CTFd.models import Users
+    from CTFd.utils.crypto import verify_password
+
+    ng_user = user_factory(name="ssouser", email="sso@example.com", password="password")
+    ng_user.oauth_id = "okta|123"
+    db_session.commit()
+    user_id = ng_user.id
+
+    response = admin_client.put(f"/ng/admin/users/{user_id}", json={"password": "newpassword123"})
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["success"] is False
+    assert "password" in data["errors"]
+
+    # the password must be left untouched
+    assert verify_password("password", Users.query.filter_by(id=user_id).first().password)
+
+
+def test_user_serialize_is_sso(admin_client, user_factory, db_session):
+    """
+    Test that the admin serializer reports SSO status
+    """
+    expo = user_factory(name="expouser", email="expo@example.com")
+    sso = user_factory(name="ssouser2", email="sso2@example.com")
+    sso.oauth_id = "okta|456"
+    db_session.commit()
+
+    expo_res = admin_client.get(f"/ng/admin/users/{expo.id}")
+    assert expo_res.get_json()["data"]["is_sso"] is False
+
+    sso_res = admin_client.get(f"/ng/admin/users/{sso.id}")
+    assert sso_res.get_json()["data"]["is_sso"] is True

--- a/backend/ng/user/tests/test_user_api.py
+++ b/backend/ng/user/tests/test_user_api.py
@@ -388,3 +388,89 @@ def test_update_user_sponsor_no_data(client_factory,user_factory):
     assert data["success"] is False
     assert "sponsor" in data["errors"]
 
+
+
+def test_admin_create_user(admin_client):
+    """
+    Test creating a new user as an admin
+    """
+    from CTFd.models import Users
+    from CTFd.utils.crypto import verify_password
+
+    password = "  hunter2  "
+
+    response = admin_client.post(
+        "/ng/admin/users",
+        json={
+            "name": "createduser",
+            "email": "createduser@example.com",
+            "password": password,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert data["data"]["name"] == "createduser"
+    assert data["data"]["email"] == "createduser@example.com"
+
+    # the created user should be retrievable
+    user_id = data["data"]["id"]
+    verify = admin_client.get(f"/ng/admin/users/{user_id}")
+    assert verify.status_code == 200
+
+    assert verify_password(password, Users.query.filter_by(id=user_id).first().password)
+
+
+def test_admin_create_user_missing_password(admin_client):
+    """
+    Test that creating a user without a password fails validation
+    """
+    response = admin_client.post(
+        "/ng/admin/users",
+        json={
+            "name": "nopassword",
+            "email": "nopassword@example.com",
+        },
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["success"] is False
+    assert "password" in data["errors"]
+
+
+def test_admin_create_user_duplicate(admin_client, user_factory):
+    """
+    Test that creating a user with an existing email conflicts
+    """
+    user_factory(name="existing", email="existing@example.com")
+
+    response = admin_client.post(
+        "/ng/admin/users",
+        json={
+            "name": "existing",
+            "email": "existing@example.com",
+            "password": "hunter2",
+        },
+    )
+
+    assert response.status_code == 409
+    data = response.get_json()
+    assert data["success"] is False
+
+
+def test_non_admin_create_user(logged_in_client):
+    """
+    Test that non-admins cannot create users
+    """
+    response = logged_in_client.post(
+        "/ng/admin/users",
+        json={
+            "name": "shouldfail",
+            "email": "shouldfail@example.com",
+            "password": "hunter2",
+        },
+    )
+
+    assert response.status_code == 403

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -184,7 +184,7 @@ export function createUser(user: Pick<User, 'name' | 'email'> & { password: stri
   });
 }
 
-export function adminUpdateUser(userId: number, user: Pick<User, 'name' | 'email'>) {
+export function adminUpdateUser(userId: number, user: Pick<User, 'name' | 'email'> & { password?: string }) {
   return apiMutation(`/admin/users/${userId}`, user, {
     method : 'PUT',
   }).then(() => {

--- a/frontend/src/hooks/users.ts
+++ b/frontend/src/hooks/users.ts
@@ -175,6 +175,15 @@ export function useWorkspaceStatus(userId : number) {
   });
 }
 
+export function createUser(user: Pick<User, 'name' | 'email'> & { password: string }) {
+  return apiMutation('/admin/users', user, {
+    method : 'POST',
+  }).then((data) => {
+    mutate('/admin/users');
+    return data as AdminUser;
+  });
+}
+
 export function adminUpdateUser(userId: number, user: Pick<User, 'name' | 'email'>) {
   return apiMutation(`/admin/users/${userId}`, user, {
     method : 'PUT',

--- a/frontend/src/routes/admin/users/AdminUpdateUserModal.tsx
+++ b/frontend/src/routes/admin/users/AdminUpdateUserModal.tsx
@@ -1,7 +1,7 @@
 import { COLOR_WARNING } from '@/constants';
 import { adminUpdateUserRoles } from '@/hooks/permissions';
 import { adminUpdateUser } from '@/hooks/users';
-import type { User } from '@/types';
+import type { AdminUser } from '@/types';
 import {
   Box,
   Button,
@@ -11,11 +11,10 @@ import {
 } from '@radix-ui/themes';
 import FormField from 'components/FormField';
 import Modal from 'components/Modal';
-import { pick } from 'lodash';
 import { Controller } from 'react-hook-form';
 import { TbPencil } from 'react-icons/tb';
 
-export default function AdminUpdateUserModal({ user }: {user: User}) {
+export default function AdminUpdateUserModal({ user }: {user: AdminUser}) {
   return (
     <Modal
       title="Edit User"
@@ -35,7 +34,12 @@ export default function AdminUpdateUserModal({ user }: {user: User}) {
         }
 
         return Promise.all([
-          adminUpdateUser(user.id, pick(data, [ 'name', 'email' ])),
+          adminUpdateUser(user.id, {
+            name : data.name,
+            email : data.email,
+            // blank password field means leave it unchanged
+            ...(data.password ? { password : data.password } : {}),
+          }),
           adminUpdateUserRoles(user.id, roles),
         ]);
       }}
@@ -46,6 +50,8 @@ export default function AdminUpdateUserModal({ user }: {user: User}) {
         email : user.email,
         admin : user.roles.includes('admin'),
         support : user.roles.includes('support'),
+        password : '',
+        confirmPassword : '',
       }}
     >
       {({ register, control, formState : { errors } }) => (
@@ -72,6 +78,37 @@ export default function AdminUpdateUserModal({ user }: {user: User}) {
               />
             )}
           </FormField>
+
+          <Flex direction="row" gap="2" className="*:grow *:basis-0">
+            <FormField label="Password" error={errors.password}>
+              {(injected) => (
+                <TextField.Root
+                  {...register('password', {
+                    maxLength : { value : 128, message : 'Password cannot be longer than 128 characters' },
+                  })}
+                  {...injected}
+                  type="password"
+                  disabled={user.is_sso}
+                  placeholder={user.is_sso ? 'Password can\'t be set for SSO users' : 'Leave blank to keep current'}
+                  autoComplete="new-password"
+                />
+              )}
+            </FormField>
+            {!user.is_sso && (
+              <FormField label="Confirm Password" error={errors.confirmPassword}>
+                {(injected) => (
+                  <TextField.Root
+                    {...register('confirmPassword', {
+                      validate : (value, { password }) => !password || value === password || 'Password does not match',
+                    })}
+                    {...injected}
+                    type="password"
+                    autoComplete="new-password"
+                  />
+                )}
+              </FormField>
+            )}
+          </Flex>
 
           <Flex direction="row" gap="2" className="*:grow *:basis-0">
 

--- a/frontend/src/routes/admin/users/CreateUserModal.tsx
+++ b/frontend/src/routes/admin/users/CreateUserModal.tsx
@@ -1,0 +1,90 @@
+import { COLOR_POSITIVE } from '@/constants';
+import { createUser } from '@/hooks/users';
+import { Button, Flex, TextField } from '@radix-ui/themes';
+import FormField from 'components/FormField';
+import Modal from 'components/Modal';
+import { TbPlus } from 'react-icons/tb';
+import { useSearchParams } from 'react-router';
+
+export default function CreateUserModal() {
+  const [ , setSearchParams ] = useSearchParams();
+
+  return (
+    <Modal
+      title="Create Expo Account"
+      description="Expo users can sign in with the provided credentials instead of via SSO."
+      trigger={(
+        <Button color={COLOR_POSITIVE}>
+          <TbPlus />
+          Create Expo Account
+        </Button>
+      )}
+      defaultValues={{
+        name : '',
+        email : '',
+        password : '',
+        confirmPassword : '',
+      }}
+      submitVerb="Create Expo Account"
+      onSubmit={({ name, email, password }) => createUser({ name, email, password }).then((user) => {
+        // select the newly created user in the grid
+        setSearchParams((params) => {
+          params.set('id', user.id.toString());
+          return params;
+        });
+      })}
+    >
+      {({ register, formState : { errors } }) => (
+        <>
+          <FormField label="Name" error={errors?.name}>
+            {(injected) => (
+              <TextField.Root
+                {...register('name', {
+                  required : 'Name is required',
+                })}
+                {...injected}
+              />
+            )}
+          </FormField>
+          <FormField label="Email" error={errors?.email}>
+            {(injected) => (
+              <TextField.Root
+                {...register('email', {
+                  required : 'Email is required',
+                })}
+                {...injected}
+                type="email"
+              />
+            )}
+          </FormField>
+          <Flex direction="row" gap="2" className="*:grow *:basis-0">
+            <FormField label="Password" error={errors?.password}>
+              {(injected) => (
+                <TextField.Root
+                  {...register('password', {
+                    required : 'Password is required',
+                    maxLength : { value : 128, message : 'Password cannot be longer than 128 characters' },
+                  })}
+                  {...injected}
+                  type="password"
+                />
+              )}
+            </FormField>
+            <FormField label="Confirm Password" error={errors?.confirmPassword}>
+              {(injected) => (
+                <TextField.Root
+                  {...register('confirmPassword', {
+                    required : 'Please confirm the password',
+                    validate : (value, { password }) => value === password || 'Password does not match',
+                  })}
+                  {...injected}
+                  type="password"
+                />
+              )}
+            </FormField>
+          </Flex>
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -58,6 +58,13 @@ const colDefs: ColDef<AdminUser>[] = [
     width : 200,
   },
   {
+    field : 'is_sso',
+    headerName : 'SSO',
+    width : 100,
+    filter : true,
+    floatingFilter : true,
+  },
+  {
     field : 'banned',
     width : 100,
     filter : true,

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -5,7 +5,9 @@ import AdminGrid from 'components/AdminGrid';
 import { ErrorCallout } from 'components/Callouts';
 import RoleBadge from 'components/RoleBadge';
 import { Fragment } from 'react/jsx-runtime';
+import { Flex } from '@radix-ui/themes';
 import UserSidebar from './UserSidebar';
+import CreateUserModal from './CreateUserModal';
 
 const colDefs: ColDef<AdminUser>[] = [
   {
@@ -85,6 +87,11 @@ export default function AdminUsers() {
         loading={isLoading}
         getRowId={(params) => params.data.id.toString()}
         sidebarComponent={UserSidebar}
+        toolbar={(
+          <Flex direction="row" justify="start">
+            <CreateUserModal />
+          </Flex>
+        )}
       />
     </>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -41,6 +41,7 @@ export interface User {
 
 export interface AdminUser extends User {
   banned: boolean;
+  is_sso: boolean;
 }
 
 export interface Team {


### PR DESCRIPTION
New create expo account button on the Users page opens this modal:
<img width="640" height="379" alt="Screenshot From 2026-07-21 10-07-29" src="https://github.com/user-attachments/assets/f6e95ed7-1fe5-4be3-a8b9-dfebba40665d" />

Password changes are available for expo users through the existing edit user form. Leaving the fields blank means that the password will not be changed. These fields are disabled for SSO/Okta users to ensure those accounts always go through OAuth and 2FA for authentication.
<img width="640" height="412" alt="Screenshot From 2026-07-21 10-08-03" src="https://github.com/user-attachments/assets/d491449d-b125-4f16-9df1-a0f9060f3ef6" />

SSO grid column shows whether users are authenticated via SSO (none are on my dev instance)
<img width="123" height="339" alt="Screenshot From 2026-07-21 10-08-21" src="https://github.com/user-attachments/assets/a7922531-9934-471b-8273-6829fc0ba28a" />
