### PR TITLE
Clean up orphaned celery processes

### DIFF
--- a/conf/ctfd/entrypoint.sh
+++ b/conf/ctfd/entrypoint.sh
@@ -14,6 +14,8 @@ install_plugin_deps() {
 }
 
 start_dev() {
+  # kill any orphaned celery workers to prevent OOM
+  pkill -f 'celery.*worker' || true
   celery -A CTFd.plugins.ng.containers.tasks worker --loglevel=INFO &
   python serve_debug.py
 }
@@ -46,6 +48,8 @@ start_prod() {
   # Initialize database
   flask db upgrade
 
+  # kill any orphaned celery workers to prevent OOM
+  pkill -f 'celery.*worker' || true
   celery -A CTFd.plugins.ng.containers.tasks worker --loglevel=INFO &
 
   mv init_patch CTFd/__init__.py


### PR DESCRIPTION
When the dev server restarts, new celery processes get created without cleaning up old ones, resulting in a memory/pid leak. Entrypoint now cleans up those processes to prevent resource exhaustion.

Before:
<img width="571" height="518" alt="Screenshot From 2026-07-22 12-16-10" src="https://github.com/user-attachments/assets/711682d7-40d9-4b64-a41c-156a969c49ab" />

After:
<img width="571" height="518" alt="Screenshot From 2026-07-22 12-24-38" src="https://github.com/user-attachments/assets/b080320d-d828-455e-b46c-a42b7c6d0c8f" />
