### PR TITLE
Require consistency between linked objects for loaders

### DIFF
--- a/backend/ng/core/middleware/loaders/_util.py
+++ b/backend/ng/core/middleware/loaders/_util.py
@@ -61,6 +61,13 @@ def generate_loader_decorator(source: LoaderType, model_name: str, input_key: st
             instance = model_class.find_by_id(model_id)
             if not instance:
                 raise NotFoundError(f"{model_name} with ID {model_id} not found")
+
+            # a nested route names its parents in the path (e.g. the event a challenge is in),
+            # so an instance under a different parent reads as missing rather than loading
+            for key, value in (request.view_args or {}).items():
+                if key != input_key and key.endswith("_id") and getattr(instance, key, value) != value:
+                    raise NotFoundError(f"{model_name} with ID {model_id} not found")
+
             kwargs[output_key] = instance
             return f(*args, **kwargs)
 

--- a/backend/ng/core/middleware/loaders/load_team_by_invite_code.py
+++ b/backend/ng/core/middleware/loaders/load_team_by_invite_code.py
@@ -17,9 +17,13 @@ def load_team_by_invite_code(source : LoaderType = LoaderType.BODY, input_key="i
             else:
                 raise ValueError(f"Invalid loader type: {source}")
 
+            event = kwargs.get("event")
+            if not event:
+                raise ValueError("Event must be loaded first")
+
             team = Team.find_by_invite_code(invite_code)
 
-            if not team:
+            if not team or team.event_id != event.id:
                 raise NotFoundError(f"Invalid invite code: {invite_code}")
 
             kwargs[output_key] = team

--- a/backend/ng/event/controllers/user/join_event_controller.py
+++ b/backend/ng/event/controllers/user/join_event_controller.py
@@ -25,7 +25,7 @@ def join_event_controller(event: Event, user : User, invite_code : str = "", tea
         Demographic.create_demographic(user_id=user.id, event_id=event.id, commit=False)
         if invite_code:
             team = Team.find_by_invite_code(invite_code)
-            if not team:
+            if not team or team.event_id != event.id:
                 raise NotFoundError(f"Team with invite code {invite_code} not found")
 
             team.add_member(user.id, commit=False)

--- a/backend/ng/event/routes/user_routes.py
+++ b/backend/ng/event/routes/user_routes.py
@@ -539,6 +539,7 @@ class EventChallengeStatuses(Resource):
 class EventChallengeStartContainers(Resource):
     @user_endpoint()
     @load_event(source = LoaderType.PARAM)
+    @load_challenge(source = LoaderType.PARAM)
     @load_team_by_user_and_event()
     @check_permissions(PermissionEnum.CAN_PLAY_CHALLENGES, "You do not have permission to play challenges.")
     @events_user_namespace.doc(
@@ -552,15 +553,17 @@ class EventChallengeStartContainers(Resource):
             400: "Bad request",
         },
     )
-    def post(self, team: Team, current_user: User, challenge_id: int, event_id: int, event: Event, permissions):
-        started = start_containers(challenge_id, team.id, current_user)
+    def post(self, team: Team, current_user: User, challenge_id: int, event_id: int, event: Event, challenge: Challenge, permissions):
+        started = start_containers(challenge.id, team.id, current_user)
         return success_response(started)
 
 @events_user_namespace.route("/<int:event_id>/challenge/<int:challenge_id>/containers/recycle")
 class EventChallengeRecycleContainers(Resource):
     @user_endpoint()
     @load_event(source=LoaderType.PARAM)
+    @load_challenge(source=LoaderType.PARAM)
     @load_team_by_user_and_event()
+    @check_permissions(PermissionEnum.CAN_PLAY_CHALLENGES, "You do not have permission to play challenges.")
     @limiter.limit("1 per 5 minutes") # Note - this is per-user, not per-team
     @events_user_namespace.doc(
         description="Recycle a challenges containers",
@@ -573,6 +576,6 @@ class EventChallengeRecycleContainers(Resource):
             400: "Bad request",
         },
     )
-    def post(self, team: Team, challenge_id: int, event_id: int, event: Event, **kwargs):
-        started = recycle_containers(challenge_id, team.id)
+    def post(self, team: Team, challenge_id: int, event_id: int, event: Event, challenge: Challenge, **kwargs):
+        started = recycle_containers(challenge.id, team.id)
         return success_response(started)

--- a/backend/ng/event/routes/user_routes.py
+++ b/backend/ng/event/routes/user_routes.py
@@ -246,7 +246,7 @@ class EventTeamCode(Resource):
         if not invite_code:
             return error_response("Invite code is required.", "validation", 400)
         team = Team.find_by_invite_code(invite_code)
-        if not team:
+        if not team or team.event_id != event_id:
             return error_response("Invalid invite code.", "not_found", 404)
         return success_response(team)
 

--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -1780,6 +1780,13 @@ class Test_Event_Challenge_Render:
         assert isinstance(render_data["hints"], list)
         assert isinstance(render_data["attempts"], list)
 
+    def test_challenge_from_another_event_not_found(self, started_player_client, challenge_factory, event_factory):
+        challenge = challenge_factory(event=event_factory(), name="Other Event Challenge")
+
+        response = started_player_client.get(self.get_endpoint(1, challenge.id))
+
+        assert response.status_code == 404
+
 
 class Test_Event_Challenge_Statuses:
     def get_endpoint(self, event_id: int) -> str:

--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -408,6 +408,33 @@ class Test_Event_Registration:
         ).first()
         assert team_member is not None
 
+    def test_register_with_invite_code_from_another_event(
+        self,
+        client_factory,
+        user_factory,
+        event_factory,
+        team_factory,
+        sponsor_factory,
+    ):
+        event = event_factory(name = "Event for Cross Event Registration", public = True)
+        sponsor = sponsor_factory()
+
+        captain = user_factory(name = "captain", email = "captain@example.com", sponsor = sponsor)
+        other_team = team_factory(
+            event = event_factory(name = "Event That Owns The Team", public = True),
+            members = [captain],
+        )
+
+        user = user_factory(name = "outsider", email = "outsider@example.com", sponsor = sponsor)
+        client = client_factory(user = user)
+
+        response = client.post(
+            self.get_endpoint(event.id),
+            json = {"invite_code": other_team.invite_code},
+        )
+
+        assert response.status_code == 404
+
     def test_register_member_name_cannot_be_in_team_name(
         self,
         logged_in_client,
@@ -840,6 +867,25 @@ class Test_Event_Team_Lookup:
         data = response.get_json()
         assert data["success"] is True
         assert data["data"] == team.serialize()
+
+    def test_get_team_by_invite_code_from_another_event(
+        self,
+        logged_in_client,
+        user,
+        event_factory,
+        team_factory
+    ):
+        event = event_factory(name = "Event for Cross Event Invite Code", public = True)
+        other_team = team_factory(
+            event = event_factory(name = "Event That Owns The Team"),
+            members = [user],
+        )
+
+        response = logged_in_client.get(
+            f"/ng/events/{event.id}/team/{other_team.invite_code}",
+        )
+
+        assert response.status_code == 404
 
     def test_get_team_by_invalid_invite_code(
         self,

--- a/backend/ng/event/tests/test_event_api.py
+++ b/backend/ng/event/tests/test_event_api.py
@@ -1788,6 +1788,25 @@ class Test_Event_Challenge_Render:
         assert response.status_code == 404
 
 
+class Test_Event_Challenge_Containers:
+    def get_endpoint(self, event_id: int, challenge_id: int) -> str:
+        return f"/ng/events/{event_id}/challenge/{challenge_id}/containers"
+
+    def test_start_containers_challenge_from_another_event(self, started_player_client, challenge_factory, event_factory):
+        challenge = challenge_factory(event=event_factory())
+
+        response = started_player_client.post(self.get_endpoint(1, challenge.id), json={})
+
+        assert response.status_code == 404
+
+    def test_recycle_containers_challenge_from_another_event(self, started_player_client, challenge_factory, event_factory):
+        challenge = challenge_factory(event=event_factory())
+
+        response = started_player_client.post(f"{self.get_endpoint(1, challenge.id)}/recycle", json={})
+
+        assert response.status_code == 404
+
+
 class Test_Event_Challenge_Statuses:
     def get_endpoint(self, event_id: int) -> str:
         return f"/ng/events/{event_id}/me/challenges"

--- a/backend/ng/scoring/tests/test_scoring_api.py
+++ b/backend/ng/scoring/tests/test_scoring_api.py
@@ -177,6 +177,18 @@ class TestUserScoringEndpoints:
         assert data["data"]["is_correct"] is True
         assert data["data"]["points"] == question.points
 
+    def test_submit_answer_question_from_another_challenge(self, started_player_client, challenge_factory, question_factory):
+        """A question outside the challenge in the path must not be submittable against it"""
+        challenge = challenge_factory(event_id=1)
+        question = question_factory(challenge_id=challenge_factory(event_id=1).id)
+
+        response = started_player_client.post(
+            f"/ng/events/{challenge.event_id}/challenges/{challenge.id}/questions/{question.id}/submit",
+            json={"submission": question.answer},
+        )
+
+        assert response.status_code == 404
+
     def test_submit_answer_incorrect(self, started_player_client, challenge_factory, question_factory):
         """Test submitting incorrect answer"""
         challenge = challenge_factory(event_id=1)
@@ -426,8 +438,8 @@ class TestUserScoringEndpoints:
         user,
         team_with_member,
         locked_event,
-        challenge,
-        hint
+        challenge_factory,
+        hint_factory
     ):
         """Test redeeming hint for locked event"""
         # Create team in locked event
@@ -439,6 +451,10 @@ class TestUserScoringEndpoints:
             captain_id = user.id,
             invite_code = "locked123"
         )
+
+        # the challenge must live in the locked event, otherwise the request is a cross-event 404
+        challenge = challenge_factory(event=locked_event)
+        hint = hint_factory(challenge_id=challenge.id)
 
         with logged_in_client.session_transaction() as sess:
             nonce = sess.get("nonce")


### PR DESCRIPTION
Previously, loaders did not enforce consistent references between linked objects, which opened up some IDOR issues with data loading and how it interacts with permissions.

This change ensures that references between loaded objects are consistent, i.e. a loaded challenge belongs to the event id specified in the route. Same goes for hints, questions, teams, etc. - if there's a mismatch, you get a 404 so as not to disclose the existence of any unavailable objects.