### PR TITLE
Resolve expo login redirect race

### DIFF
--- a/frontend/src/components/RequireUser.tsx
+++ b/frontend/src/components/RequireUser.tsx
@@ -1,9 +1,12 @@
+import { ROUTEPREFIX } from '@/constants';
 import { useAuth } from '@/hooks/users';
 import type { ReactNode } from 'react';
-import { Navigate } from 'react-router';
+import { Navigate, useLocation } from 'react-router';
 
 export default function RequireUser({ children, replace }: { children: ReactNode, replace?: ReactNode }) {
   const { isAuthenticated, isUnauthenticated } = useAuth();
+
+  const { pathname, search } = useLocation();
 
   if (isAuthenticated) {
     return children;
@@ -14,7 +17,7 @@ export default function RequireUser({ children, replace }: { children: ReactNode
       return replace;
     }
 
-    return <Navigate to={`/login?redirect=${encodeURIComponent(window.location.pathname + window.location.search)}`} replace />;
+    return <Navigate to={`/login?redirect=${encodeURIComponent(ROUTEPREFIX + pathname + search)}`} replace />;
   }
 
   return null;


### PR DESCRIPTION
Resolves #327.

Race condition between window.location and react router path state in Chromium browsers meant that occasionally the RequireUser navigation could fire twice and produce a login page URL that redirects back to the login page again, even after a successful login.

Using react router state as the single source of truth for the redirect destination resolves this by keeping states in sync.